### PR TITLE
Improve settings language switch and template brief dismissal

### DIFF
--- a/apps/app/src/i18n/index.ts
+++ b/apps/app/src/i18n/index.ts
@@ -9,6 +9,7 @@ import ca from "./locales/ca";
 import es from "./locales/es";
 import ru from "./locales/ru";
 export const LANGUAGE_PREF_KEY = "ipollowork.language";
+export const localeChangedEvent = "ipollowork:locale-changed";
 
 /**
  * Supported languages
@@ -108,6 +109,7 @@ export const setLocale = (newLocale: Language) => {
     } catch (e) {
       console.warn("Failed to persist language preference:", e);
     }
+    window.dispatchEvent(new CustomEvent(localeChangedEvent, { detail: { locale: newLocale } }));
   }
 };
 

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { UIMessage } from "ai";
 import { usePanelRef } from "react-resizable-panels";
 import { useNavigate } from "react-router-dom";
-import { Code2, Ellipsis, Eye, FileText, Film, Globe, Image, LoaderCircle, Mic2, Palette, PanelRightClose, PanelRightOpen, Pencil, Presentation, Search, Settings2, Trash2, Upload, Zap } from "lucide-react";
+import { Code2, Ellipsis, Eye, FileText, Film, Globe, Image, LoaderCircle, Mic2, Palette, PanelRightClose, PanelRightOpen, Pencil, Presentation, Search, Settings2, Trash2, Upload, X, Zap } from "lucide-react";
 import type { TemplateCatalogItem, TemplateManifestV1, TemplateSessionSnapshot, TemplateSessionState, TemplateStyle } from "@ipollowork/types/templates";
 
 import { t } from "../../../../i18n";
@@ -171,7 +171,7 @@ export type SessionPageProps = {
   hasUsableModel?: boolean;
   providers?: ProviderListItem[];
   mcpConnectedCount: number;
-  onOpenSettings: () => void;
+  onOpenSettings: (route?: string) => void;
   sidebar: SessionPageSidebarProps;
   surface?: SessionPageSurfaceProps | null;
   history?: SessionPageHistoryControls | null;
@@ -375,7 +375,7 @@ function TemplatePalettePicker({ selectedId, customPalette, onSelect, onCustomCo
   </div>;
 }
 
-function TemplateBriefCard({ template, onSubmit }: { template: TemplateManifestV1; onSubmit: (brief: TemplateBrief) => void }) {
+function TemplateBriefCard({ template, onSubmit, onClose }: { template: TemplateManifestV1; onSubmit: (brief: TemplateBrief) => void; onClose: () => void | Promise<void> }) {
   const config = templateBriefConfigFor(template);
   const [brief, setBrief] = useState<Omit<TemplateBrief, "colorPalette">>({ title: "", audience: "", details: "" });
   const [selectedPaletteId, setSelectedPaletteId] = useState(DEFAULT_TEMPLATE_COLOR_PALETTE.id);
@@ -383,7 +383,7 @@ function TemplateBriefCard({ template, onSubmit }: { template: TemplateManifestV
   const colorPalette = selectedPaletteId === "custom"
     ? customPalette
     : TEMPLATE_COLOR_PRESETS.find((palette) => palette.id === selectedPaletteId) ?? DEFAULT_TEMPLATE_COLOR_PALETTE;
-  return <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto px-6 py-10"><div className="w-full max-w-xl overflow-hidden rounded-3xl border border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]"><div className={cn("p-5", template.surface === "video" ? "bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 text-white" : "bg-gradient-to-br from-stone-100 via-orange-50 to-white")}><p className={cn("text-xs font-medium", template.surface === "video" ? "text-indigo-200" : "text-dls-secondary")}>{template.title} · {config.label}</p><h2 className="mt-1 text-lg font-semibold">{config.heading}</h2><p className={cn("mt-1 text-sm", template.surface === "video" ? "text-white/65" : "text-dls-secondary")}>{config.description}</p></div><div className="space-y-4 p-5">{config.fields.map((field) => <label key={field.key} className="block text-sm font-medium">{field.label}{field.optional ? <span className="ml-1 text-xs font-normal text-dls-secondary">（可选）</span> : null}<Input value={brief[field.key]} onChange={(event) => { const value = event.currentTarget.value; setBrief((current) => ({ ...current, [field.key]: value })); }} placeholder={field.placeholder} className="mt-2" /></label>)}<TemplatePalettePicker selectedId={selectedPaletteId} customPalette={customPalette} onSelect={setSelectedPaletteId} onCustomColorChange={(key, value) => setCustomPalette((current) => ({ ...current, [key]: value }))} /><Button className="w-full" disabled={!brief.title.trim() || !brief.audience.trim()} onClick={() => onSubmit({ ...brief, title: brief.title.trim(), audience: brief.audience.trim(), details: brief.details.trim(), colorPalette })}>{config.submitLabel}</Button></div></div></div>;
+  return <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto px-6 py-10"><div className="w-full max-w-xl overflow-hidden rounded-3xl border border-dls-border bg-dls-surface shadow-[var(--dls-card-shadow)]"><div className={cn("relative p-5 pr-14", template.surface === "video" ? "bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 text-white" : "bg-gradient-to-br from-stone-100 via-orange-50 to-white")}><Button type="button" variant="ghost" size="icon-sm" className={cn("absolute right-4 top-4 rounded-full", template.surface === "video" ? "text-white/70 hover:text-white" : "text-dls-secondary hover:text-dls-text")} aria-label={t("common.close")} onClick={() => void onClose()}><X className="size-4" /></Button><p className={cn("text-xs font-medium", template.surface === "video" ? "text-indigo-200" : "text-dls-secondary")}>{template.title} · {config.label}</p><h2 className="mt-1 text-lg font-semibold">{config.heading}</h2><p className={cn("mt-1 text-sm", template.surface === "video" ? "text-white/65" : "text-dls-secondary")}>{config.description}</p></div><div className="space-y-4 p-5">{config.fields.map((field) => <label key={field.key} className="block text-sm font-medium">{field.label}{field.optional ? <span className="ml-1 text-xs font-normal text-dls-secondary">（可选）</span> : null}<Input value={brief[field.key]} onChange={(event) => { const value = event.currentTarget.value; setBrief((current) => ({ ...current, [field.key]: value })); }} placeholder={field.placeholder} className="mt-2" /></label>)}<TemplatePalettePicker selectedId={selectedPaletteId} customPalette={customPalette} onSelect={setSelectedPaletteId} onCustomColorChange={(key, value) => setCustomPalette((current) => ({ ...current, [key]: value }))} /><Button className="w-full" disabled={!brief.title.trim() || !brief.audience.trim()} onClick={() => onSubmit({ ...brief, title: brief.title.trim(), audience: brief.audience.trim(), details: brief.details.trim(), colorPalette })}>{config.submitLabel}</Button></div></div></div>;
 }
 
 export function SessionPage(props: SessionPageProps) {
@@ -448,12 +448,16 @@ export function SessionPage(props: SessionPageProps) {
     sessionId: null,
     messages: [],
   });
+  const [dismissedTemplateBriefSessionIds, setDismissedTemplateBriefSessionIds] = useState<Set<string>>(() => new Set());
   const handleConversationMessagesChange = useCallback((sessionId: string, messages: UIMessage[]) => {
     setConversationMessageState({ sessionId, messages });
   }, []);
   const conversationMessages = conversationMessageState.sessionId === props.selectedSessionId
     ? conversationMessageState.messages
     : [];
+  const templateBriefDismissed = Boolean(
+    props.selectedSessionId && dismissedTemplateBriefSessionIds.has(props.selectedSessionId),
+  );
   const activateVideoStudio = useCallback(() => {
     // Video creation always begins with a selected video template. This keeps
     // the right studio and the agent on the same canonical session snapshot.
@@ -526,6 +530,11 @@ export function SessionPage(props: SessionPageProps) {
       const result = await props.ipolloworkServerClient.materializeTemplate(props.runtimeWorkspaceId, templateId, props.selectedSessionId);
       setSessionType(props.selectedSessionId, sessionTypeForTemplate(result.manifest));
       setTemplateSessionData({ ...result, hasBrief: false });
+      setDismissedTemplateBriefSessionIds((current) => {
+        const next = new Set(current);
+        next.delete(props.selectedSessionId!);
+        return next;
+      });
       setSessionTypeRevision((value) => value + 1);
       setTemplateSessionRevision((value) => value + 1);
       setSidePanelState(props.selectedSessionId, "design");
@@ -593,9 +602,39 @@ export function SessionPage(props: SessionPageProps) {
     });
     setTemplateSessionData((current) => current ? { ...current, hasBrief: true } : current);
     setTemplateSessionRevision((value) => value + 1);
+    setDismissedTemplateBriefSessionIds((current) => {
+      if (!props.selectedSessionId || !current.has(props.selectedSessionId)) return current;
+      const next = new Set(current);
+      next.delete(props.selectedSessionId);
+      return next;
+    });
     const prompt = templateBriefPrompt({ template, entryPath: state.entry, briefPath: state.briefPath });
     props.surface?.onSendDraft({ mode: "prompt", parts: [{ type: "text", text: prompt }], attachments: [], text: prompt }, props.selectedSessionId);
   }, [props.ipolloworkServerClient, props.runtimeWorkspaceId, props.selectedSessionId, props.surface, templateSessionData]);
+  const closeTemplateBrief = useCallback(async () => {
+    const sessionId = props.selectedSessionId;
+    if (!sessionId) return;
+    const emptyGeneratedTemplateSession = !templateSessionData?.hasBrief && conversationMessages.length === 0;
+    if (emptyGeneratedTemplateSession && props.onDeleteSession) {
+      try {
+        await props.onDeleteSession(sessionId);
+        setTemplateSessionData(null);
+        setDismissedTemplateBriefSessionIds((current) => {
+          const next = new Set(current);
+          next.delete(sessionId);
+          return next;
+        });
+        return;
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : "Could not delete this empty session.");
+      }
+    }
+    setDismissedTemplateBriefSessionIds((current) => {
+      const next = new Set(current);
+      next.add(sessionId);
+      return next;
+    });
+  }, [conversationMessages.length, props.onDeleteSession, props.selectedSessionId, templateSessionData?.hasBrief]);
   const [sessionPanelView, setSessionPanelView] = useState<SessionPanelView | null>(null);
   const effectiveSidePanelView = activeSidePanel ?? sessionPanelView;
   const sidePanelOpen = effectiveSidePanelView !== null;
@@ -1601,8 +1640,8 @@ export function SessionPage(props: SessionPageProps) {
                           onUninstall={(templateId) => void uninstallDesignTemplate(templateId)}
                           onImport={(file, category) => void importDesignTemplate(file, category)}
                         />
-                      ) : templateSessionData && !hasTemplateBrief ? (
-                        <TemplateBriefCard template={templateSessionData.manifest} onSubmit={(brief) => void submitTemplateBrief(brief)} />
+                      ) : templateSessionData && !hasTemplateBrief && !templateBriefDismissed ? (
+                        <TemplateBriefCard template={templateSessionData.manifest} onSubmit={(brief) => void submitTemplateBrief(brief)} onClose={() => void closeTemplateBrief()} />
                       ) : <SessionSurface
                         // Spread `surface` first so the explicit per-workspace
                         // routing props below CAN'T be silently overridden by

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -4,9 +4,11 @@ import {
   AlertCircle,
   Archive,
   ArchiveRestore,
+  Check,
   ChevronRight,
   FolderPlus,
   Loader2,
+  Languages,
   MoreHorizontal,
   Pencil,
   Pin,
@@ -38,7 +40,7 @@ import {
   isMacPlatform,
   isWindowsPlatform,
 } from "../../../../app/utils";
-import { t } from "../../../../i18n";
+import { currentLocale, setLocale, t, type Language } from "../../../../i18n";
 import { useBrandAppName, useBrandLogoUrl } from "../../cloud/brand-theme";
 
 import {
@@ -597,7 +599,7 @@ export type AppSidebarProps = {
   };
   activePrimaryItem?: "template-market" | "extensions" | null;
   onOpenAccount: () => void;
-  onOpenSettings: () => void;
+  onOpenSettings: (route?: string) => void;
   onOpenTemplateMarket: () => void;
   onOpenExtensions: () => void;
   onSignIn: () => void;
@@ -629,6 +631,12 @@ export function AppSidebar(props: AppSidebarProps) {
   const [expandedSessionIds, setExpandedSessionIds] = React.useState<Set<string>>(
     () => new Set(),
   );
+  const [language, setLanguage] = React.useState<Language>(() => currentLocale());
+
+  const switchLanguage = React.useCallback((nextLanguage: Language) => {
+    setLanguage(nextLanguage);
+    setLocale(nextLanguage);
+  }, []);
 
   const expandWorkspace = React.useCallback((workspaceId: string) => {
     const id = workspaceId.trim();
@@ -887,14 +895,32 @@ export function AppSidebar(props: AppSidebarProps) {
                 </SidebarMenuButton>
               )}
               </div>
-              <button
-                type="button"
-                onClick={props.onOpenSettings}
-                aria-label={t("status.settings")}
-                className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/65 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:outline-hidden mac:hover:bg-black/5 mac:active:bg-black/5 dark:mac:hover:bg-white/10 dark:mac:active:bg-white/10"
-              >
-                <Settings className="size-4" />
-              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground/65 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:outline-hidden mac:hover:bg-black/5 mac:active:bg-black/5 dark:mac:hover:bg-white/10 dark:mac:active:bg-white/10"
+                  aria-label={t("status.settings")}
+                  title={t("status.settings")}
+                >
+                  <Settings className="size-4" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent side="top" align="end" className="w-36 min-w-36">
+                  <DropdownMenuItem onClick={() => props.onOpenSettings("/settings/general")}>
+                    <Settings className="size-4" />
+                    {t("status.settings")}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={() => switchLanguage("zh")}>
+                    <Languages className="size-4" />
+                    中文
+                    {language === "zh" ? <Check className="ml-auto size-3.5" /> : null}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={() => switchLanguage("en")}>
+                    <Languages className="size-4" />
+                    English
+                    {language === "en" ? <Check className="ml-auto size-3.5" /> : null}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
               <NotificationBell className="shrink-0 rounded-lg text-sidebar-foreground/65 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" />
             </SidebarMenuItem>
           </SidebarMenu>

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../app/lib/den-session-events";
 import { evalRelaunchDesktopApp } from "../../app/lib/desktop";
 import { Button } from "../../components/ui/button";
-import { t } from "../../i18n";
+import { localeChangedEvent, t } from "../../i18n";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { OrgOnboardingPage } from "../domains/cloud/org-onboarding-page";
@@ -347,6 +347,7 @@ let appOpenedCaptured = false;
 
 export function AppRoot() {
   useDesktopFontZoomBehavior();
+  const [, setLocaleVersion] = useState(0);
 
   // Module-level dedupe keeps StrictMode double-mounts from double-counting.
   useEffect(() => {
@@ -354,6 +355,12 @@ export function AppRoot() {
     appOpenedCaptured = true;
     initAnalytics();
     captureAnalyticsEvent("app_opened", {});
+  }, []);
+
+  useEffect(() => {
+    const refreshLocale = () => setLocaleVersion((version) => version + 1);
+    window.addEventListener(localeChangedEvent, refreshLocale);
+    return () => window.removeEventListener(localeChangedEvent, refreshLocale);
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

- Adds a compact settings menu beside the account area with direct Chinese / English switching.
- Broadcasts locale changes so the React shell updates immediately after switching language.
- Adds a close button to the template brief card.
- Deletes empty template-created sessions when the brief card is dismissed before any user input, avoiding blank junk sessions.

## Validation

- `pnpm --filter @ipollowork/app typecheck`
- `git diff --check`
