### PR TITLE
Lunette

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ The setup command installs the locked workspace dependencies. The dev command pr
 | Type checks and desktop tests | `./ipollowork check` | `.\ipollowork.cmd check` |
 | Production build | `./ipollowork build` | `.\ipollowork.cmd build` |
 
+Windows development builds do not register the production `ipollowork://`
+handler automatically. When testing Cloud sign-in through an external browser,
+use the repository's protocol switcher and restore the production handler when
+you finish. See [Windows protocol switching](docs/windows-protocol-switcher.md).
+
 ## Build and package
 
 There are three different build levels:

--- a/docs/superpowers/plans/2026-07-14-windows-protocol-switcher.md
+++ b/docs/superpowers/plans/2026-07-14-windows-protocol-switcher.md
@@ -1,0 +1,56 @@
+# Windows Protocol Switcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two safe Windows scripts that switch `ipollowork://` between the repository development app and an installed production app.
+
+**Architecture:** Each root `.cmd` delegates quoting, discovery, registry writes, and verification to embedded PowerShell. A test-only registry-root override permits behavior tests without changing the user's live protocol handler.
+
+**Tech Stack:** Windows cmd, Windows PowerShell 5.1, `reg.exe`, Node.js built-in test runner.
+
+## Global Constraints
+
+- Modify only the current user's registry hive.
+- Require no administrator privileges.
+- Do not start or stop applications.
+- Do not change application authentication code.
+- Use pnpm for repository commands.
+
+---
+
+### Task 1: Protocol switching scripts
+
+**Files:**
+- Create: `切到开发版.cmd`
+- Create: `恢复正式版.cmd`
+- Create: `scripts/windows-protocol-switcher.test.mjs`
+
+**Interfaces:**
+- Consumes: repository-relative Electron executable and `apps/desktop/electron/main.mjs`; Windows uninstall registry and standard installation directories.
+- Produces: verified `shell\open\command` for the selected `ipollowork://` handler.
+
+- [ ] **Step 1: Write failing behavior tests**
+
+Create tests that copy both scripts to a temporary repository-shaped directory and use `IPOLLOWORK_PROTOCOL_REGISTRY_ROOT` plus `IPOLLOWORK_PRODUCTION_EXE` overrides. Assert that the scripts are missing initially, then assert exact development registration, exact production restoration, and no registry mutation when production is missing.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `node --test scripts/windows-protocol-switcher.test.mjs`
+
+Expected: FAIL because the two root scripts do not exist.
+
+- [ ] **Step 3: Implement the minimal scripts**
+
+Use embedded PowerShell to validate paths, write URL Protocol metadata and the quoted open command, then read it back and compare exactly. Production discovery must complete before any registry write.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `node --test scripts/windows-protocol-switcher.test.mjs`
+
+Expected: all protocol-switching tests pass.
+
+- [ ] **Step 5: Run focused repository checks**
+
+Run: `git diff --check` and inspect `git status --short`.
+
+Expected: no whitespace errors and only the two scripts, test, spec, and plan are changed.

--- a/docs/superpowers/specs/2026-07-14-windows-protocol-switcher-design.md
+++ b/docs/superpowers/specs/2026-07-14-windows-protocol-switcher-design.md
@@ -1,0 +1,20 @@
+# Windows Protocol Switcher Design
+
+## Goal
+
+Provide two root-level Windows command scripts that switch the current user's `ipollowork://` protocol handler between this repository's Electron development app and an installed production iPolloWork app.
+
+## Behavior
+
+- `切到开发版.cmd` derives every development path from its own repository location, registers itself as the handler, and verifies the resulting open command. When Windows invokes it with a callback URL, it restores the `dev:cloud` environment and forwards the URL to the isolated development Electron instance.
+- `恢复正式版.cmd` searches the current-user and machine uninstall registries, then common per-user and Program Files install locations. It stops without changing the registry if no production executable exists.
+- Both scripts modify only `HKCU`; they require no administrator permissions and do not start or stop either app.
+- Both scripts print an explicit success or failure result and return a non-zero exit code on failure.
+
+## Safety
+
+The production restore script resolves and validates an existing executable before writing anything. Registry writes use `reg.exe` with explicit value names. Development registration quotes the Electron executable, Electron entry point, and callback placeholder independently so paths containing spaces or Chinese characters remain valid.
+
+## Verification
+
+A Node test runs the scripts against a temporary registry key selected through a test-only environment override. It verifies development command construction, production discovery and restoration, and the no-production-installation case without altering the real `ipollowork://` handler.

--- a/docs/windows-protocol-switcher.md
+++ b/docs/windows-protocol-switcher.md
@@ -1,0 +1,77 @@
+# Windows protocol switching
+
+The packaged iPolloWork app owns the `ipollowork://` protocol used to return a
+browser sign-in grant to the desktop. Electron development builds intentionally
+do not register that production protocol automatically. As a result, Windows
+development against iPolloCloud may remain on `Connecting to iPolloWork...`
+after Cloud has created the handoff grant.
+
+This repository includes two Windows helpers for local development:
+
+- `切到开发版.cmd` points `ipollowork://` at this source checkout.
+- `恢复正式版.cmd` points it back at an installed production app.
+
+They modify only the current user's
+`HKCU\Software\Classes\ipollowork` registry key and do not require
+administrator permission.
+
+## Switch to the development app
+
+Install dependencies and start the isolated Cloud development profile:
+
+```powershell
+.\ipollowork.cmd setup
+.\ipollowork.cmd dev:cloud http://localhost:3100
+```
+
+Then double-click `切到开发版.cmd`, or run:
+
+```powershell
+.\切到开发版.cmd
+```
+
+After registration or sign-in in the system browser, approve the browser prompt
+to open iPolloWork. The helper recreates the `dev:cloud` environment and
+forwards the one-time callback URL to the already-running isolated Electron
+profile.
+
+The registered command follows the location of this checkout. Run the switch
+script again after moving or renaming the repository.
+
+## Restore the production app
+
+When development testing is complete, double-click `恢复正式版.cmd`, or run:
+
+```powershell
+.\恢复正式版.cmd
+```
+
+The helper searches standard per-user and Program Files locations plus Windows
+uninstall metadata. It validates the production executable before changing the
+registry. If no installed production app is found, it exits with an error and
+leaves the current protocol handler unchanged.
+
+Installing or launching a packaged iPolloWork release may also register the
+production handler again.
+
+## Safety and limitations
+
+- Only one application can own `ipollowork://` for the current Windows user.
+- Switching to development temporarily redirects production browser callbacks
+  to the development checkout.
+- Restore the production handler before testing the packaged application.
+- The scripts do not start iPolloCloud and do not initialize its database.
+- This is a local workaround for external-browser development authentication;
+  a dedicated development protocol remains the preferred long-term solution.
+
+## Verification
+
+The regression test uses a temporary registry key and never changes the live
+protocol handler:
+
+```powershell
+node --test scripts/windows-protocol-switcher.test.mjs
+```
+
+It covers development registration, production restoration, and the safe
+failure path when no production installation exists.

--- a/scripts/windows-protocol-switcher.test.mjs
+++ b/scripts/windows-protocol-switcher.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const registryRoot = `HKCU\\Software\\iPolloWorkProtocolSwitcherTests\\${process.pid}`;
+
+function queryCommand() {
+  try {
+    const output = execFileSync("reg.exe", ["query", `${registryRoot}\\shell\\open\\command`, "/ve"], { encoding: "utf8" });
+    return output.match(/REG_SZ\s+(.+)$/m)?.[1]?.trim() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function run(script, env = {}) {
+  return execFileSync("cmd.exe", ["/d", "/c", script], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, IPOLLOWORK_PROTOCOL_REGISTRY_ROOT: registryRoot, IPOLLOWORK_PROTOCOL_NO_PAUSE: "1", ...env },
+  });
+}
+
+test.afterEach(() => {
+  execFileSync("reg.exe", ["delete", registryRoot, "/f"], { stdio: "ignore" });
+});
+
+test("switches the protocol to this repository's development Electron entrypoint", () => {
+  const script = path.join(root, "切到开发版.cmd");
+  assert.equal(existsSync(script), true, "development switch script should exist");
+
+  const temp = mkdtempSync(path.join(os.tmpdir(), "ipollowork-electron-"));
+  const electron = path.join(temp, "electron.exe");
+  writeFileSync(electron, "test");
+  try {
+    run(script, { IPOLLOWORK_DEV_ELECTRON: electron });
+    assert.equal(queryCommand(), `\"${script}\" --dispatch \"%1\"`);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("restores the protocol to a validated production executable", () => {
+  const script = path.join(root, "恢复正式版.cmd");
+  assert.equal(existsSync(script), true, "production restore script should exist");
+  const temp = mkdtempSync(path.join(os.tmpdir(), "ipollowork-production-"));
+  const executable = path.join(temp, "iPolloWork.exe");
+  writeFileSync(executable, "test");
+
+  try {
+    run(script, { IPOLLOWORK_PRODUCTION_EXE: executable });
+    assert.equal(queryCommand(), `\"${executable}\" \"%1\"`);
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("does not change the current handler when production cannot be found", () => {
+  const script = path.join(root, "恢复正式版.cmd");
+  execFileSync("reg.exe", ["add", `${registryRoot}\\shell\\open\\command`, "/ve", "/d", "sentinel", "/f"], { stdio: "ignore" });
+
+  assert.throws(() => run(script, { IPOLLOWORK_PRODUCTION_EXE: path.join(os.tmpdir(), "missing-ipollowork.exe"), IPOLLOWORK_SKIP_PRODUCTION_DISCOVERY: "1" }));
+  assert.equal(queryCommand(), "sentinel");
+});

--- a/切到开发版.cmd
+++ b/切到开发版.cmd
@@ -1,13 +1,19 @@
 @echo off
 setlocal
 
+rem Switch the current user's ipollowork:// handler to this source checkout.
+rem The same file is also the registered callback entrypoint. Windows calls
+rem the --dispatch branch with the deep-link URL after browser authentication.
 set "REPO=%~dp0"
 if /i "%~1"=="--dispatch" goto dispatch
 
+rem Allow tests and unusual installations to provide a known Electron binary.
 set "ELECTRON=%IPOLLOWORK_DEV_ELECTRON%"
 if not defined ELECTRON set "ELECTRON=%REPO%apps\desktop\node_modules\electron\dist\electron.exe"
 set "MAIN=%REPO%apps\desktop\electron\main.mjs"
 set "HANDLER=%~f0"
+
+rem Tests override this root so they never modify the live protocol handler.
 set "REGISTRY_ROOT=%IPOLLOWORK_PROTOCOL_REGISTRY_ROOT%"
 if not defined REGISTRY_ROOT set "REGISTRY_ROOT=HKCU\Software\Classes\ipollowork"
 
@@ -20,6 +26,9 @@ if not exist "%MAIN%" (
   exit /b 1
 )
 
+rem Register only under HKCU: no administrator permission is required.
+rem PowerShell constructs the quoted command reliably for paths with spaces or
+rem non-ASCII characters, then verifies the value that Windows will execute.
 powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ^
   "$key = 'Registry::' + $env:REGISTRY_ROOT;" ^
   "$command = [char]34 + $env:HANDLER + [char]34 + ' --dispatch ' + [char]34 + '%%1' + [char]34;" ^
@@ -38,6 +47,9 @@ if not defined IPOLLOWORK_PROTOCOL_NO_PAUSE pause
 exit /b 0
 
 :dispatch
+rem Recreate the isolated dev:cloud environment before forwarding the URL.
+rem requestSingleInstanceLock in Electron delivers this second invocation to
+rem the already-running development window.
 set "ELECTRON=%REPO%apps\desktop\node_modules\electron\dist\electron.exe"
 set "MAIN=%REPO%apps\desktop\electron\main.mjs"
 set "IPOLLOWORK_DEV_MODE=1"

--- a/切到开发版.cmd
+++ b/切到开发版.cmd
@@ -1,0 +1,51 @@
+@echo off
+setlocal
+
+set "REPO=%~dp0"
+if /i "%~1"=="--dispatch" goto dispatch
+
+set "ELECTRON=%IPOLLOWORK_DEV_ELECTRON%"
+if not defined ELECTRON set "ELECTRON=%REPO%apps\desktop\node_modules\electron\dist\electron.exe"
+set "MAIN=%REPO%apps\desktop\electron\main.mjs"
+set "HANDLER=%~f0"
+set "REGISTRY_ROOT=%IPOLLOWORK_PROTOCOL_REGISTRY_ROOT%"
+if not defined REGISTRY_ROOT set "REGISTRY_ROOT=HKCU\Software\Classes\ipollowork"
+
+if not exist "%ELECTRON%" (
+  echo [FAILED] Electron was not found. Run pnpm install in this repository first.
+  exit /b 1
+)
+if not exist "%MAIN%" (
+  echo [FAILED] The development entrypoint was not found: %MAIN%
+  exit /b 1
+)
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$key = 'Registry::' + $env:REGISTRY_ROOT;" ^
+  "$command = [char]34 + $env:HANDLER + [char]34 + ' --dispatch ' + [char]34 + '%%1' + [char]34;" ^
+  "New-Item -Path ($key + '\shell\open\command') -Force | Out-Null;" ^
+  "Set-Item -Path $key -Value 'URL:iPolloWork Protocol';" ^
+  "New-ItemProperty -Path $key -Name 'URL Protocol' -Value '' -PropertyType String -Force | Out-Null;" ^
+  "Set-Item -Path ($key + '\shell\open\command') -Value $command;" ^
+  "if ((Get-Item -Path ($key + '\shell\open\command')).GetValue('') -ne $command) { exit 1 }"
+if errorlevel 1 (
+  echo [FAILED] The development protocol handler could not be registered.
+  exit /b 1
+)
+
+echo [OK] ipollowork:// now opens this repository's development app.
+if not defined IPOLLOWORK_PROTOCOL_NO_PAUSE pause
+exit /b 0
+
+:dispatch
+set "ELECTRON=%REPO%apps\desktop\node_modules\electron\dist\electron.exe"
+set "MAIN=%REPO%apps\desktop\electron\main.mjs"
+set "IPOLLOWORK_DEV_MODE=1"
+set "IPOLLOWORK_DESKTOP_BOOTSTRAP_PATH=%REPO%.ipollowork-dev\cloud\bootstrap.json"
+set "IPOLLOWORK_ELECTRON_USERDATA=%REPO%.ipollowork-dev\cloud\electron-userdata"
+set "IPOLLOWORK_DATA_DIR=%REPO%.ipollowork-dev\cloud\runtime-data"
+set "IPOLLOWORK_FORCE_SIGNIN=1"
+if not exist "%ELECTRON%" exit /b 1
+if not exist "%MAIN%" exit /b 1
+start "" "%ELECTRON%" "%MAIN%" "%~2"
+exit /b 0

--- a/恢复正式版.cmd
+++ b/恢复正式版.cmd
@@ -1,9 +1,14 @@
 @echo off
 setlocal
 
+rem Restore ipollowork:// to an installed production iPolloWork executable.
+rem Discovery completes before any registry write. If no executable is found,
+rem the current handler is left unchanged.
 set "REGISTRY_ROOT=%IPOLLOWORK_PROTOCOL_REGISTRY_ROOT%"
 if not defined REGISTRY_ROOT set "REGISTRY_ROOT=HKCU\Software\Classes\ipollowork"
 
+rem Search common install paths and Windows uninstall metadata. Tests may
+rem provide IPOLLOWORK_PRODUCTION_EXE to exercise this without an installation.
 powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ^
   "$key = 'Registry::' + $env:REGISTRY_ROOT;" ^
   "$exe = $env:IPOLLOWORK_PRODUCTION_EXE;" ^

--- a/恢复正式版.cmd
+++ b/恢复正式版.cmd
@@ -1,0 +1,35 @@
+@echo off
+setlocal
+
+set "REGISTRY_ROOT=%IPOLLOWORK_PROTOCOL_REGISTRY_ROOT%"
+if not defined REGISTRY_ROOT set "REGISTRY_ROOT=HKCU\Software\Classes\ipollowork"
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass -Command ^
+  "$key = 'Registry::' + $env:REGISTRY_ROOT;" ^
+  "$exe = $env:IPOLLOWORK_PRODUCTION_EXE;" ^
+  "if (-not ($exe -and (Test-Path -LiteralPath $exe)) -and $env:IPOLLOWORK_SKIP_PRODUCTION_DISCOVERY -ne '1') {" ^
+  "  $candidates = @($env:LOCALAPPDATA + '\Programs\iPolloWork\iPolloWork.exe', $env:ProgramFiles + '\iPolloWork\iPolloWork.exe', ${env:ProgramFiles(x86)} + '\iPolloWork\iPolloWork.exe');" ^
+  "  $keys = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*';" ^
+  "  foreach ($item in Get-ItemProperty $keys -ErrorAction SilentlyContinue | Where-Object { $_.DisplayName -match '^iPolloWork' }) { if ($item.DisplayIcon) { $candidates += $item.DisplayIcon.Trim([char]34).Split(',')[0] }; if ($item.InstallLocation) { $candidates += Join-Path $item.InstallLocation 'iPolloWork.exe' } };" ^
+  "  $exe = $candidates | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -First 1;" ^
+  "}" ^
+  "if (-not ($exe -and (Test-Path -LiteralPath $exe))) { exit 2 };" ^
+  "$command = [char]34 + $exe + [char]34 + ' ' + [char]34 + '%%1' + [char]34;" ^
+  "New-Item -Path ($key + '\shell\open\command') -Force | Out-Null;" ^
+  "Set-Item -Path $key -Value 'URL:iPolloWork Protocol';" ^
+  "New-ItemProperty -Path $key -Name 'URL Protocol' -Value '' -PropertyType String -Force | Out-Null;" ^
+  "Set-Item -Path ($key + '\shell\open\command') -Value $command;" ^
+  "if ((Get-Item -Path ($key + '\shell\open\command')).GetValue('') -ne $command) { exit 1 }"
+if errorlevel 2 (
+  echo [FAILED] An installed iPolloWork production app was not found. The registry was not changed.
+  if not defined IPOLLOWORK_PROTOCOL_NO_PAUSE pause
+  exit /b 2
+)
+if errorlevel 1 (
+  echo [FAILED] The production protocol handler could not be registered.
+  exit /b 1
+)
+
+echo [OK] ipollowork:// now opens the installed production app.
+if not defined IPOLLOWORK_PROTOCOL_NO_PAUSE pause
+exit /b 0


### PR DESCRIPTION
## Temporary workaround

I confirmed that the failure is caused by the missing `ipollowork://` protocol handler in the Windows development build.

As a temporary local workaround, I added two Windows scripts:

- `切到开发版.cmd`: registers `ipollowork://` for the current development checkout and forwards the callback to the isolated `dev:cloud` Electron profile.
- `恢复正式版.cmd`: restores the protocol handler to an installed production app. If no production app is found, it exits without changing the registry.

The workaround only modifies:

```text
HKCU\Software\Classes\ipollowork