### PR TITLE
Polish panel navigation and message layout

### DIFF
--- a/apps/app/src/components/chat/artifact.tsx
+++ b/apps/app/src/components/chat/artifact.tsx
@@ -53,13 +53,13 @@ function ArtifactButton({ artifact, onOpenVideoStudio, compact = false }: Artifa
 
   const content = (
     <>
-      <DescriptiveButtonIcon className="size-5">
-        <ArtifactIcon className="size-4 shrink-0" type={artifact.type} />
+      <DescriptiveButtonIcon className={cn(compact ? "size-5" : "size-12 rounded-2xl bg-muted/55")}>
+        <ArtifactIcon className={cn("shrink-0", compact ? "size-4" : "size-5")} type={artifact.type} />
       </DescriptiveButtonIcon>
-      <DescriptiveButtonContent className="min-w-0 flex-none">
-        <DescriptiveButtonTitle className={cn("text-xs font-medium", compact ? "max-w-56" : "max-w-[172px]")} title={artifact.name}>{title}</DescriptiveButtonTitle>
+      <DescriptiveButtonContent className={cn("min-w-0", compact && "flex-none")}>
+        <DescriptiveButtonTitle className={cn(compact ? "max-w-56 text-xs font-medium" : "max-w-full text-sm font-medium")} title={artifact.name}>{title}</DescriptiveButtonTitle>
         {(!compact || canOpenVideoStudio) && canActivate ? (
-          <DescriptiveButtonDescription className="text-[10px] leading-3">
+          <DescriptiveButtonDescription className={cn(compact ? "text-[10px] leading-3" : "text-xs leading-4")}>
             {canOpenVideoStudio ? t("session.outputs.action_video_preview_edit") : t("session.outputs.action_browse_edit")}
           </DescriptiveButtonDescription>
         ) : null}
@@ -74,7 +74,7 @@ function ArtifactButton({ artifact, onOpenVideoStudio, compact = false }: Artifa
 
   if (!canActivate) {
     return (
-      <div className={cn("flex h-auto max-w-full flex-none shrink-0 items-center justify-start gap-1.5 rounded-xl border px-2 py-1.5 text-left whitespace-nowrap", compact ? "w-full border-transparent" : "w-fit border-border")}>
+      <div className={cn("flex h-auto max-w-full items-center justify-start gap-1.5 rounded-xl border text-left whitespace-nowrap", compact ? "w-full flex-none shrink-0 border-transparent px-2 py-1.5" : "min-h-[72px] w-full min-w-0 gap-4 border-border px-5 py-4")}>
         {content}
       </div>
     );
@@ -82,7 +82,7 @@ function ArtifactButton({ artifact, onOpenVideoStudio, compact = false }: Artifa
 
   return (
     <DescriptiveButton
-      className={cn("max-w-full flex-none items-center gap-1.5 rounded-xl px-2.5 py-2 whitespace-nowrap", compact ? "w-full justify-start px-2 py-1.5 hover:bg-muted/70" : "min-w-[220px]")}
+      className={cn("max-w-full items-center whitespace-nowrap", compact ? "w-full flex-none justify-start gap-1.5 rounded-xl px-2 py-1.5 hover:bg-muted/70" : "min-h-[72px] w-full min-w-0 gap-4 rounded-2xl px-5 py-4")}
       onClick={() => {
         if (canOpenVideoStudio) {
           onOpenVideoStudio?.();
@@ -155,7 +155,7 @@ export function ArtifactList({ messages, includeTargetFallbacks = false, onOpenV
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-2 md:px-10">
+    <div className="w-full">
       <div className="no-scrollbar flex min-w-0 flex-nowrap gap-2 overflow-x-auto pb-1">
         {artifacts.map((artifact) => (
           <ArtifactButton key={artifact.id} artifact={artifact} onOpenVideoStudio={onOpenVideoStudio} />

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -252,7 +252,7 @@ function EmptyMessage({
   return (
     <div
       className={cn(
-        "mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10 text-muted-foreground",
+        "mx-auto flex w-full max-w-[800px] flex-col items-start gap-2 px-2 md:px-10 text-muted-foreground",
         className
       )}
       {...props}
@@ -319,7 +319,7 @@ const AssistantMessage = React.memo(
 
     return (
       <Message
-        className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
+        className="mx-auto flex w-full max-w-[800px] flex-col items-start gap-2 px-2 md:px-10"
         data-message-id={message.id}
         data-message-role={message.role}
       >
@@ -442,7 +442,7 @@ const UserMessage = React.memo(
 
     return (
       <Message
-        className="mx-auto flex w-full max-w-3xl flex-col items-end gap-2 px-2 md:px-10"
+        className="mx-auto flex w-full max-w-[800px] flex-col items-end gap-2 px-2 md:px-10"
         data-message-id={message.id}
         data-message-role={message.role}
       >
@@ -581,7 +581,7 @@ const MessageComponent = React.memo(
 MessageComponent.displayName = "MessageComponent"
 
 const LoadingMessage = React.memo(({ label }: { label?: string }) => (
-  <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
+  <Message className="mx-auto flex w-full max-w-[800px] flex-col items-start gap-2 px-2 md:px-10">
     <div className="group flex w-full flex-col gap-0">
       <div className="flex items-center gap-2 px-1 py-1 text-sm text-muted-foreground">
         <img
@@ -604,7 +604,7 @@ interface ErrorMessageProps {
 
 function ErrorMessage({ error }: ErrorMessageProps) {
   return (
-    <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
+    <Message className="not-prose mx-auto flex w-full max-w-[800px] flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
         <div className="text-foreground flex min-w-0 flex-1 flex-row items-start gap-2 rounded-lg border-2 border-red-300 bg-red-300/20 px-2 py-1">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-destructive" />
@@ -648,7 +648,7 @@ const RetryMessage = React.memo(({ status }: RetryMessageProps) => {
   const action = status.action
 
   return (
-    <Message className="not-prose mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-0 md:px-10">
+    <Message className="not-prose mx-auto flex w-full max-w-[800px] flex-col items-start gap-2 px-0 md:px-10">
       <div className="group flex w-full flex-col items-start gap-0">
         <div className="text-foreground flex min-w-0 flex-1 flex-col gap-2 rounded-lg border-2 border-amber-300 bg-amber-300/20 px-3 py-2">
           <div className="flex items-start gap-2">
@@ -764,7 +764,7 @@ function MessageGroup({
       ) : null}
       {proseItems.map((item, groupIndex) => renderItem(item, stepItems.length + groupIndex))}
       {lastTextMessage && !isStreaming && (
-        <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 md:px-8">
+        <div className="mx-auto flex w-full max-w-[800px] flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 md:px-8">
           <MessageActions className="flex gap-0">
             <CopyMessageButton messages={renderableItems.map((item) => item.message)} />
             {lastRealItem ? (

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -671,7 +671,7 @@ export function SessionPage(props: SessionPageProps) {
       setSidePanelState(GLOBAL_VOICE_SIDE_PANEL_KEY, null);
       return;
     }
-    if (isDesignSession && (activeSidePanel === "video" || activeSidePanel === "panel")) {
+    if (isDesignSession && activeSidePanel === "video") {
       setSidePanelState(props.selectedSessionId, "design");
     }
   }, [activeSidePanel, isDesignSession, isVideoSession, props.selectedSessionId, setSidePanelState]);
@@ -1985,6 +1985,7 @@ export function SessionPage(props: SessionPageProps) {
                       client={props.ipolloworkServerClient}
                       workspaceId={props.runtimeWorkspaceId}
                       isRemoteWorkspace={props.selectedWorkspaceDisplay.workspaceType === "remote"}
+                      launcherItems={sidePanelLauncherItems}
                       onClose={closeRightPane}
                     />
                   ) : activeSidePanel === "video" && props.selectedSessionId ? (
@@ -1995,6 +1996,7 @@ export function SessionPage(props: SessionPageProps) {
                       client={props.ipolloworkServerClient}
                       workspaceId={props.runtimeWorkspaceId}
                       isRemoteWorkspace={props.selectedWorkspaceDisplay.workspaceType === "remote"}
+                      launcherItems={sidePanelLauncherItems}
                       onClose={closeRightPane}
                     />
                   ) : activeSidePanel === "outputs" ? (

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -6,6 +6,7 @@ import { AlignCenter, AlignLeft, AlignRight, ArrowLeft, Check, ChevronLeft, Chev
 import type { iPolloWorkServerClient } from "@/app/lib/ipollowork-server";
 import { pickLocalImageFile, readLocalImageAsDataUrl } from "@/app/lib/desktop";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -34,6 +35,7 @@ import {
   type DesignStyleField,
 } from "./design-html-runtime";
 import { DesignSystemDrawer, type DesignTokenValues } from "./design-system-drawer";
+import type { SidePanelLauncherItem } from "../panel/side-panel";
 import {
   downgradeUnsupportedPdfExportColors,
   downgradeUnsupportedPdfExportColorText,
@@ -70,6 +72,7 @@ type DesignPanelProps = {
   client: iPolloWorkServerClient | null;
   workspaceId: string | null;
   isRemoteWorkspace?: boolean;
+  launcherItems?: SidePanelLauncherItem[];
   onClose: () => void;
 };
 
@@ -243,6 +246,7 @@ export function DesignPanel({
   client,
   workspaceId,
   isRemoteWorkspace = false,
+  launcherItems = [],
   onClose,
 }: DesignPanelProps) {
   const queryClient = useQueryClient();
@@ -1083,6 +1087,39 @@ export function DesignPanel({
         <div className="flex min-w-0 flex-1 items-center">
           <p className="truncate text-sm font-medium">Design</p>
         </div>
+        {launcherItems.length > 0 ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={(
+                <Button variant="ghost" size="icon-sm" aria-label="Add panel">
+                  <Plus />
+                </Button>
+              )}
+            />
+            <DropdownMenuContent
+              align="end"
+              className="w-[296px] rounded-[18px] border border-[#E5E5E5] bg-white p-3 text-[#242424] shadow-[0_8px_24px_rgba(0,0,0,0.10)] before:hidden"
+            >
+              {launcherItems.map((item) => (
+                <DropdownMenuItem
+                  key={item.id}
+                  disabled={item.disabled}
+                  onClick={item.onClick}
+                  className={cn(
+                    "h-9 rounded-xl px-2 text-[14px] font-normal tracking-[-0.56px] text-[#242424] focus:bg-[#F5F5F5] focus:text-[#242424] data-disabled:opacity-40",
+                    item.active && "bg-[#F5F5F5]",
+                  )}
+                >
+                  <img src={item.iconSrc} alt="" className="size-4 shrink-0" />
+                  <span className="flex-1">{item.label}</span>
+                  {item.shortcut ? (
+                    <span className="text-[12px] tracking-[-0.24px] text-[#8A8A8A]">{item.shortcut}</span>
+                  ) : null}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
         <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close Design">
           <X />
         </Button>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -349,7 +349,7 @@ function SessionErrorCard({ error, onDismiss, onChangeModel, onOpenModelPicker }
   onOpenModelPicker?: () => void;
 }) {
   return (
-    <div className="mx-auto max-w-[720px] px-3 py-3 sm:px-5">
+    <div className="mx-auto max-w-[800px] px-3 py-3 sm:px-5">
       <div className="rounded-2xl border border-red-6/30 bg-red-3/15 px-5 py-4">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
@@ -1452,7 +1452,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
       {isEmptyConversation ? (
         <div className="flex min-h-0 flex-1 justify-center overflow-y-auto px-5">
-          <div className="flex min-h-full w-full max-w-[720px] flex-col justify-center pb-12 pt-8">
+          <div className="flex min-h-full w-full max-w-[800px] flex-col justify-center pb-12 pt-8">
             <NewConversationStarter
               selectedMode={newConversationMode}
               selectedCapabilityId={starterCapability?.id}
@@ -1504,7 +1504,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         >
           {/* Chat column: tighter than the composer (800px) so messages
                keep a comfortable reading width and don't feel "too big". */}
-          <div ref={contentRef} className="mx-auto w-full max-w-[720px]">
+          <div ref={contentRef} className="mx-auto w-full max-w-[800px]">
             {showDelayedLoading && pendingSessionLoad ? (
               <div className="px-6 py-16">
                 <div className="mx-auto max-w-sm rounded-3xl border border-dls-border bg-dls-hover/60 px-8 py-10 text-center">

--- a/apps/app/src/react-app/domains/session/video/video-panel.tsx
+++ b/apps/app/src/react-app/domains/session/video/video-panel.tsx
@@ -1,11 +1,14 @@
 /** @jsxImportSource react */
 import * as React from "react";
-import { AudioLines, Film, Layers3, Loader2, Play, RefreshCw, X } from "lucide-react";
+import { AudioLines, Film, Layers3, Loader2, Play, Plus, RefreshCw, X } from "lucide-react";
 
 import type { iPolloWorkServerClient } from "@/app/lib/ipollowork-server";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { t } from "@/i18n";
+import type { SidePanelLauncherItem } from "../panel/side-panel";
 import {
   HYPERFRAMES_VERSION,
   hyperframesStudioPort,
@@ -29,10 +32,11 @@ type VideoPanelProps = {
   client: iPolloWorkServerClient | null;
   workspaceId: string | null;
   isRemoteWorkspace?: boolean;
+  launcherItems?: SidePanelLauncherItem[];
   onClose: () => void;
 };
 
-export function VideoPanel({ sessionId, workspaceRoot, client, workspaceId, isRemoteWorkspace = false, onClose }: VideoPanelProps) {
+export function VideoPanel({ sessionId, workspaceRoot, client, workspaceId, isRemoteWorkspace = false, launcherItems = [], onClose }: VideoPanelProps) {
   const terminalIdRef = React.useRef<string | null>(null);
   const [revision, setRevision] = React.useState(0);
   const [status, setStatus] = React.useState<"starting" | "ready" | "failed">("starting");
@@ -127,6 +131,39 @@ export function VideoPanel({ sessionId, workspaceRoot, client, workspaceId, isRe
         </Tooltip>
         <Button variant="ghost" size="icon-xs" onClick={() => { setStudioFrameLoaded(false); setStudioChromeReady(false); setDetail(t("video.reload")); setRevision((value) => value + 1); }} aria-label={t("video.reload")}><RefreshCw /></Button>
         <Button variant={simpleMode ? "ghost" : "secondary"} size="xs" onClick={() => void applySimpleMode(!simpleMode)} aria-label={t("video.toggle_advanced")}><Layers3 />{simpleMode ? t("video.advanced") : t("video.simple")}</Button>
+        {launcherItems.length > 0 ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={(
+                <Button variant="ghost" size="icon-xs" aria-label="Add panel">
+                  <Plus />
+                </Button>
+              )}
+            />
+            <DropdownMenuContent
+              align="end"
+              className="w-[296px] rounded-[18px] border border-[#E5E5E5] bg-white p-3 text-[#242424] shadow-[0_8px_24px_rgba(0,0,0,0.10)] before:hidden"
+            >
+              {launcherItems.map((item) => (
+                <DropdownMenuItem
+                  key={item.id}
+                  disabled={item.disabled}
+                  onClick={item.onClick}
+                  className={cn(
+                    "h-9 rounded-xl px-2 text-[14px] font-normal tracking-[-0.56px] text-[#242424] focus:bg-[#F5F5F5] focus:text-[#242424] data-disabled:opacity-40",
+                    item.active && "bg-[#F5F5F5]",
+                  )}
+                >
+                  <img src={item.iconSrc} alt="" className="size-4 shrink-0" />
+                  <span className="flex-1">{item.label}</span>
+                  {item.shortcut ? (
+                    <span className="text-[12px] tracking-[-0.24px] text-[#8A8A8A]">{item.shortcut}</span>
+                  ) : null}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
         <Button variant="ghost" size="icon-xs" onClick={onClose} aria-label={t("video.close")} title={t("video.close")}><X /></Button>
       </header>
 


### PR DESCRIPTION
## Summary

- Added the same “+” panel switcher menu to Design and Video Studio headers.
- Fixed Design sessions so opening generated files like .md no longer gets forced back to the Design panel.
- Unified chat message width with the composer width at 800px.
- Updated artifact/file cards to use full message width, larger card styling, and proper left alignment.
- Removed duplicated artifact list padding so file cards align with surrounding message text.