### PR TITLE
Bump client package to 0.17.25

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/app",
   "private": true,
-  "version": "0.17.24",
+  "version": "0.17.25",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/desktop",
   "private": true,
-  "version": "0.17.24",
+  "version": "0.17.25",
   "description": "iPolloWork desktop shell",
   "author": {
     "name": "iPolloWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-orchestrator",
-  "version": "0.17.24",
+  "version": "0.17.25",
   "description": "iPolloWork host orchestrator for opencode + iPolloWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.18.3",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "ipollowork-server": "workspace:*",
+    "ipollowork-server": "0.17.25",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-server",
-  "version": "0.17.24",
+  "version": "0.17.25",
   "description": "Filesystem-backed API for iPolloWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       ipollowork-server:
-        specifier: workspace:*
+        specifier: 0.17.25
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
The local client packaging flow generated the 0.17.25 version bump after PR #56 was merged.

This keeps the App, Desktop, Orchestrator, Server, and lockfile versions aligned with the generated macOS installers.

Validation: `pnpm package` completed successfully and produced the arm64 DMG and ZIP installers.