### PR TITLE
fix design template responsive preview

### DIFF
--- a/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
+++ b/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
@@ -55,6 +55,44 @@ export type DesignRuntimeMessage =
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "navigate"; href: string }
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "deck"; deck: DesignDeckState };
 
+export type DesignDeckRuntimeInfo = {
+  slideCount: number;
+  dataSlideCount: number;
+  topLevelSectionSlideCount?: number;
+  explicitDeckContainer: boolean;
+  deckControlCount: number;
+  templateDeck?: boolean;
+};
+
+export function shouldRunDesignDeckRuntime(info: DesignDeckRuntimeInfo) {
+  return info.slideCount >= 2
+    && (info.dataSlideCount >= 2 || (info.topLevelSectionSlideCount ?? 0) >= 2 || info.explicitDeckContainer || info.deckControlCount > 0 || Boolean(info.templateDeck));
+}
+
+export function designDeckDirectionForKey(key: string): "previous" | "next" | null {
+  if (key === "ArrowLeft" || key === "ArrowUp" || key === "PageUp") return "previous";
+  if (key === "ArrowRight" || key === "ArrowDown" || key === "PageDown" || key === " ") return "next";
+  return null;
+}
+
+export function designDeckFitScale(viewportWidth: number, contentWidth: number, viewportHeight?: number, contentHeight?: number) {
+  if (!Number.isFinite(viewportWidth) || !Number.isFinite(contentWidth) || contentWidth <= 0) return 1;
+  const widthScale = contentWidth > viewportWidth ? (Math.max(0, viewportWidth) - 16) / contentWidth : 1;
+  const heightScale = viewportHeight !== undefined && contentHeight !== undefined && Number.isFinite(viewportHeight) && Number.isFinite(contentHeight) && contentHeight > 0
+    ? contentHeight > viewportHeight ? (Math.max(0, viewportHeight) - 16) / contentHeight : 1
+    : 1;
+  return Math.max(0.1, Math.min(1, widthScale, heightScale));
+}
+
+export function designPreviewFitScale(viewportWidth: number, contentWidth: number, viewportHeight?: number, contentHeight?: number, mode: "fluid" | "artboard" = "fluid") {
+  if (!Number.isFinite(viewportWidth) || !Number.isFinite(contentWidth) || contentWidth <= 0) return 1;
+  const widthScale = contentWidth > viewportWidth ? (Math.max(0, viewportWidth) - 16) / contentWidth : 1;
+  const heightScale = mode === "artboard" && viewportHeight !== undefined && contentHeight !== undefined && Number.isFinite(viewportHeight) && Number.isFinite(contentHeight) && contentHeight > 0
+    ? contentHeight > viewportHeight ? (Math.max(0, viewportHeight) - 16) / contentHeight : 1
+    : 1;
+  return Math.max(0.1, Math.min(1, widthScale, heightScale));
+}
+
 export function isLocalHtmlPath(path: string) {
   return /\.html?$/i.test(path.trim());
 }
@@ -87,17 +125,157 @@ export function buildDesignPreviewDocument(source: string, includeEditor: boolea
   const tokenStyle = templateTokenCss.trim()
     ? `<style id="ipollowork-design-template-token-style">${templateTokenCss.replace(/<\/style/gi, "<\\/style")}</style>`
     : "";
+  const deckRuntimeDetector = shouldRunDesignDeckRuntime.toString();
+  const previewFitRuntime = `<script id="ipollowork-design-preview-fit-runtime">(${designPreviewFitRuntime.toString()})(${deckRuntimeDetector});<\/script>`;
   const navigationRuntime = `<script id="ipollowork-design-navigation-runtime">(${designNavigationRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${editing ? "true" : "false"});<\/script>`;
-  const deckRuntime = `<script id="ipollowork-design-deck-runtime">(${designDeckRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)});<\/script>`;
+  const deckRuntime = `<script id="ipollowork-design-deck-runtime">(${designDeckRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${deckRuntimeDetector});<\/script>`;
   const editingRuntime = includeEditor
     ? `<script id="ipollowork-design-runtime">(${designRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${JSON.stringify(DESIGN_STYLE_FIELDS)},${editing ? "true" : "false"});<\/script>`
     : "";
-  const runtime = `${tokenStyle}${navigationRuntime}${deckRuntime}${editingRuntime}`;
+  const runtime = `${tokenStyle}${previewFitRuntime}${navigationRuntime}${deckRuntime}${editingRuntime}`;
   const bodyEnd = source.toLowerCase().lastIndexOf("</body>");
   if (bodyEnd >= 0) {
     return `${source.slice(0, bodyEnd)}${runtime}${source.slice(bodyEnd)}`;
   }
   return `${source}${runtime}`;
+}
+
+function designPreviewFitRuntime(shouldRunDeckRuntime: (info: DesignDeckRuntimeInfo) => boolean) {
+  const deckSlideSelector = "[data-ipw-slide], body > section.slide, [data-ipw-deck] .slide, .deck .slide, #deck .slide, .stage .slide";
+  const deckControlSelector = "[data-ipw-deck-control],[data-action='prev'],[data-action='previous'],[data-action='next'],button[aria-label^='Go to slide']";
+  const templateDeck = () => /\b(deck|ppt|slide|slides|present|weekly-update)\b/i.test(
+    document.documentElement.getAttribute("data-ipw-template") || document.body.getAttribute("data-ipw-template") || "",
+  );
+  const deckInfo = () => ({
+    slideCount: document.querySelectorAll(deckSlideSelector).length,
+    dataSlideCount: document.querySelectorAll("[data-ipw-slide]").length,
+    topLevelSectionSlideCount: document.querySelectorAll("body > section.slide").length,
+    explicitDeckContainer: Boolean(document.querySelector("[data-ipw-deck],.deck,#deck")),
+    deckControlCount: document.querySelectorAll(deckControlSelector).length,
+    templateDeck: templateDeck(),
+  });
+  if (shouldRunDeckRuntime(deckInfo())) return;
+
+  const fitStyleId = "ipollowork-design-preview-fit-style";
+  const fitTargetAttribute = "data-ipw-design-preview-fit-target";
+  const fitModeAttribute = "data-ipw-design-preview-fit";
+  const runtimeIds = new Set([
+    "ipollowork-design-preview-fit-runtime",
+    "ipollowork-design-navigation-runtime",
+    "ipollowork-design-deck-runtime",
+    "ipollowork-design-runtime",
+    "ipollowork-design-runtime-style",
+    "ipollowork-design-template-token-style",
+    "ipollowork-design-transform-overlay",
+  ]);
+  const style = document.createElement("style");
+  style.id = fitStyleId;
+  document.head.appendChild(style);
+
+  const fitScale = (viewportWidth: number, contentWidth: number, viewportHeight?: number, contentHeight?: number, mode: "fluid" | "artboard" = "fluid") => {
+    if (!Number.isFinite(viewportWidth) || !Number.isFinite(contentWidth) || contentWidth <= 0) return 1;
+    const widthScale = contentWidth > viewportWidth ? (Math.max(0, viewportWidth) - 16) / contentWidth : 1;
+    const heightScale = mode === "artboard" && viewportHeight !== undefined && contentHeight !== undefined && Number.isFinite(viewportHeight) && Number.isFinite(contentHeight) && contentHeight > 0
+      ? contentHeight > viewportHeight ? (Math.max(0, viewportHeight) - 16) / contentHeight : 1
+      : 1;
+    return Math.max(0.1, Math.min(1, widthScale, heightScale));
+  };
+
+  const ignored = (element: Element) => runtimeIds.has(element.id) || element.hasAttribute("data-ipw-brand-slot") || element.tagName === "SCRIPT" || element.tagName === "STYLE";
+  const explicitTarget = () => document.querySelector<HTMLElement>("[data-ipw-frame='artboard'],[data-ipw-frame='fluid'],[data-ipw-artboard]");
+  const bodyChildren = () => Array.from(document.body.children).filter((element): element is HTMLElement => element instanceof HTMLElement && !ignored(element));
+  const widestChild = () => bodyChildren().reduce<HTMLElement | null>((best, child) => {
+    const rect = child.getBoundingClientRect();
+    const width = Math.max(child.scrollWidth, rect.width);
+    if (!best) return child;
+    const bestRect = best.getBoundingClientRect();
+    const bestWidth = Math.max(best.scrollWidth, bestRect.width);
+    return width > bestWidth ? child : best;
+  }, null);
+  const targetElement = () => {
+    const explicit = explicitTarget();
+    if (explicit) return explicit;
+    const children = bodyChildren();
+    if (children.length === 1) return children[0];
+    return document.body;
+  };
+  const frameMode = (target: HTMLElement): "fluid" | "artboard" => (
+    target.getAttribute("data-ipw-frame") === "artboard" || target.hasAttribute("data-ipw-artboard") || document.body.getAttribute("data-ipw-frame") === "artboard"
+      ? "artboard"
+      : "fluid"
+  );
+  const measure = (target: HTMLElement) => {
+    style.textContent = "";
+    target.removeAttribute(fitTargetAttribute);
+    document.documentElement.removeAttribute(fitModeAttribute);
+    const widest = widestChild();
+    const targetRect = target.getBoundingClientRect();
+    const widestRect = widest?.getBoundingClientRect();
+    const contentWidth = Math.ceil(Math.max(
+      document.documentElement.scrollWidth,
+      document.body.scrollWidth,
+      target.scrollWidth,
+      targetRect.width,
+      widest?.scrollWidth || 0,
+      widestRect?.width || 0,
+      window.innerWidth,
+    ));
+    const contentHeight = Math.ceil(Math.max(
+      target.scrollHeight,
+      targetRect.height,
+      document.body.scrollHeight,
+      document.documentElement.scrollHeight,
+      window.innerHeight,
+    ));
+    return { contentWidth, contentHeight };
+  };
+
+  let pending = false;
+  let fallbackTimer: number | null = null;
+  const fit = () => {
+    pending = false;
+    if (fallbackTimer !== null) {
+      window.clearTimeout(fallbackTimer);
+      fallbackTimer = null;
+    }
+    const target = targetElement();
+    const { contentWidth, contentHeight } = measure(target);
+    const mode = frameMode(target);
+    const scale = fitScale(window.innerWidth, contentWidth, window.innerHeight, contentHeight, mode);
+    if (scale >= 0.999) return;
+    target.setAttribute(fitTargetAttribute, "true");
+    document.documentElement.setAttribute(fitModeAttribute, mode);
+    style.textContent = `
+      html[${fitModeAttribute}] {
+        overflow-x: hidden !important;
+      }
+      [${fitTargetAttribute}="true"] {
+        --ipw-design-preview-fit-scale: ${scale};
+        --ipw-design-preview-fit-width: ${contentWidth}px;
+        min-width: var(--ipw-design-preview-fit-width) !important;
+        max-width: none !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+        transform-origin: top center !important;
+        zoom: var(--ipw-design-preview-fit-scale);
+      }
+    `;
+  };
+  const scheduleFit = () => {
+    if (pending) return;
+    pending = true;
+    const runFit = () => {
+      if (!pending) return;
+      fit();
+    };
+    window.requestAnimationFrame(runFit);
+    fallbackTimer = window.setTimeout(runFit, 80);
+  };
+  window.addEventListener("resize", scheduleFit);
+  window.addEventListener("load", scheduleFit);
+  new MutationObserver(scheduleFit).observe(document.body, { subtree: true, childList: true, attributes: true, attributeFilter: ["class", "style", "data-ipw-frame"] });
+  scheduleFit();
+  window.setTimeout(scheduleFit, 180);
 }
 
 function designNavigationRuntime(channel: string, editing: boolean) {
@@ -154,15 +332,42 @@ function designNavigationRuntime(channel: string, editing: boolean) {
   });
 }
 
-function designDeckRuntime(channel: string) {
-  const slideSelector = "[data-ipw-slide], section.slide, .slide";
+function designDeckRuntime(channel: string, shouldRunDeckRuntime: (info: DesignDeckRuntimeInfo) => boolean) {
+  const directionForKey = (key: string): "previous" | "next" | null => {
+    if (key === "ArrowLeft" || key === "ArrowUp" || key === "PageUp") return "previous";
+    if (key === "ArrowRight" || key === "ArrowDown" || key === "PageDown" || key === " ") return "next";
+    return null;
+  };
+  const fitScale = (viewportWidth: number, contentWidth: number, viewportHeight?: number, contentHeight?: number) => {
+    if (!Number.isFinite(viewportWidth) || !Number.isFinite(contentWidth) || contentWidth <= 0) return 1;
+    const widthScale = contentWidth > viewportWidth ? (Math.max(0, viewportWidth) - 16) / contentWidth : 1;
+    const heightScale = viewportHeight !== undefined && contentHeight !== undefined && Number.isFinite(viewportHeight) && Number.isFinite(contentHeight) && contentHeight > 0
+      ? contentHeight > viewportHeight ? (Math.max(0, viewportHeight) - 16) / contentHeight : 1
+      : 1;
+    return Math.max(0.1, Math.min(1, widthScale, heightScale));
+  };
+  const slideSelector = "[data-ipw-slide], body > section.slide, [data-ipw-deck] section.slide, .deck section.slide, #deck section.slide";
+  const deckControlSelector = "[data-ipw-deck-control],[data-action='prev'],[data-action='previous'],[data-action='next'],button[aria-label^='Go to slide']";
   const slides = Array.from(document.querySelectorAll<HTMLElement>(slideSelector))
     .filter((element, index, list) => list.indexOf(element) === index);
-  if (slides.length < 2) return;
+  if (!shouldRunDeckRuntime({
+    slideCount: slides.length,
+    dataSlideCount: document.querySelectorAll("[data-ipw-slide]").length,
+    topLevelSectionSlideCount: document.querySelectorAll("body > section.slide").length,
+    explicitDeckContainer: Boolean(document.querySelector("[data-ipw-deck],.deck,#deck")),
+    deckControlCount: document.querySelectorAll(deckControlSelector).length,
+  })) return;
 
   slides.forEach((slide, index) => {
     if (!slide.hasAttribute("data-ipw-slide")) slide.setAttribute("data-ipw-slide", String(index + 1));
   });
+  const fitTargetAttribute = "data-ipw-design-deck-fit-target";
+  const fitStyleId = "ipollowork-design-deck-fit-style";
+  const fitTarget = slides[0]?.closest<HTMLElement>("[data-ipw-deck],.deck,#deck") || slides[0]?.parentElement || document.body;
+  fitTarget.setAttribute(fitTargetAttribute, "true");
+  const fitStyle = document.createElement("style");
+  fitStyle.id = fitStyleId;
+  document.head.appendChild(fitStyle);
 
   const deckControl = (direction: "previous" | "next") => {
     const aliases = direction === "previous"
@@ -195,8 +400,36 @@ function designDeckRuntime(channel: string) {
     return 0;
   };
 
+  const fitDeck = () => {
+    const active = slides[activeIndex()] || slides[0];
+    const contentWidth = Math.max(
+      active?.scrollWidth || 0,
+      active?.getBoundingClientRect().width || 0,
+      window.innerWidth,
+    );
+    const contentHeight = Math.max(
+      active?.scrollHeight || 0,
+      active?.getBoundingClientRect().height || 0,
+      window.innerHeight,
+    );
+    const scale = fitScale(window.innerWidth, contentWidth, window.innerHeight, contentHeight);
+    fitStyle.textContent = `
+      [${fitTargetAttribute}="true"] {
+        --ipw-design-deck-fit-scale: ${scale};
+        --ipw-design-deck-fit-width: ${Math.ceil(contentWidth)}px;
+        min-width: var(--ipw-design-deck-fit-width) !important;
+        max-width: none !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+        transform-origin: top center !important;
+        zoom: var(--ipw-design-deck-fit-scale);
+      }
+    `;
+  };
+
   let lastState = "";
   const report = () => {
+    fitDeck();
     const index = activeIndex();
     const title = slides[index]?.getAttribute("data-title") || slides[index]?.querySelector("h1,h2,h3")?.textContent?.trim() || "";
     const key = `${index}:${title}`;
@@ -236,8 +469,23 @@ function designDeckRuntime(channel: string) {
   };
 
   document.addEventListener("click", () => window.setTimeout(report, 0), true);
-  document.addEventListener("keydown", () => window.setTimeout(report, 0), true);
+  window.addEventListener("keydown", (event) => {
+    const direction = directionForKey(event.key);
+    if (!direction) {
+      window.setTimeout(report, 0);
+      return;
+    }
+    const target = event.target;
+    if (target instanceof HTMLElement && target.closest("input,textarea,select,[contenteditable='true']")) return;
+    const before = activeIndex();
+    event.preventDefault();
+    window.setTimeout(() => {
+      if (activeIndex() === before) navigate(direction);
+      else report();
+    }, 0);
+  }, true);
   document.addEventListener("scroll", () => window.setTimeout(report, 0), true);
+  window.addEventListener("resize", () => window.setTimeout(report, 0));
   window.addEventListener("hashchange", report);
   new MutationObserver(report).observe(document.body, { subtree: true, attributes: true, attributeFilter: ["class", "aria-hidden"] });
   window.addEventListener("message", (event) => {
@@ -253,6 +501,11 @@ function designDeckRuntime(channel: string) {
 function designRuntime(channel: string, styleFields: readonly string[], initialEditing: boolean) {
   const runtimeId = "ipollowork-design-runtime";
   const styleId = "ipollowork-design-runtime-style";
+  const fitStyleId = "ipollowork-design-deck-fit-style";
+  const fitTargetAttribute = "data-ipw-design-deck-fit-target";
+  const previewFitStyleId = "ipollowork-design-preview-fit-style";
+  const previewFitTargetAttribute = "data-ipw-design-preview-fit-target";
+  const previewFitAttribute = "data-ipw-design-preview-fit";
   const selectedAttribute = "data-ipollowork-design-selected";
   const editingAttribute = "data-ipollowork-design-editing";
   const idAttribute = "data-ipollowork-design-id";
@@ -331,19 +584,26 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     const clone = document.documentElement.cloneNode(true);
     if (!(clone instanceof HTMLElement)) return "";
     clone.querySelector(`#${runtimeId}`)?.remove();
+    clone.querySelector("#ipollowork-design-preview-fit-runtime")?.remove();
     clone.querySelector("#ipollowork-design-navigation-runtime")?.remove();
     clone.querySelector("#ipollowork-design-deck-runtime")?.remove();
     clone.querySelector(`#${styleId}`)?.remove();
+    clone.querySelector(`#${fitStyleId}`)?.remove();
+    clone.querySelector(`#${previewFitStyleId}`)?.remove();
     clone.querySelector("#ipollowork-design-template-token-style")?.remove();
     clone.querySelector(`#${overlayId}`)?.remove();
     clone.querySelectorAll(`[${textNodeAttribute}]`).forEach((element) => element.replaceWith(...Array.from(element.childNodes)));
     clone.querySelectorAll(`[${idAttribute}]`).forEach((element) => element.removeAttribute(idAttribute));
+    clone.querySelectorAll(`[${fitTargetAttribute}]`).forEach((element) => element.removeAttribute(fitTargetAttribute));
+    clone.querySelectorAll(`[${previewFitTargetAttribute}]`).forEach((element) => element.removeAttribute(previewFitTargetAttribute));
+    clone.querySelectorAll(`[${previewFitAttribute}]`).forEach((element) => element.removeAttribute(previewFitAttribute));
     clone.querySelectorAll(`[${selectedAttribute}]`).forEach((element) => element.removeAttribute(selectedAttribute));
     clone.querySelectorAll(`[${editingAttribute}]`).forEach((element) => {
       element.removeAttribute(editingAttribute);
       element.removeAttribute("contenteditable");
     });
     clone.removeAttribute(modeAttribute);
+    clone.removeAttribute(previewFitAttribute);
     const doctype = document.doctype
       ? `<!DOCTYPE ${document.doctype.name}${document.doctype.publicId ? ` PUBLIC \"${document.doctype.publicId}\"` : ""}${document.doctype.systemId ? ` \"${document.doctype.systemId}\"` : ""}>\n`
       : "";

--- a/apps/app/tests/design-html-runtime.test.ts
+++ b/apps/app/tests/design-html-runtime.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "bun:test";
 import {
   buildDesignPreviewDocument,
   DESIGN_MESSAGE_CHANNEL,
+  designDeckFitScale,
+  designDeckDirectionForKey,
+  designPreviewFitScale,
   isLocalHtmlPath,
+  shouldRunDesignDeckRuntime,
 } from "../src/react-app/domains/session/design/design-html-runtime";
 
 describe("Design HTML runtime", () => {
@@ -55,6 +59,109 @@ describe("Design HTML runtime", () => {
     expect(preview).toContain("deck-navigate");
     expect(preview).toContain('data-ipw-slide');
     expect(preview).toContain('data-action=\'next\'');
+  });
+
+  test("normalizes deck keyboard navigation across arrow directions", () => {
+    expect(designDeckDirectionForKey("ArrowLeft")).toBe("previous");
+    expect(designDeckDirectionForKey("ArrowUp")).toBe("previous");
+    expect(designDeckDirectionForKey("PageUp")).toBe("previous");
+    expect(designDeckDirectionForKey("ArrowRight")).toBe("next");
+    expect(designDeckDirectionForKey("ArrowDown")).toBe("next");
+    expect(designDeckDirectionForKey("PageDown")).toBe("next");
+    expect(designDeckDirectionForKey(" ")).toBe("next");
+    expect(designDeckDirectionForKey("Enter")).toBeNull();
+  });
+
+  test("injects the unified keyboard navigation map into deck previews", () => {
+    const source = "<!doctype html><html><body><section class=\"slide is-active\"><h1>One</h1></section><section class=\"slide\"><h1>Two</h1></section></body></html>";
+    const preview = buildDesignPreviewDocument(source, true, "", false);
+
+    expect(preview).toContain("ArrowUp");
+    expect(preview).toContain("ArrowDown");
+    expect(preview).toContain("event.preventDefault()");
+    expect(preview).toContain("directionForKey(event.key)");
+  });
+
+  test("does not treat ordinary website slide classes as deck previews", () => {
+    expect(shouldRunDesignDeckRuntime({
+      slideCount: 9,
+      dataSlideCount: 0,
+      explicitDeckContainer: false,
+      deckControlCount: 0,
+    })).toBe(false);
+    expect(shouldRunDesignDeckRuntime({
+      slideCount: 2,
+      dataSlideCount: 2,
+      topLevelSectionSlideCount: 0,
+      explicitDeckContainer: false,
+      deckControlCount: 0,
+    })).toBe(true);
+    expect(shouldRunDesignDeckRuntime({
+      slideCount: 6,
+      dataSlideCount: 0,
+      topLevelSectionSlideCount: 6,
+      explicitDeckContainer: false,
+      deckControlCount: 0,
+    })).toBe(true);
+    expect(shouldRunDesignDeckRuntime({
+      slideCount: 2,
+      dataSlideCount: 0,
+      topLevelSectionSlideCount: 0,
+      explicitDeckContainer: true,
+      deckControlCount: 0,
+    })).toBe(true);
+    expect(shouldRunDesignDeckRuntime({
+      slideCount: 2,
+      dataSlideCount: 0,
+      topLevelSectionSlideCount: 0,
+      explicitDeckContainer: false,
+      deckControlCount: 1,
+    })).toBe(true);
+  });
+
+  test("scales fixed-width deck canvases down to the preview viewport", () => {
+    expect(designDeckFitScale(1024, 810)).toBe(1);
+    expect(designDeckFitScale(760, 720, 690, 680)).toBe(1);
+    expect(designDeckFitScale(760, 810)).toBeCloseTo(0.9185, 4);
+    expect(designDeckFitScale(760, 810, 690, 1080)).toBeCloseTo(0.6241, 4);
+    expect(designDeckFitScale(390, 810)).toBeCloseTo(0.4617, 4);
+  });
+
+  test("scales overflowing website canvases down by width in the preview", () => {
+    expect(designPreviewFitScale(1180, 1180)).toBe(1);
+    expect(designPreviewFitScale(760, 1180)).toBeCloseTo(0.6305, 4);
+    expect(designPreviewFitScale(390, 1180)).toBeCloseTo(0.3169, 4);
+  });
+
+  test("scales fixed artboards by both width and height in the preview", () => {
+    expect(designPreviewFitScale(760, 1080, 690, 1920, "artboard")).toBeCloseTo(0.351, 3);
+    expect(designPreviewFitScale(1200, 1080, 900, 720, "artboard")).toBe(1);
+  });
+
+  test("injects generic preview fitting without saving it as user markup", () => {
+    const source = "<!doctype html><html data-ipw-frame=\"fluid\"><body><main style=\"width:1180px\"><h1>Wide site</h1></main></body></html>";
+    const preview = buildDesignPreviewDocument(source, true, "", false);
+
+    expect(preview).toContain('id="ipollowork-design-preview-fit-runtime"');
+    expect(preview).toContain("ipollowork-design-preview-fit-style");
+    expect(preview).toContain("data-ipw-design-preview-fit-target");
+    expect(preview).toContain("--ipw-design-preview-fit-scale");
+    expect(preview).toContain("overflow-x");
+    expect(preview).toContain("fallbackTimer");
+    expect(preview).toContain("window.setTimeout(scheduleFit, 180)");
+    expect(preview).toContain('removeAttribute("data-ipw-design-preview-fit-target")');
+    expect(preview).toContain('removeAttribute("data-ipw-design-preview-fit")');
+  });
+
+  test("injects deck canvas fitting into previews without saving it as user markup", () => {
+    const source = "<!doctype html><html><body><div class=\"deck\"><section class=\"slide is-active\"><h1>One</h1></section><section class=\"slide\"><h1>Two</h1></section></div></body></html>";
+    const preview = buildDesignPreviewDocument(source, true, "", false);
+
+    expect(preview).toContain("ipollowork-design-deck-fit-style");
+    expect(preview).toContain("data-ipw-design-deck-fit-target");
+    expect(preview).toContain("--ipw-design-deck-fit-scale");
+    expect(preview).toContain("zoom:");
+    expect(preview).toContain('removeAttribute("data-ipw-design-deck-fit-target")');
   });
 
   test("inlines template token CSS into the preview without treating it as user HTML", () => {

--- a/apps/server/bundled-templates/ipollowork.html-anything.web-proto-brutalist/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.web-proto-brutalist/entry.html
@@ -114,6 +114,11 @@
       text-transform: uppercase; margin: 0;
     }
     .hero .meta-col p { font-family: var(--sans); font-size: 14px; line-height: 1.55; margin: 0; max-width: 38ch; text-align: justify; }
+    .hero > * { min-width: 0; }
+    .hero .meta-col h2,
+    .hero .meta-col p,
+    .ascii-frame,
+    .meta-row span { min-width: 0; max-width: 100%; overflow-wrap: anywhere; }
     .meta-row { display: grid; grid-template-columns: 8ch 1fr; gap: 12px; padding: 10px 0; border-top: 1px solid var(--ink); font-size: 11.5px; text-transform: uppercase; letter-spacing: 0.08em; }
     .meta-row b { color: var(--hazard); font-weight: 500; }
 
@@ -225,6 +230,11 @@
     .spec-row .glyph.s2 { font-size: clamp(60px, 9vw, 120px); }
     .spec-row .glyph.s3 { font-size: clamp(120px, 16vw, 220px); }
     .spec-row .stats { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; text-align: right; line-height: 1.6; }
+    .spec-row,
+    .spec-row > * { min-width: 0; max-width: 100%; }
+    .spec-row .label,
+    .spec-row .glyph,
+    .spec-row .stats { overflow-wrap: anywhere; }
 
     /* ========= ALERT BLOCK ========= */
     .alert {
@@ -261,12 +271,13 @@
 
     /* ========= RESPONSIVE ========= */
     @media (max-width: 880px) {
+      html, body { max-width: 100%; overflow-x: hidden; }
       .strip { grid-template-columns: 1fr 1fr; gap: 8px 22px; }
       .strip > div:nth-child(n+5) { display: none; }
       .nav ul { display: none; }
-      .hero { grid-template-columns: 1fr; }
+      .hero { grid-template-columns: 1fr; width: 100%; max-width: 100%; overflow: hidden; }
       .hero .num { font-size: 36vw; }
-      .hero .meta-col { border-left: none; border-top: 1px solid var(--ink); }
+      .hero .meta-col { min-width: 0; max-width: 100%; overflow: hidden; border-left: none; border-top: 1px solid var(--ink); }
       .abstract { grid-template-columns: 1fr; }
       .thesis { grid-template-columns: 6ch 1fr; }
       .thesis .tag { display: none; }
@@ -313,7 +324,7 @@
       .spec-row { grid-template-columns: 1fr; gap: 8px; }
       .spec-row .glyph.s1 { font-size: 34px; }
       .spec-row .glyph.s2 { font-size: 54px; }
-      .spec-row .glyph.s3 { font-size: 104px; }
+      .spec-row .glyph.s3 { font-size: clamp(64px, 25vw, 96px); }
       .spec-row .stats { text-align: left; }
       .alert { padding: 18px 16px; }
       .colophon { padding: 28px 16px; }
@@ -323,7 +334,7 @@
     }
   </style>
 <link rel="stylesheet" href="design-tokens.css"></head>
-<body><div class="ipw-brand-slot" data-ipw-brand-slot><img src="assets/ipollowork-logo.svg" alt="iPolloWork logo" data-ipw-logo><span data-ipw-text="brand.name">iPolloWork</span></div>
+<body data-ipw-frame="fluid"><div class="ipw-brand-slot" data-ipw-brand-slot><img src="assets/ipollowork-logo.svg" alt="iPolloWork logo" data-ipw-logo><span data-ipw-text="brand.name">iPolloWork</span></div>
   <div class="strip">
     <div><b>VOL.</b><span>04 / FIELD UNIT</span></div>
     <div><b>ISS.</b><span>2026 · MAY · QRTLY</span></div>


### PR DESCRIPTION
## Summary

Fix responsive preview issues for template-market designs, especially mobile viewport misalignment in website templates.

## What changed

- Updated `design-html-runtime.ts` with real preview behavior fixes:
  - Added mobile preview auto-fit scaling for overflowing website canvases.
  - Narrowed deck/slide detection so ordinary website `.slide` classes are not treated as presentation decks.
  - Added deck fit scaling and keyboard navigation handling.
  - Cleans preview/deck runtime attributes before saving user markup.

- Updated `web-proto-brutalist/entry.html`:
  - Improved mobile CSS to prevent horizontal overflow.
  - Added safer wrapping/min-width rules for hero/meta/spec sections.
  - Adjusted large glyph sizing on small screens.
  - Marked the template as `data-ipw-frame="fluid"`.

- Added regression coverage in `design-html-runtime.test.ts` for:
  - Mobile preview fitting.
  - Deck canvas scaling.
  - Deck keyboard behavior.
  - Avoiding false deck detection on normal website templates.

## Verification

- `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-html-runtime.test.ts tests/template-brief.test.ts tests/design-panel.test.ts`
  - 21 pass, 0 fail

- `pnpm.cmd --filter ipollowork-server exec bun test src/templates.test.ts`
  - 18 pass, 0 fail

- `pnpm.cmd --filter @ipollowork/app typecheck`
  - Passed

## Notes

Only the responsive-preview fix files were included in this branch. Other existing local changes were intentionally left out.