### PR TITLE
Complete Design editor pagination and exports

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -76,6 +76,7 @@
     "marked-emoji": "^2.0.3",
     "marked-shiki": "^1.2.1",
     "motion": "^12.38.0",
+    "pptxgenjs": "3.12.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-markdown": "^10.1.0",

--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Descarregar",
+  "design.export.download_html": "Descarregar HTML",
   "design.export.download_pdf": "Descarregar PDF",
   "design.export.download_pptx": "Descarregar PPTX",
   "new_conversation.mode_label": "Trieu l'enfocament de la conversa",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Download",
+  "design.export.download_html": "Download HTML",
   "design.export.download_pdf": "Download PDF",
   "design.export.download_pptx": "Download PPTX",
   "app.compact_command_desc": "Summarize this session to reduce context size.",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Descargar",
+  "design.export.download_html": "Descargar HTML",
   "design.export.download_pdf": "Descargar PDF",
   "design.export.download_pptx": "Descargar PPTX",
   "new_conversation.mode_label": "Elige el enfoque de la conversación",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Télécharger",
+  "design.export.download_html": "Télécharger le HTML",
   "design.export.download_pdf": "Télécharger le PDF",
   "design.export.download_pptx": "Télécharger le PPTX",
   "new_conversation.mode_label": "Choisir le sujet de la conversation",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -4,6 +4,7 @@
 
 export default {
   "design.export.download": "ダウンロード",
+  "design.export.download_html": "HTML をダウンロード",
   "design.export.download_pdf": "PDF をダウンロード",
   "design.export.download_pptx": "PPTX をダウンロード",
   "new_conversation.mode_label": "会話の目的を選択",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Baixar",
+  "design.export.download_html": "Baixar HTML",
   "design.export.download_pdf": "Baixar PDF",
   "design.export.download_pptx": "Baixar PPTX",
   "new_conversation.mode_label": "Escolha o foco da conversa",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Скачать",
+  "design.export.download_html": "Скачать HTML",
   "design.export.download_pdf": "Скачать PDF",
   "design.export.download_pptx": "Скачать PPTX",
   "new_conversation.mode_label": "Выберите фокус беседы",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "ดาวน์โหลด",
+  "design.export.download_html": "ดาวน์โหลด HTML",
   "design.export.download_pdf": "ดาวน์โหลด PDF",
   "design.export.download_pptx": "ดาวน์โหลด PPTX",
   "new_conversation.mode_label": "เลือกจุดประสงค์ของการสนทนา",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -5,6 +5,7 @@
 
 export default {
   "design.export.download": "Tải xuống",
+  "design.export.download_html": "Tải xuống HTML",
   "design.export.download_pdf": "Tải xuống PDF",
   "design.export.download_pptx": "Tải xuống PPTX",
   "new_conversation.mode_label": "Chọn trọng tâm cuộc trò chuyện",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -7,9 +7,10 @@
  */
 
 export default {
-  "design.export.download": "??",
-  "design.export.download_pdf": "?? PDF",
-  "design.export.download_pptx": "?? PPTX",
+  "design.export.download": "下载",
+  "design.export.download_html": "下载 HTML",
+  "design.export.download_pdf": "下载 PDF",
+  "design.export.download_pptx": "下载 PPTX",
   "app.compact_command_desc": "压缩此会话以减少上下文大小。",
   "app.error_audit_load": "加载审计日志失败。",
   "app.error_auth_failed": "认证失败",

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1118,10 +1118,9 @@ export function SessionPage(props: SessionPageProps) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>iPolloWork Slide Editing Demo</title>
     <style>
-      body { margin: 0; min-height: 100vh; display: grid; place-items: center; font-family: system-ui, sans-serif; background: #111827; color: #f8fafc; }
-      main { width: min(760px, calc(100% - 48px)); }
-      .slide { display: none; min-height: 390px; padding: 52px; border-radius: 28px; background: linear-gradient(135deg, #312e81, #0f172a); box-sizing: border-box; }
-      .slide.is-active { display: block; }
+      body { margin: 0; min-height: 100vh; font-family: system-ui, sans-serif; background: #111827; color: #f8fafc; }
+      main { display: grid; width: min(960px, calc(100% - 48px)); margin: 40px auto; gap: 32px; }
+      .slide { display: block; min-height: 540px; padding: 52px; aspect-ratio: 16 / 9; border-radius: 28px; background: linear-gradient(135deg, #312e81, #0f172a); box-sizing: border-box; }
       .eyebrow { color: #c4b5fd; font-size: 14px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
       h1 { max-width: 620px; margin: 72px 0 16px; font-size: 54px; line-height: 1.02; letter-spacing: -.04em; }
       p { max-width: 560px; color: #cbd5e1; font-size: 19px; line-height: 1.6; }

--- a/apps/app/src/react-app/domains/session/design/design-export-menu.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-export-menu.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { Download, Loader2, Presentation } from "lucide-react";
+import { Download, FileCode2, FileText, Loader2, Presentation } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -11,15 +11,21 @@ import {
 import { t } from "@/i18n";
 
 type DesignExportMenuProps = {
+  exportingHtml: boolean;
   exportingPdf: boolean;
   exportingPptx: boolean;
+  isPresentation: boolean;
+  onExportHtml: () => void;
   onExportPdf: () => void;
   onExportPptx: () => void;
 };
 
 export function DesignExportMenu({
+  exportingHtml,
   exportingPdf,
   exportingPptx,
+  isPresentation,
+  onExportHtml,
   onExportPdf,
   onExportPptx,
 }: DesignExportMenuProps) {
@@ -32,7 +38,7 @@ export function DesignExportMenu({
           <Button
             variant="outline"
             size="icon-sm"
-            disabled={exportingPdf && exportingPptx}
+            disabled={exportingHtml || exportingPdf || exportingPptx}
             aria-label={downloadLabel}
             title={downloadLabel}
           >
@@ -41,14 +47,22 @@ export function DesignExportMenu({
         )}
       />
       <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuItem disabled={exportingPdf} onClick={onExportPdf}>
-          {exportingPdf ? <Loader2 className="animate-spin" /> : <Download />}
-          {t("design.export.download_pdf")}
+        <DropdownMenuItem disabled={exportingHtml} onClick={onExportHtml}>
+          {exportingHtml ? <Loader2 className="animate-spin" /> : <FileCode2 />}
+          {t("design.export.download_html")}
         </DropdownMenuItem>
-        <DropdownMenuItem disabled={exportingPptx} onClick={onExportPptx}>
-          {exportingPptx ? <Loader2 className="animate-spin" /> : <Presentation />}
-          {t("design.export.download_pptx")}
-        </DropdownMenuItem>
+        {isPresentation ? (
+          <>
+            <DropdownMenuItem disabled={exportingPdf} onClick={onExportPdf}>
+              {exportingPdf ? <Loader2 className="animate-spin" /> : <FileText />}
+              {t("design.export.download_pdf")}
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled={exportingPptx} onClick={onExportPptx}>
+              {exportingPptx ? <Loader2 className="animate-spin" /> : <Presentation />}
+              {t("design.export.download_pptx")}
+            </DropdownMenuItem>
+          </>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
+++ b/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
@@ -1,5 +1,42 @@
 export const DESIGN_MESSAGE_CHANNEL = "ipollowork-design-html-v1";
 
+const DESIGN_DECK_STATE_ATTRIBUTE = "data-ipollowork-design-deck-original-state";
+const DESIGN_SLIDE_SELECTOR = "[data-ipw-slide],section.slide,.slide,.slide-frame";
+
+type DesignAttributeState = {
+  name: string;
+  present: boolean;
+  value: string;
+};
+
+type DesignDeckOriginalState = {
+  slides: DesignAttributeState[][];
+  wrappers: Array<DesignAttributeState[] | null>;
+};
+
+function readOriginalDeckState(source: string): DesignDeckOriginalState | null {
+  if (typeof DOMParser === "undefined") return null;
+  const parsed = new DOMParser().parseFromString(source, "text/html");
+  const slides = Array.from(parsed.querySelectorAll<HTMLElement>(DESIGN_SLIDE_SELECTOR))
+    .filter((element, index, list) => list.indexOf(element) === index);
+  const readAttributes = (element: HTMLElement, names: readonly string[]) => names.map((name) => ({
+    name,
+    present: element.hasAttribute(name),
+    value: element.getAttribute(name) ?? "",
+  }));
+  return {
+    slides: slides.map((slide) => readAttributes(slide, ["class", "data-ipw-slide", "aria-hidden"])),
+    wrappers: slides.map((slide) => {
+      const wrapper = slide.closest<HTMLElement>(".slide-wrap");
+      return wrapper ? readAttributes(wrapper, ["class"]) : null;
+    }),
+  };
+}
+
+function runtimeJson(value: unknown) {
+  return JSON.stringify(value).replace(/</g, "\\u003c");
+}
+
 export const DESIGN_STYLE_FIELDS = [
   "color",
   "backgroundColor",
@@ -91,18 +128,19 @@ export function buildDesignPreviewDocument(
   fixedSlideStage = false,
   isPresentationTemplate = fixedSlideStage,
 ) {
+  const originalDeckState = isPresentationTemplate && includeEditor ? readOriginalDeckState(source) : null;
   const tokenStyle = templateTokenCss.trim()
     ? `<style id="ipollowork-design-template-token-style">${templateTokenCss.replace(/<\/style/gi, "<\\/style")}</style>`
     : "";
   const navigationRuntime = `<script id="ipollowork-design-navigation-runtime">(${designNavigationRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${editing ? "true" : "false"});<\/script>`;
-  const deckRuntime = isPresentationTemplate
-    ? `<script id="ipollowork-design-deck-runtime">(${designDeckRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${fixedSlideStage ? "true" : "false"});<\/script>`
+  const deckRuntime = isPresentationTemplate && includeEditor
+    ? `<script id="ipollowork-design-deck-runtime">(${designDeckRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${fixedSlideStage ? "true" : "false"},${JSON.stringify(DESIGN_DECK_STATE_ATTRIBUTE)},${runtimeJson(originalDeckState)});<\/script>`
     : "";
   const fixedSlideRuntime = fixedSlideStage
     ? `<script id="ipollowork-design-fixed-slide-runtime">(${designFixedSlideRuntime.toString()})();<\/script>`
     : "";
   const editingRuntime = includeEditor
-    ? `<script id="ipollowork-design-runtime">(${designRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${JSON.stringify(DESIGN_STYLE_FIELDS)},${editing ? "true" : "false"},${fixedSlideStage ? "true" : "false"});<\/script>`
+    ? `<script id="ipollowork-design-runtime">(${designRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${JSON.stringify(DESIGN_STYLE_FIELDS)},${editing ? "true" : "false"},${JSON.stringify(DESIGN_DECK_STATE_ATTRIBUTE)});<\/script>`
     : "";
   const runtime = `${tokenStyle}${navigationRuntime}${deckRuntime}${fixedSlideRuntime}${editingRuntime}`;
   const bodyEnd = source.toLowerCase().lastIndexOf("</body>");
@@ -220,23 +258,42 @@ function designNavigationRuntime(channel: string, editing: boolean) {
   });
 }
 
-function designDeckRuntime(channel: string, runtimeOwnsNavigation = false) {
-  const slideSelector = "[data-ipw-slide],section.slide,.slide,.slide-frame";
-  const slides = Array.from(document.querySelectorAll<HTMLElement>(slideSelector))
+function designDeckRuntime(channel: string, runtimeOwnsNavigation = false, originalStateAttribute: string, originalState: unknown) {
+  const slides = Array.from(document.querySelectorAll<HTMLElement>("[data-ipw-slide],section.slide,.slide,.slide-frame"))
     .filter((element, index, list) => list.indexOf(element) === index);
   if (!slides.length) return;
-
-  slides.forEach((slide, index) => {
-    if (!slide.hasAttribute("data-ipw-slide")) slide.setAttribute("data-ipw-slide", String(index + 1));
-  });
   const slideWrappers = slides.map((slide) => slide.closest<HTMLElement>(".slide-wrap"));
   const usesSlideWrappers = slideWrappers.every(Boolean);
+
+  const originalAttributes = (collection: "slides" | "wrappers", index: number) => {
+    if (!originalState || typeof originalState !== "object") return null;
+    const states = Reflect.get(originalState, collection);
+    return Array.isArray(states) && Array.isArray(states[index]) ? states[index] : null;
+  };
+  const rememberAttributes = (element: HTMLElement, names: readonly string[], sourceState: unknown[] | null) => {
+    if (element.hasAttribute(originalStateAttribute)) return;
+    const state = sourceState ?? names.map((name) => ({
+      name,
+      present: element.hasAttribute(name),
+      value: element.getAttribute(name) ?? "",
+    }));
+    element.setAttribute(originalStateAttribute, JSON.stringify(state));
+  };
+
+  slides.forEach((slide, index) => {
+    rememberAttributes(slide, ["class", "data-ipw-slide", "aria-hidden"], originalAttributes("slides", index));
+    if (!slide.hasAttribute("data-ipw-slide")) slide.setAttribute("data-ipw-slide", String(index + 1));
+  });
+  slideWrappers.forEach((wrapper, index) => {
+    if (wrapper) rememberAttributes(wrapper, ["class"], originalAttributes("wrappers", index));
+  });
 
   // Some templates include a static, vertically stacked preview fallback.
   // The deck runtime owns aria-hidden so only the active page is laid out.
   const visibilityStyle = document.createElement("style");
   visibilityStyle.id = "ipollowork-design-deck-runtime-style";
   visibilityStyle.textContent = `
+    html, body { width: 100% !important; height: 100% !important; overflow: hidden !important; }
     [data-ipw-slide][aria-hidden="true"] { display: none !important; opacity: 0 !important; pointer-events: none !important; }
     [data-ipw-slide][aria-hidden="false"] { opacity: 1 !important; pointer-events: auto !important; }
   `;
@@ -374,7 +431,7 @@ function designDeckRuntime(channel: string, runtimeOwnsNavigation = false) {
   report();
 }
 
-function designRuntime(channel: string, styleFields: readonly string[], initialEditing: boolean, strictPptx = false) {
+function designRuntime(channel: string, styleFields: readonly string[], initialEditing: boolean, deckStateAttribute: string) {
   const runtimeId = "ipollowork-design-runtime";
   const styleId = "ipollowork-design-runtime-style";
   const selectedAttribute = "data-ipollowork-design-selected";
@@ -457,12 +514,35 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     clone.querySelector(`#${runtimeId}`)?.remove();
     clone.querySelector("#ipollowork-design-navigation-runtime")?.remove();
     clone.querySelector("#ipollowork-design-deck-runtime")?.remove();
+    clone.querySelector("#ipollowork-design-deck-runtime-style")?.remove();
     clone.querySelector("#ipollowork-design-fixed-slide-runtime")?.remove();
     clone.querySelector("#ipollowork-design-fixed-slide-runtime-style")?.remove();
     clone.querySelector(`#${styleId}`)?.remove();
     clone.querySelector("#ipollowork-design-template-token-style")?.remove();
     clone.querySelector(`#${overlayId}`)?.remove();
     clone.querySelectorAll("[data-ipw-materialize-once]").forEach((element) => element.remove());
+    // Pagination is editor-only. Restore every slide and wrapper attribute to
+    // the value it had before the Design deck adapter touched the document.
+    clone.querySelectorAll(`[${deckStateAttribute}]`).forEach((element) => {
+      const serialized = element.getAttribute(deckStateAttribute);
+      try {
+        const entries: unknown = serialized ? JSON.parse(serialized) : null;
+        if (Array.isArray(entries)) {
+          entries.forEach((entry) => {
+            if (!entry || typeof entry !== "object") return;
+            const name = Reflect.get(entry, "name");
+            const present = Reflect.get(entry, "present");
+            const value = Reflect.get(entry, "value");
+            if (typeof name !== "string" || typeof present !== "boolean" || typeof value !== "string") return;
+            if (present) element.setAttribute(name, value);
+            else element.removeAttribute(name);
+          });
+        }
+      } catch {
+        // A malformed editor-only marker must never prevent saving user HTML.
+      }
+      element.removeAttribute(deckStateAttribute);
+    });
     clone.querySelectorAll(`[${textNodeAttribute}]`).forEach((element) => element.replaceWith(...Array.from(element.childNodes)));
     clone.querySelectorAll(`[${idAttribute}]`).forEach((element) => element.removeAttribute(idAttribute));
     clone.querySelectorAll(`[${selectedAttribute}]`).forEach((element) => element.removeAttribute(selectedAttribute));
@@ -470,10 +550,6 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
       element.removeAttribute(editingAttribute);
       element.removeAttribute("contenteditable");
     });
-    if (strictPptx) {
-      clone.querySelectorAll("script,[data-ipw-notes],.ipw-notes,.slide-counter,.controls,.deck-chrome,.deck-controls,.dots,.counter,[data-ipw-deck-control],[data-ipw-prev],[data-ipw-next],[data-action='prev'],[data-action='previous'],[data-action='next']")
-        .forEach((element) => element.remove());
-    }
     clone.removeAttribute(modeAttribute);
     const doctype = document.doctype
       ? `<!DOCTYPE ${document.doctype.name}${document.doctype.publicId ? ` PUBLIC \"${document.doctype.publicId}\"` : ""}${document.doctype.systemId ? ` \"${document.doctype.systemId}\"` : ""}>\n`
@@ -670,8 +746,16 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
       }
       width = Math.max(12, width);
       height = Math.max(12, height);
-      selected.style.width = `${width}px`;
-      selected.style.height = `${height}px`;
+      if (west || east) {
+        selected.style.minWidth = "0";
+        selected.style.maxWidth = "none";
+        selected.style.width = `${width}px`;
+      }
+      if (north || south) {
+        selected.style.minHeight = "0";
+        selected.style.maxHeight = "none";
+        selected.style.height = `${height}px`;
+      }
       if (west) selected.style.left = `${transform.left + (transform.width - width)}px`;
       if (north) selected.style.top = `${transform.top + (transform.height - height)}px`;
     }

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -130,6 +130,11 @@ function fileName(path: string) {
   return path.split(/[\\/]/).pop() || path;
 }
 
+function htmlDownloadFileName(path: string) {
+  const name = fileName(path).trim() || "design.html";
+  return /\.html?$/i.test(name) ? name : `${name}.html`;
+}
+
 function directoryPath(path: string) {
   const boundary = path.lastIndexOf("/");
   return boundary < 0 ? "" : path.slice(0, boundary + 1);
@@ -311,6 +316,7 @@ export function DesignPanel({
   const [quickEdit, setQuickEdit] = React.useState<"text" | "href" | "src" | "color" | "fontSize" | null>(null);
   const [advancedOpen, setAdvancedOpen] = React.useState(false);
   const [designSystemOpen, setDesignSystemOpen] = React.useState(false);
+  const [exportingHtml, setExportingHtml] = React.useState(false);
   const [exportingPdf, setExportingPdf] = React.useState(false);
   const [exportingPptx, setExportingPptx] = React.useState(false);
   const [pptxConfirmationOpen, setPptxConfirmationOpen] = React.useState(false);
@@ -359,7 +365,7 @@ export function DesignPanel({
 
   React.useEffect(() => {
     const viewport = previewViewportRef.current;
-    if (!viewport || !isPresentationTemplate) return;
+    if (!viewport || !isPresentationTemplate || !sourceHydrated) return;
     const sync = () => {
       const rect = viewport.getBoundingClientRect();
       setPreviewViewport({ width: rect.width, height: rect.height });
@@ -368,7 +374,7 @@ export function DesignPanel({
     const observer = new ResizeObserver(sync);
     observer.observe(viewport);
     return () => observer.disconnect();
-  }, [isPresentationTemplate]);
+  }, [isPresentationTemplate, sourceHydrated]);
   const templateTokenPath = React.useMemo(() => {
     const tokenPath = designTemplate?.designSystem.tokens || linkedDesignTokenPath(fileQuery.data?.content) || "design-tokens.css";
     const briefPath = templateQuery.data?.state.briefPath;
@@ -544,8 +550,30 @@ export function DesignPanel({
     });
   }, [editing, quickEdit, selection]);
 
+  const exportDesignToHtml = React.useCallback(async () => {
+    if (!activePagePath || exportingHtml) return;
+    setExportingHtml(true);
+    try {
+      const content = editing ? await readLatestCanvasHtml() : draftRef.current;
+      const blobUrl = URL.createObjectURL(new Blob([content], { type: "text/html;charset=utf-8" }));
+      const link = document.createElement("a");
+      link.href = blobUrl;
+      link.download = htmlDownloadFileName(activePagePath);
+      link.hidden = true;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(blobUrl), 1_000);
+      toast.success("Design downloaded as HTML.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not download this design.");
+    } finally {
+      setExportingHtml(false);
+    }
+  }, [activePagePath, editing, exportingHtml, readLatestCanvasHtml]);
+
   const exportDeckToPdf = React.useCallback(async () => {
-    if (!deck || exportingPdf) return;
+    if (!isPresentationTemplate || exportingPdf) return;
     setExportingPdf(true);
     const frame = document.createElement("iframe");
     frame.setAttribute("aria-hidden", "true");
@@ -622,10 +650,10 @@ export function DesignPanel({
       frame.remove();
       setExportingPdf(false);
     }
-  }, [activePagePath, deck, editing, exportingPdf, isPresentationTemplate, readLatestCanvasHtml, templateTokenQuery.data]);
+  }, [activePagePath, editing, exportingPdf, isPresentationTemplate, readLatestCanvasHtml, templateTokenQuery.data]);
 
   const exportDeckToPptx = React.useCallback(async () => {
-    if (!deck || exportingPptx) return;
+    if (!isPresentationTemplate || exportingPptx) return;
     setExportingPptx(true);
     const frame = document.createElement("iframe");
     frame.setAttribute("aria-hidden", "true");
@@ -677,7 +705,7 @@ export function DesignPanel({
       const pptx = new PptxGenJS();
       pptx.layout = "LAYOUT_WIDE";
       pptx.author = "iPolloWork";
-      pptx.title = deck.title || "Presentation";
+      pptx.title = deck?.title || "Presentation";
       let nativeObjectCount = 0;
       let fallbackCount = 0;
       const capturePptxElement = async (element: HTMLElement, captureBackground = false) => {
@@ -821,7 +849,7 @@ export function DesignPanel({
       frame.remove();
       setExportingPptx(false);
     }
-  }, [activePagePath, deck, editing, exportingPptx, isPresentationTemplate, readLatestCanvasHtml, templateTokenQuery.data, usesNativeEditablePptx]);
+  }, [activePagePath, deck?.title, editing, exportingPptx, isPresentationTemplate, readLatestCanvasHtml, templateTokenQuery.data, usesNativeEditablePptx]);
 
   const saveMutation = useMutation({
     mutationFn: async () => {
@@ -1204,7 +1232,7 @@ export function DesignPanel({
               <Button
                 variant={designSystemOpen ? "secondary" : "ghost"}
                 size="icon-sm"
-                className={cn("rounded-lg", !deck && "ml-auto")}
+                className="rounded-lg"
                 onClick={() => {
                   setDesignSystemOpen((current) => !current);
                   setAdvancedOpen(false);
@@ -1256,16 +1284,17 @@ export function DesignPanel({
                 </ToggleGroupItem>
               </ToggleGroup>
             ) : null}
-            {deck ? (
-              <div className="ml-auto">
-                <DesignExportMenu
-                  exportingPdf={exportingPdf}
-                  exportingPptx={exportingPptx}
-                  onExportPdf={() => void exportDeckToPdf()}
-                  onExportPptx={() => setPptxConfirmationOpen(true)}
-                />
-              </div>
-            ) : null}
+            <div className="ml-auto">
+              <DesignExportMenu
+                exportingHtml={exportingHtml}
+                exportingPdf={exportingPdf}
+                exportingPptx={exportingPptx}
+                isPresentation={isPresentationTemplate}
+                onExportHtml={() => void exportDesignToHtml()}
+                onExportPdf={() => void exportDeckToPdf()}
+                onExportPptx={() => setPptxConfirmationOpen(true)}
+              />
+            </div>
           </div>
 
           {fileQuery.isLoading || !sourceHydrated ? (

--- a/apps/app/tests/design-deck-navigation.test.ts
+++ b/apps/app/tests/design-deck-navigation.test.ts
@@ -23,6 +23,15 @@ describe("Design deck navigation", () => {
 
     expect(source).toContain("h-[900px] w-[1600px] origin-center");
     expect(source).toContain("presentationCanvasScale(previewViewport.width, previewViewport.height)");
+    expect(source).toContain("[isPresentationTemplate, sourceHydrated]");
     expect(source).toContain("!isPresentationTemplate ? (");
+  });
+
+  test("renders the export menu independently from detected deck state", async () => {
+    const source = await Bun.file(panelUrl).text();
+
+    expect(source).toContain("isPresentation={isPresentationTemplate}");
+    expect(source).toMatch(/<div className="ml-auto">\s*<DesignExportMenu/);
+    expect(source).not.toMatch(/\{deck \? \(\s*<div className="ml-auto">\s*<DesignExportMenu/);
   });
 });

--- a/apps/app/tests/design-export-menu.test.tsx
+++ b/apps/app/tests/design-export-menu.test.tsx
@@ -44,8 +44,11 @@ function findByAriaLabel(node: React.ReactNode, label: string): React.ReactEleme
 
 function menu(overrides: Partial<React.ComponentProps<typeof DesignExportMenu>> = {}) {
   return DesignExportMenu({
+    exportingHtml: false,
     exportingPdf: false,
     exportingPptx: false,
+    isPresentation: true,
+    onExportHtml: () => undefined,
     onExportPdf: () => undefined,
     onExportPptx: () => undefined,
     ...overrides,
@@ -60,6 +63,7 @@ describe("design export download menu", () => {
     const englishMenu = menu();
     const englishTrigger = findByAriaLabel(englishMenu, "Download");
     expect(textContent(englishTrigger).trim()).toBe("");
+    expect(textContent(englishMenu)).toContain("Download HTML");
     expect(textContent(englishMenu)).toContain("Download PDF");
     expect(textContent(englishMenu)).toContain("Download PPTX");
 
@@ -67,6 +71,7 @@ describe("design export download menu", () => {
     const chineseMenu = menu();
     const chineseTrigger = findByAriaLabel(chineseMenu, "下载");
     expect(textContent(chineseTrigger).trim()).toBe("");
+    expect(textContent(chineseMenu)).toContain("下载 HTML");
     expect(textContent(chineseMenu)).toContain("下载 PDF");
     expect(textContent(chineseMenu)).toContain("下载 PPTX");
   });
@@ -78,16 +83,23 @@ describe("design export download menu", () => {
     );
 
     expect(panelSource).toContain("<DesignExportMenu");
+    expect(panelSource).toContain("onExportHtml={() => void exportDesignToHtml()}");
     expect(panelSource).toContain("onExportPdf={() => void exportDeckToPdf()}");
     expect(panelSource).toContain("onExportPptx={() => setPptxConfirmationOpen(true)}");
     expect(panelSource).not.toContain("Export presentation to PDF");
     expect(panelSource).not.toContain("Export presentation to PPTX");
   });
 
-  test("routes each format to its existing export action", () => {
+  test("routes each format to its export action", () => {
+    const onExportHtml = mock(() => undefined);
     const onExportPdf = mock(() => undefined);
     const onExportPptx = mock(() => undefined);
-    const result = menu({ onExportPdf, onExportPptx });
+    const result = menu({ onExportHtml, onExportPdf, onExportPptx });
+
+    Reflect.get(findByText(result, "Download HTML").props, "onClick")();
+    expect(onExportHtml).toHaveBeenCalledTimes(1);
+    expect(onExportPdf).not.toHaveBeenCalled();
+    expect(onExportPptx).not.toHaveBeenCalled();
 
     Reflect.get(findByText(result, "Download PDF").props, "onClick")();
     expect(onExportPdf).toHaveBeenCalledTimes(1);
@@ -98,6 +110,10 @@ describe("design export download menu", () => {
   });
 
   test("disables only the format currently being generated", () => {
+    const htmlBusy = menu({ exportingHtml: true });
+    expect(Reflect.get(findByText(htmlBusy, "Download HTML").props, "disabled")).toBe(true);
+    expect(Reflect.get(findByText(htmlBusy, "Download PDF").props, "disabled")).toBe(false);
+
     const pdfBusy = menu({ exportingPdf: true });
     expect(Reflect.get(findByText(pdfBusy, "Download PDF").props, "disabled")).toBe(true);
     expect(Reflect.get(findByText(pdfBusy, "Download PPTX").props, "disabled")).toBe(false);
@@ -107,9 +123,32 @@ describe("design export download menu", () => {
     expect(Reflect.get(findByText(pptxBusy, "Download PPTX").props, "disabled")).toBe(true);
   });
 
-  test("disables the download trigger only when both formats are busy", () => {
-    expect(Reflect.get(findByAriaLabel(menu({ exportingPdf: true }), "Download").props, "disabled")).toBe(false);
-    expect(Reflect.get(findByAriaLabel(menu({ exportingPptx: true }), "Download").props, "disabled")).toBe(false);
-    expect(Reflect.get(findByAriaLabel(menu({ exportingPdf: true, exportingPptx: true }), "Download").props, "disabled")).toBe(true);
+  test("disables the download trigger while any format is being generated", () => {
+    expect(Reflect.get(findByAriaLabel(menu({ exportingHtml: true }), "Download").props, "disabled")).toBe(true);
+    expect(Reflect.get(findByAriaLabel(menu({ exportingPdf: true }), "Download").props, "disabled")).toBe(true);
+    expect(Reflect.get(findByAriaLabel(menu({ exportingPptx: true }), "Download").props, "disabled")).toBe(true);
+  });
+
+  test("offers HTML to every Design document and presentation formats only to decks", () => {
+    const pageMenu = menu({ isPresentation: false });
+    expect(textContent(pageMenu)).toContain("Download HTML");
+    expect(textContent(pageMenu)).not.toContain("Download PDF");
+    expect(textContent(pageMenu)).not.toContain("Download PPTX");
+
+    const deckMenu = menu({ isPresentation: true });
+    expect(textContent(deckMenu)).toContain("Download HTML");
+    expect(textContent(deckMenu)).toContain("Download PDF");
+    expect(textContent(deckMenu)).toContain("Download PPTX");
+  });
+
+  test("downloads the latest clean canvas snapshot instead of the preview source", () => {
+    const panelSource = readFileSync(
+      new URL("../src/react-app/domains/session/design/design-panel.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(panelSource).toContain("const content = editing ? await readLatestCanvasHtml() : draftRef.current");
+    expect(panelSource).toContain('new Blob([content], { type: "text/html;charset=utf-8" })');
+    expect(panelSource).toContain("link.download = htmlDownloadFileName(activePagePath)");
   });
 });

--- a/apps/app/tests/design-html-runtime.test.ts
+++ b/apps/app/tests/design-html-runtime.test.ts
@@ -43,6 +43,8 @@ describe("Design HTML runtime", () => {
     expect(preview).toContain('data-handle="se"');
     expect(preview).toContain('prepareTransform(selected, handle === "move" ? "move" : "resize"');
     expect(preview).toContain('selected.style.width = `${width}px`');
+    expect(preview).toContain('selected.style.maxWidth = "none"');
+    expect(preview).toContain('selected.style.maxHeight = "none"');
   });
 
   test("keeps a dormant editor bridge and deck adapter in the same preview document", () => {
@@ -62,6 +64,30 @@ describe("Design HTML runtime", () => {
     expect(preview).toContain('const slideWrappers = slides.map((slide) => slide.closest(".slide-wrap"))');
     expect(preview).toContain('const wrapperIndex = slideWrappers.findIndex((wrapper) => wrapper && !wrapper.classList.contains("hidden")');
     expect(preview).toContain("event.stopImmediatePropagation();");
+    expect(preview).toContain("data-ipollowork-design-deck-original-state");
+    expect(preview).toContain('rememberAttributes(slide, ["class", "data-ipw-slide", "aria-hidden"], originalAttributes("slides", index))');
+    expect(preview).toContain('originalAttributes("wrappers", index)');
+  });
+
+  test("keeps presentation pagination out of non-editor documents", () => {
+    const source = "<!doctype html><html><body><section class=\"slide\" aria-hidden=\"keep\"><h1>One</h1></section><section class=\"slide\"><h1>Two</h1></section></body></html>";
+    const rendered = buildDesignPreviewDocument(source, false, "", false, false, true);
+
+    expect(rendered).toContain('<section class="slide" aria-hidden="keep">');
+    expect(rendered).not.toContain('id="ipollowork-design-deck-runtime"');
+    expect(rendered).not.toContain("ipollowork-design-deck-runtime-style");
+    expect(rendered).not.toContain("data-ipollowork-design-deck-original-state");
+  });
+
+  test("restores pagination attributes and removes editor artifacts during serialization", () => {
+    const source = "<!doctype html><html><body><section class=\"slide\"><h1>One</h1></section></body></html>";
+    const preview = buildDesignPreviewDocument(source, true, "", false, false, true);
+
+    expect(preview).toContain('clone.querySelector("#ipollowork-design-deck-runtime-style")?.remove()');
+    expect(preview).toContain("element.setAttribute(name, value)");
+    expect(preview).toContain("element.removeAttribute(name)");
+    expect(preview).toContain("element.removeAttribute(deckStateAttribute)");
+    expect(preview).not.toContain("clone.querySelectorAll(\"script,[data-ipw-notes]");
   });
 
   test("treats a one-page canvas as a presentation so it can be exported", () => {

--- a/evals/flows/design-editor-export.flow.mjs
+++ b/evals/flows/design-editor-export.flow.mjs
@@ -1,0 +1,386 @@
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { access, mkdtemp, readFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { connect, debuggerUrlFor, evaluate, listTargets } from "../runner/cdp.mjs";
+
+const vo = await loadVoiceoverParagraphs("design-editor-export");
+const EDITED_HEADING = "Edit the visible slide directly.";
+const ACTIVE_HEADING = "[data-ipw-slide][aria-hidden='false'] h1";
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let downloadedHtml = "";
+let downloadedHtmlPath = "";
+let transformProof = null;
+
+async function ensureSession(ctx) {
+  await ctx.waitFor("Boolean(window.__ipolloworkControl)", { timeoutMs: 60_000, label: "iPolloWork control API" });
+  await ctx.eval(`(() => {
+    const stop = [...document.querySelectorAll('button')].find((button) => (button.textContent || '').trim() === 'Stop' && !button.disabled);
+    stop?.click();
+    return Boolean(stop);
+  })()`);
+  await ctx.waitFor("window.__ipolloworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)", { timeoutMs: 30_000, label: "create task action" });
+  await ctx.control("session.create_task");
+  await ctx.waitFor("window.__ipolloworkControl.snapshot().route.includes('/session/')", { timeoutMs: 60_000, label: "active task" });
+}
+
+async function withFrame(ctx, callback) {
+  const targets = await listTargets(ctx.cdpBaseUrl);
+  const target = targets.find((entry) => entry.type === "iframe" && entry.url === "about:srcdoc" && entry.webSocketDebuggerUrl);
+  if (!target) return null;
+  const client = await connect(debuggerUrlFor(ctx.cdpBaseUrl, target));
+  try {
+    return await callback(client);
+  } finally {
+    client.close();
+  }
+}
+
+async function frameEval(ctx, expression) {
+  return withFrame(ctx, (client) => evaluate(client, expression));
+}
+
+async function waitFrame(ctx, expression, label, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await frameEval(ctx, expression)) return;
+    await sleep(150);
+  }
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+async function pagePointForFrameElement(ctx, selector) {
+  const local = await frameEval(ctx, `(() => {
+    const element = document.querySelector(${JSON.stringify(selector)});
+    if (!element) return null;
+    const rect = element.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    };
+  })()`);
+  const frame = await ctx.eval(`(() => {
+    const rect = document.querySelector('[data-testid="design-panel"] iframe')?.getBoundingClientRect();
+    return rect ? { left: rect.left, top: rect.top, width: rect.width, height: rect.height } : null;
+  })()`);
+  if (!local || !frame) return null;
+  return {
+    x: frame.left + local.x * frame.width / local.viewportWidth,
+    y: frame.top + local.y * frame.height / local.viewportHeight,
+  };
+}
+
+async function openDeck(ctx) {
+  await ctx.control("eval.design.seed_deck");
+  await ctx.waitFor("document.querySelector('[data-testid=\"design-panel\"] iframe')?.dataset.previewLoaded === 'true'", { timeoutMs: 30_000, label: "Design preview" });
+  await waitFrame(ctx, "document.title === 'iPolloWork Slide Editing Demo'", "deck preview");
+}
+
+async function typeInVisibleHeading(ctx) {
+  const screenshotHash = async () => createHash("sha256")
+    .update((await ctx.client.send("Page.captureScreenshot", { format: "png", fromSurface: true })).data)
+    .digest("hex");
+  const beforeHash = await screenshotHash();
+  const point = await pagePointForFrameElement(ctx, ACTIVE_HEADING);
+  if (!point) return null;
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", ...point });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...point, button: "left", buttons: 1, clickCount: 1 });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...point, button: "left", clickCount: 1 });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mousePressed", ...point, button: "left", buttons: 1, clickCount: 2 });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", ...point, button: "left", clickCount: 2 });
+  await waitFrame(ctx, `document.querySelector(${JSON.stringify(ACTIVE_HEADING)})?.getAttribute('contenteditable') === 'true'`, "visible heading text editor");
+  await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Control", code: "ControlLeft", modifiers: 2 });
+  await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "a", code: "KeyA", modifiers: 2, commands: ["SelectAll"] });
+  await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "a", code: "KeyA", modifiers: 2 });
+  await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Control", code: "ControlLeft" });
+  await ctx.client.send("Input.insertText", { text: EDITED_HEADING });
+  await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape" });
+  await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape" });
+  await sleep(200);
+  return {
+    beforeHash,
+    afterHash: await screenshotHash(),
+    text: await frameEval(ctx, `document.querySelector(${JSON.stringify(ACTIVE_HEADING)})?.textContent || ''`),
+  };
+}
+
+async function dragFrameElement(ctx, selector, deltaX, deltaY) {
+  const point = await pagePointForFrameElement(ctx, selector);
+  if (!point) return false;
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mousePressed", x: point.x, y: point.y, button: "left", buttons: 1, clickCount: 1 });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x + deltaX, y: point.y + deltaY, button: "left", buttons: 1 });
+  await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseReleased", x: point.x + deltaX, y: point.y + deltaY, button: "left", clickCount: 1 });
+  await sleep(200);
+  return true;
+}
+
+async function allowDownloads(ctx, downloadPath) {
+  try {
+    await ctx.client.send("Browser.setDownloadBehavior", { behavior: "allow", downloadPath });
+  } catch {
+    await ctx.client.send("Page.setDownloadBehavior", { behavior: "allow", downloadPath });
+  }
+}
+
+async function waitForHtmlDownload(downloadPath) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const entries = await readdir(downloadPath);
+    const filename = entries.find((entry) => /\.html?$/i.test(entry) && !entry.endsWith(".crdownload"));
+    if (filename) return join(downloadPath, filename);
+    await sleep(200);
+  }
+  throw new Error(`Timed out waiting for HTML download in ${downloadPath}.`);
+}
+
+async function externalBrowserPath() {
+  const candidates = [
+    join(process.env["PROGRAMFILES(X86)"] || "", "Microsoft", "Edge", "Application", "msedge.exe"),
+    join(process.env.PROGRAMFILES || "", "Microsoft", "Edge", "Application", "msedge.exe"),
+    join(process.env.LOCALAPPDATA || "", "Google", "Chrome", "Application", "chrome.exe"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Try the next standard browser installation.
+    }
+  }
+  throw new Error("No independent Chromium browser is available for downloaded HTML verification.");
+}
+
+async function inspectHtmlOutsideDesign(htmlPath) {
+  const userDataDirectory = await mkdtemp(join(tmpdir(), "ipollowork-design-browser-"));
+  const browser = spawn(await externalBrowserPath(), [
+    "--headless=new",
+    "--disable-gpu",
+    "--disable-extensions",
+    "--no-first-run",
+    "--no-default-browser-check",
+    "--remote-debugging-port=0",
+    `--user-data-dir=${userDataDirectory}`,
+    pathToFileURL(htmlPath).href,
+  ], { stdio: "ignore" });
+  let page = null;
+  try {
+    const deadline = Date.now() + 15_000;
+    let cdpBaseUrl = "";
+    while (Date.now() < deadline && !cdpBaseUrl) {
+      try {
+        const [port] = (await readFile(join(userDataDirectory, "DevToolsActivePort"), "utf8")).trim().split(/\r?\n/);
+        if (port) cdpBaseUrl = `http://127.0.0.1:${port}`;
+      } catch {
+        await sleep(100);
+      }
+    }
+    if (!cdpBaseUrl) throw new Error("The independent browser did not expose a debugging port.");
+    while (Date.now() < deadline && !page) {
+      const target = (await listTargets(cdpBaseUrl)).find((entry) => entry.type === "page" && entry.url.startsWith("file:") && entry.webSocketDebuggerUrl);
+      if (target) page = await connect(debuggerUrlFor(cdpBaseUrl, target));
+      else await sleep(150);
+    }
+    if (!page) throw new Error("Downloaded HTML target did not become available.");
+    while (Date.now() < deadline) {
+      let ready = false;
+      try {
+        ready = await evaluate(page, "document.readyState === 'complete'");
+      } catch (error) {
+        throw new Error(`Independent browser readiness check failed: ${error instanceof Error ? error.message : String(error)}`);
+      }
+      if (ready) break;
+      await sleep(100);
+    }
+    try {
+      return await evaluate(page, `(() => ({
+      scrollHeight: Math.max(document.documentElement.scrollHeight, document.body.scrollHeight),
+      viewportHeight: window.innerHeight,
+      visibleSlides: [...document.querySelectorAll('.slide')].filter((slide) => getComputedStyle(slide).display !== 'none').length,
+      editorArtifacts: document.querySelectorAll('[data-ipollowork-design-id],[data-ipollowork-design-selected],[data-ipollowork-design-editing],#ipollowork-design-runtime,#ipollowork-design-deck-runtime,#ipollowork-design-transform-overlay').length,
+      editedText: [...document.querySelectorAll('h1')].some((heading) => heading.textContent?.includes(${JSON.stringify(EDITED_HEADING)})),
+    }))()`);
+    } catch (error) {
+      throw new Error(`Independent browser content check failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  } finally {
+    page?.close();
+    browser.kill();
+  }
+}
+
+export default {
+  id: "design-editor-export",
+  title: "Presentation editing is paged in Design and scrollable after HTML export",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__ipolloworkControl)", { timeoutMs: 60_000, label: "iPolloWork control API" });
+    const route = await ctx.eval("window.__ipolloworkControl.snapshot().route");
+    return route.startsWith("/welcome") || route.startsWith("/signin")
+      ? "iPolloWork must have a local workspace before the Design export flow can run."
+      : null;
+  },
+  steps: [
+    {
+      name: "One landscape slide",
+      run: async (ctx) => ctx.prove("A scrolling presentation source opens as one active 16:9 slide with app-level paging", {
+        voiceover: vo[0],
+        action: async () => {
+          await ensureSession(ctx);
+          await openDeck(ctx);
+        },
+        assert: async () => {
+          const frame = await frameEval(ctx, `(() => {
+            const slides = [...document.querySelectorAll('.slide')];
+            const visible = slides.filter((slide) => getComputedStyle(slide).display !== 'none');
+            return { total: slides.length, visible: visible.length, overflow: getComputedStyle(document.body).overflow };
+          })()`);
+          const shell = await ctx.eval(`(() => {
+            const rect = document.querySelector('[data-testid="design-panel"] iframe')?.getBoundingClientRect();
+            return { pager: document.querySelector('[data-testid="design-deck-navigation"]')?.textContent || '', ratio: rect ? rect.width / rect.height : 0 };
+          })()`);
+          ctx.assert(frame.total === 3 && frame.visible === 1 && frame.overflow === "hidden", `Unexpected active-slide state: ${JSON.stringify(frame)}`);
+          ctx.assert(shell.pager.includes("1 / 3") && Math.abs(shell.ratio - 16 / 9) < 0.02, `Unexpected presentation frame: ${JSON.stringify(shell)}`);
+        },
+        screenshot: { name: "one-landscape-slide", requireText: ["1 / 3", "Edit page"], rejectText: ["Something went wrong"] },
+      }),
+    },
+    {
+      name: "Direct visible text editing",
+      run: async (ctx) => {
+        let typing = null;
+        await ctx.prove("Direct typing changes visible pixels on slide two and keeps that slide active", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.trustedClick('[aria-label="Next slide"]');
+            await waitFrame(ctx, `document.querySelector(${JSON.stringify(ACTIVE_HEADING)})?.textContent?.includes('second slide')`, "second slide");
+            await ctx.trustedClick('[aria-label="Edit page"]');
+            await waitFrame(ctx, "document.documentElement.dataset.ipolloworkDesignMode === 'editing'", "deck edit mode");
+            typing = await typeInVisibleHeading(ctx);
+          },
+          assert: async () => {
+            ctx.assert(typing?.text === EDITED_HEADING && typing.beforeHash !== typing.afterHash, `Direct typing did not change visible pixels: ${JSON.stringify(typing)}`);
+            const state = await frameEval(ctx, `(() => ({
+              active: [...document.querySelectorAll('.slide')].findIndex((slide) => slide.getAttribute('aria-hidden') === 'false'),
+              visible: [...document.querySelectorAll('.slide')].filter((slide) => getComputedStyle(slide).display !== 'none').length,
+            }))()`);
+            ctx.assert(state.active === 1 && state.visible === 1, `Typing targeted the wrong slide: ${JSON.stringify(state)}`);
+          },
+          screenshot: { name: "direct-edit-visible-slide", requireText: ["2 / 3", "Edit text"], rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Canvas drag and resize",
+      run: async (ctx) => ctx.prove("The selected visible heading moves and resizes from the canvas controls", {
+        voiceover: vo[2],
+        action: async () => {
+          const rect = async () => frameEval(ctx, `(() => {
+            const heading = document.querySelector(${JSON.stringify(ACTIVE_HEADING)});
+            const value = heading?.getBoundingClientRect();
+            return value ? { left: value.left, top: value.top, width: value.width, height: value.height, style: heading.getAttribute('style') || '' } : null;
+          })()`);
+          const before = await rect();
+          const moved = await dragFrameElement(ctx, "#ipollowork-design-transform-overlay", 84, 44);
+          const afterMove = await rect();
+          const resized = await dragFrameElement(ctx, "#ipollowork-design-transform-overlay [data-handle='w']", -120, 0);
+          transformProof = { before, afterMove, afterResize: await rect(), moved, resized };
+        },
+        assert: async () => {
+          ctx.assert(transformProof?.moved && transformProof?.resized, `Transform gestures were not dispatched: ${JSON.stringify(transformProof)}`);
+          ctx.assert(transformProof.afterMove.left > transformProof.before.left + 60 && transformProof.afterMove.top > transformProof.before.top + 25, `The heading did not move: ${JSON.stringify(transformProof)}`);
+          ctx.assert(transformProof.afterResize.width > transformProof.afterMove.width + 80 && transformProof.afterResize.left < transformProof.afterMove.left - 80, `The heading did not resize: ${JSON.stringify(transformProof)}`);
+        },
+        screenshot: { name: "dragged-and-resized-visible-heading", requireText: ["2 / 3", "Edit text"], rejectText: ["Something went wrong"] },
+      }),
+    },
+    {
+      name: "Clean scrollable HTML download",
+      run: async (ctx) => ctx.prove("The real HTML download contains current visual edits, has no editor runtime, and scrolls outside Design", {
+        voiceover: vo[3],
+        action: async () => {
+          const downloadDirectory = await mkdtemp(join(tmpdir(), "ipollowork-design-html-"));
+          await allowDownloads(ctx, downloadDirectory);
+          await ctx.trustedClick('[aria-label="Download"]');
+          await ctx.trustedClick('[role="menuitem"]');
+          downloadedHtmlPath = await waitForHtmlDownload(downloadDirectory);
+          downloadedHtml = await readFile(downloadedHtmlPath, "utf8");
+        },
+        assert: async () => {
+          ctx.assert(downloadedHtml.includes(EDITED_HEADING), "The HTML download does not contain the direct text edit.");
+          ctx.assert(/style="[^"]*(?:left|top):[^\"]*(?:width|height):/i.test(downloadedHtml), "The HTML download does not contain visual transform edits.");
+          ctx.assert(!/ipollowork-design-(?:runtime|deck-runtime|transform-overlay|fixed-slide-runtime|template-token-style)/i.test(downloadedHtml), "The HTML download contains an editor-only runtime or overlay.");
+          ctx.assert(!/data-ipollowork-design-(?:id|selected|editing|mode|deck-original-state)/i.test(downloadedHtml), "The HTML download contains editor-only selection state.");
+          ctx.assert(!/<section\b[^>]*\baria-hidden=/i.test(downloadedHtml), "The HTML download contains preview-only aria-hidden mutations.");
+          const outside = await inspectHtmlOutsideDesign(downloadedHtmlPath);
+          ctx.assert(outside.editedText && outside.editorArtifacts === 0, `The downloaded page is not clean: ${JSON.stringify(outside)}`);
+          ctx.assert(outside.visibleSlides === 3 && outside.scrollHeight > outside.viewportHeight + 300, `The downloaded page does not scroll vertically: ${JSON.stringify(outside)}`);
+        },
+        screenshot: { name: "html-download-complete", requireText: ["Design downloaded as HTML."], rejectText: ["Something went wrong"] },
+      }),
+    },
+    {
+      name: "Save and reopen",
+      run: async (ctx) => ctx.prove("Saving and reopening keeps the edited content while Design returns to one-slide paging", {
+        voiceover: vo[4],
+        action: async () => {
+          await ctx.eval(`(() => {
+            const panel = document.querySelector('[data-testid="design-panel"]');
+            const save = [...panel.querySelectorAll('button')].find((button) => (button.textContent || '').includes('Save'));
+            save?.click();
+            return Boolean(save);
+          })()`);
+          await ctx.waitForText("Design saved to the workspace.", { timeoutMs: 20_000 });
+          await ctx.trustedClick('[aria-label="Close Design"]');
+          await ctx.trustedClick('button[aria-label="Open right panel"]');
+          await ctx.waitFor("document.querySelector('[data-testid=\"design-panel\"] iframe')?.dataset.previewLoaded === 'true'", { timeoutMs: 20_000, label: "reopened Design preview" });
+          await waitFrame(ctx, "document.title === 'iPolloWork Slide Editing Demo'", "reopened deck");
+          await ctx.trustedClick('[aria-label="Next slide"]');
+          await waitFrame(ctx, `document.querySelector(${JSON.stringify(ACTIVE_HEADING)})?.textContent === ${JSON.stringify(EDITED_HEADING)}`, "saved second-slide edit");
+        },
+        assert: async () => {
+          const state = await frameEval(ctx, `(() => ({
+            visible: [...document.querySelectorAll('.slide')].filter((slide) => getComputedStyle(slide).display !== 'none').length,
+            text: document.querySelector(${JSON.stringify(ACTIVE_HEADING)})?.textContent || '',
+          }))()`);
+          ctx.assert(state.visible === 1 && state.text === EDITED_HEADING, `Saved Design state is wrong: ${JSON.stringify(state)}`);
+        },
+        screenshot: { name: "saved-and-reopened-paged-deck", requireText: ["2 / 3", "Save"], rejectText: ["Something went wrong"] },
+      }),
+    },
+    {
+      name: "Document-specific export formats",
+      run: async (ctx) => {
+        let presentationFormats = [];
+        await ctx.prove("Presentations offer HTML, PDF, and PPTX while ordinary Design pages offer HTML only", {
+          voiceover: vo[5],
+          action: async () => {
+            await ctx.trustedClick('[aria-label="Download"]');
+            await ctx.waitFor("document.querySelectorAll('[role=menuitem]').length > 0", { label: "presentation export menu" });
+            presentationFormats = await ctx.eval("[...document.querySelectorAll('[role=menuitem]')].map((item) => (item.textContent || '').trim())");
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape" });
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape" });
+            await ensureSession(ctx);
+            await ctx.control("eval.design.seed_html");
+            await ctx.waitFor("document.querySelector('[data-testid=\"design-panel\"] iframe')?.dataset.previewLoaded === 'true'", { timeoutMs: 30_000, label: "ordinary Design preview" });
+            await waitFrame(ctx, "document.title === 'iPolloWork Design Demo'", "ordinary Design page");
+            await ctx.trustedClick('[aria-label="Download"]');
+            await ctx.waitFor("document.querySelectorAll('[role=menuitem]').length > 0", { label: "ordinary Design export menu" });
+          },
+          assert: async () => {
+            ctx.assert(presentationFormats.some((label) => label.includes("HTML")) && presentationFormats.some((label) => label.includes("PDF")) && presentationFormats.some((label) => label.includes("PPTX")), `Presentation formats are incomplete: ${JSON.stringify(presentationFormats)}`);
+            const pageFormats = await ctx.eval("[...document.querySelectorAll('[role=menuitem]')].map((item) => (item.textContent || '').trim())");
+            ctx.assert(pageFormats.length === 1 && pageFormats[0].includes("HTML"), `Ordinary Design formats are wrong: ${JSON.stringify(pageFormats)}`);
+          },
+          screenshot: { name: "html-only-for-ordinary-design", requireText: ["Download HTML"], rejectText: ["Download PDF", "Download PPTX", "Something went wrong"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -23,7 +23,6 @@ import { join, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { connect, debuggerUrlFor, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
 import { EvalContext } from "./context.mjs";
-import { denStackDown, ensureDenStack } from "./den-stack.mjs";
 import { checkVoiceoverCoverage, loadVoiceoverParagraphs, scaffoldFlow } from "./voiceover.mjs";
 import { postPrComment } from "./pr.mjs";
 
@@ -31,6 +30,10 @@ const RUNNER_DIR = dirname(fileURLToPath(import.meta.url));
 const FLOWS_DIR = process.env.IPOLLOWORK_EVAL_FLOWS_DIR?.trim() || join(RUNNER_DIR, "..", "flows");
 const DEFAULT_RESULTS_DIR = join(RUNNER_DIR, "..", "results");
 const DEFAULT_CDP_CANDIDATES = ["http://127.0.0.1:9825", "http://127.0.0.1:9823"];
+
+async function loadDenStack() {
+  return import("./den-stack.mjs");
+}
 
 function parseArgs(argv) {
   const args = { flows: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false, scaffold: null, force: false, pr: null };
@@ -430,6 +433,7 @@ async function main() {
   }
 
   if (args.stackDown) {
+    const { denStackDown } = await loadDenStack();
     await denStackDown({ log: (msg) => console.log(`▸ ${msg}`) });
     return;
   }
@@ -442,6 +446,7 @@ async function main() {
   }
 
   if (args.stack === "den") {
+    const { ensureDenStack } = await loadDenStack();
     await ensureDenStack({
       log: (msg) => console.log(`▸ ${msg}`),
       cdpCandidates: args.cdpUrl ? [args.cdpUrl] : DEFAULT_CDP_CANDIDATES,

--- a/evals/voiceovers/design-editor-export.md
+++ b/evals/voiceovers/design-editor-export.md
@@ -1,0 +1,13 @@
+# design-editor-export - edit and export a presentation without changing its HTML layout
+
+1. I open a presentation in Design and see one landscape slide at a time, with the compact pager showing exactly where I am.
+
+2. I move to the second slide, turn on Edit page, and type directly into the visible heading. The words visibly change on the same slide without jumping back to the cover.
+
+3. I drag the selected heading to a new position and resize it from the canvas handles, so the visible slide responds like a visual editor.
+
+4. I download the presentation as HTML and open that downloaded file outside Design. My visual edits are present, the document scrolls vertically again, and no editor controls appear in the page.
+
+5. I save and reopen the presentation. The edited content remains, Design returns to its one-slide landscape view, and the saved page keeps its original behavior outside the editor.
+
+6. The presentation download menu still offers PDF and PPTX beside HTML, while an ordinary Design page offers HTML without presentation-only formats.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      pptxgenjs:
+        specifier: 3.12.0
+        version: 3.12.0
       react:
         specifier: 'catalog:'
         version: 19.2.4
@@ -2988,6 +2991,9 @@ packages:
   '@types/node@16.9.1':
     resolution: {integrity: sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@20.12.12':
     resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
 
@@ -4704,6 +4710,9 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  https@1.0.0:
+    resolution: {integrity: sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==}
+
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
@@ -4737,6 +4746,11 @@ packages:
 
   image-q@4.0.0:
     resolution: {integrity: sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==}
+
+  image-size@1.2.1:
+    resolution: {integrity: sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==}
+    engines: {node: '>=16.x'}
+    hasBin: true
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -5958,6 +5972,9 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  pptxgenjs@3.12.0:
+    resolution: {integrity: sha512-ZozkYKWb1MoPR4ucw3/aFYlHkVIJxo9czikEclcUVnS4Iw/M+r+TEwdlB3fyAWO9JY1USxJDt0Y0/r15IR/RUA==}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -6024,6 +6041,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -9672,6 +9692,10 @@ snapshots:
 
   '@types/node@16.9.1': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@20.12.12':
     dependencies:
       undici-types: 5.26.5
@@ -11698,6 +11722,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https@1.0.0: {}
+
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
@@ -11727,6 +11753,10 @@ snapshots:
   image-q@4.0.0:
     dependencies:
       '@types/node': 16.9.1
+
+  image-size@1.2.1:
+    dependencies:
+      queue: 6.0.2
 
   immediate@3.0.6: {}
 
@@ -13061,6 +13091,13 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  pptxgenjs@3.12.0:
+    dependencies:
+      '@types/node': 18.19.130
+      https: 1.0.0
+      image-size: 1.2.1
+      jszip: 3.10.1
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -13121,6 +13158,10 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   quick-lru@5.1.1: {}
 


### PR DESCRIPTION
## Summary
- keep presentation pagination inside the Design editor with one active 16:9 slide and previous/next navigation
- preserve direct text editing, selection, dragging, and resizing while restoring original slide attributes during serialization
- add clean HTML downloads for every Design document and keep PDF/PPTX actions limited to presentations
- serialize current visual edits without editor runtimes, overlays, selection markers, pagination state, or preview-only ARIA mutations

## Verification
- `pnpm --filter @ipollowork/app typecheck` - passed
- focused Design/PPTX tests - 58 passed, 0 failed
- `node evals/runner/run.mjs --flow design-editor-export --cdp-url http://127.0.0.1:9833` - passed all 6 frames plus voice-over coverage
- production build - passed
- `./ipollowork.cmd package:dir` - passed from independent, non-Junction dependencies
- verified `server/dist/embedded.js` inside `resources/app.asar` (4,435 bytes)
- launched the packaged app and verified a complete renderer with no embedded-server or generic error page

Fraimz proof: `evals/results/2026-07-21T09-13-58-491Z/fraimz.html`

## Existing main-branch failures
- full app suite: 283 passed, 3 unrelated failures in composer queue behavior, managed brand header, and permission approval modal tests
- i18n audit: the new key passes key, placeholder, plural, duplicate, and orphan checks; the command still fails on existing incomplete locale coverage, 274 unused keys, and 3 dynamic key constructions
- `./ipollowork.cmd check`: fails because current main has no Simplified Chinese README language bar; this PR does not modify README files

## Packaging note
Current main omits `ffmpeg-static` and the two `_shared` CLI template assets referenced by the HyperFrames build script. For independent local packaging verification, those exact assets were installed/restored temporarily from the vendored upstream commit and removed afterward; they are not part of this Design-scoped diff.