### PR TITLE
fix(composer): queue follow-ups by default

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -335,8 +335,8 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, [props.draft]);
 
   // Follow-up message UX (only relevant while the agent is busy):
-  // - Enter sends immediately (the agent adjusts mid-task, aka "steer").
-  // - Cmd/Ctrl+Enter queues the message to send once the agent finishes.
+  // - Enter queues the message to send once the agent finishes.
+  // - Cmd/Ctrl+Enter sends immediately (the agent adjusts mid-task).
   // - Escape arms a "Hit Escape again to stop the agent" prompt for 3s;
   //   a second Escape within that window stops the agent.
   const [escapeArmed, setEscapeArmed] = useState(false);
@@ -376,8 +376,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, []);
 
   // Editor submit (Enter). While idle this sends normally; while busy
-  // Enter sends immediately (steer) and Cmd/Ctrl+Enter queues the
-  // message to send once the agent finishes the current task.
+  // Enter queues and Cmd/Ctrl+Enter sends immediately (steer).
   const handleEditorSubmit = useCallback((options: { queue: boolean }) => {
     const hasContent = props.draft.trim().length > 0 || props.attachments.length > 0;
     if (!hasContent) return;
@@ -1704,17 +1703,17 @@ export function ReactSessionComposer(props: ComposerProps) {
                     <div className="flex items-end">
                       <button
                         type="button"
-                        onClick={canSend ? props.onSteer : undefined}
+                        onClick={canSend ? props.onQueue : undefined}
                         disabled={!canSend}
                         className={`inline-flex h-9 max-h-9 items-center gap-2 rounded-l-full pl-4 pr-3 text-[13px] font-medium transition-colors ${
                           canSend
                             ? "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
                             : "bg-gray-4 text-gray-10"
                         }`}
-                        title={t("composer.steer_hint")}
+                        title={t("composer.queue_hint")}
                       >
-                        <Zap size={14} />
-                        <span>{t("composer.steer")}</span>
+                        <ListPlus size={14} />
+                        <span>{t("composer.queue")}</span>
                       </button>
                       <DropdownMenu>
                         <DropdownMenuTrigger
@@ -1740,15 +1739,11 @@ export function ReactSessionComposer(props: ComposerProps) {
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem
                             disabled={!canSend}
-                            onClick={() => void props.onQueue()}
-                            title={t("composer.queue_hint")}
+                            onClick={() => void props.onSteer()}
+                            title={t("composer.steer_hint")}
                           >
-                            <ListPlus size={14} />
-                            <span>
-                              {props.queuedCount > 0
-                                ? `${t("composer.queue")} · ${t("composer.queued_count", { count: props.queuedCount })}`
-                                : t("composer.queue")}
-                            </span>
+                            <Zap size={14} />
+                            <span>{t("composer.steer")}</span>
                             <DropdownMenuShortcut>{isMacPlatform() ? "⌘⏎" : "Ctrl+⏎"}</DropdownMenuShortcut>
                           </DropdownMenuItem>
                         </DropdownMenuContent>

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -619,11 +619,10 @@ function SubmitPlugin(props: { onSubmit: (options: { queue: boolean }) => void |
         if (event?.shiftKey) return false;
         const selection = $getSelection();
         if (!$isRangeSelection(selection)) return false;
-        // Plain Enter submits. Cmd/Ctrl+Enter submits with the queue
-        // modifier — while the agent is busy this queues the message to
-        // send once the current task finishes.
+        // Plain Enter uses the default send path. Cmd/Ctrl+Enter requests an
+        // immediate send while the agent is busy.
         event?.preventDefault();
-        void onSubmitRef.current({ queue: event?.metaKey === true || event?.ctrlKey === true });
+        void onSubmitRef.current({ queue: !(event?.metaKey === true || event?.ctrlKey === true) });
         return true;
       },
       COMMAND_PRIORITY_HIGH,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -407,34 +407,6 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
   URL.revokeObjectURL(attachment.previewUrl);
 }
 
-// Combine multiple queued follow-up drafts into a single send. Their text and
-// parts are concatenated with blank-line separators and attachments are
-// merged, so the whole queue is delivered to the agent as one message.
-function mergeDrafts(drafts: ComposerDraft[]): ComposerDraft | null {
-  if (drafts.length === 0) return null;
-  if (drafts.length === 1) return drafts[0] ?? null;
-  const separator: ComposerPart = { type: "text", text: "\n\n" };
-  const parts: ComposerPart[] = [];
-  const attachments: ComposerAttachment[] = [];
-  const texts: string[] = [];
-  const resolvedTexts: string[] = [];
-  drafts.forEach((draft, index) => {
-    if (index > 0) parts.push(separator);
-    parts.push(...draft.parts);
-    attachments.push(...draft.attachments);
-    texts.push(draft.text);
-    resolvedTexts.push(draft.resolvedText ?? draft.text);
-  });
-  return {
-    mode: "prompt",
-    parts,
-    attachments,
-    text: texts.join("\n\n"),
-    resolvedText: resolvedTexts.join("\n\n"),
-    command: undefined,
-  };
-}
-
 export function SessionSurface(props: SessionSurfaceProps) {
   const local = useLocal();
   const { config: shellConfig } = useShellConfig();
@@ -895,30 +867,28 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   }, [liveStatus.type]);
 
-  // Drain the queued follow-ups once the session goes idle. OpenCode has no
-  // server-side queue, so we send everything that's queued as a single merged
-  // message. The ref guards against re-entrancy while the send is in flight.
+  // Drain one queued follow-up each time the session goes idle. The ref guards
+  // against re-entrancy while the send is in flight.
   const drainingQueueRef = useRef(false);
   useEffect(() => {
     if (drainingQueueRef.current) return;
     if (queuedDrafts.length === 0) return;
     if (chatStreaming || liveStatus.type !== "idle") return;
-    const merged = mergeDrafts(queuedDrafts);
-    if (!merged) return;
-    const drained = queuedDrafts;
+    const next = queuedDrafts[0];
+    if (!next) return;
     drainingQueueRef.current = true;
-    clearQueuedDrafts(props.sessionId);
+    removeQueuedDraftFromStore(props.sessionId, 0);
     void (async () => {
       try {
-        await sendDraft(merged, merged.attachments);
+        await sendDraft(next, next.attachments);
       } catch {
         // Restore the queue so the user can retry / edit on failure.
-        prependQueuedDrafts(props.sessionId, drained);
+        prependQueuedDrafts(props.sessionId, [next]);
       } finally {
         drainingQueueRef.current = false;
       }
     })();
-  }, [chatStreaming, clearQueuedDrafts, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, sendDraft]);
+  }, [chatStreaming, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, removeQueuedDraftFromStore, sendDraft]);
 
   useEffect(() => {
     props.onDraftChange(buildDraft(draft, attachments));

--- a/apps/app/tests/composer-queue-behavior.test.ts
+++ b/apps/app/tests/composer-queue-behavior.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const editorSource = readFileSync(
+  resolve(import.meta.dir, "../src/react-app/domains/session/surface/composer/editor.tsx"),
+  "utf8",
+);
+const composerSource = readFileSync(
+  resolve(import.meta.dir, "../src/react-app/domains/session/surface/composer/composer.tsx"),
+  "utf8",
+);
+const sessionSurfaceSource = readFileSync(
+  resolve(import.meta.dir, "../src/react-app/domains/session/surface/session-surface.tsx"),
+  "utf8",
+);
+
+describe("composer queue behavior", () => {
+  test("queues plain Enter and reserves Cmd/Ctrl+Enter for immediate send", () => {
+    expect(editorSource).toContain(
+      "queue: !(event?.metaKey === true || event?.ctrlKey === true)",
+    );
+  });
+
+  test("uses queue as the primary busy action", () => {
+    const busyActions = composerSource.slice(
+      composerSource.indexOf("{props.busy ? ("),
+      composerSource.indexOf("{props.busy ? (") + 4000,
+    );
+
+    expect(busyActions).toContain("onClick={canSend ? props.onQueue : undefined}");
+    expect(busyActions).toContain('title={t("composer.queue_hint")}');
+    expect(busyActions).toContain("onClick={() => void props.onSteer()}");
+  });
+
+  test("drains queued drafts one at a time", () => {
+    expect(sessionSurfaceSource).not.toContain("function mergeDrafts(");
+    expect(sessionSurfaceSource).toContain("const next = queuedDrafts[0]");
+    expect(sessionSurfaceSource).toContain("removeQueuedDraftFromStore(props.sessionId, 0)");
+    expect(sessionSurfaceSource).toContain("await sendDraft(next, next.attachments)");
+    expect(sessionSurfaceSource).toContain("prependQueuedDrafts(props.sessionId, [next])");
+  });
+});


### PR DESCRIPTION
Queues follow-ups by default while the agent is busy. Use Ctrl/Cmd+Enter to send immediately. Queued messages are sent individually.