### PR TITLE
Fix/website template cta interactions

### DIFF
--- a/apps/server/bundled-templates/ipollowork.html-anything.pricing-page/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.pricing-page/entry.html
@@ -47,6 +47,7 @@
     details { padding: 16px 0; border-top: 1px solid var(--border); }
     details summary { font-weight: 500; cursor: pointer; }
     details p { margin: 10px 0 0; color: var(--muted); }
+    .action-status { min-height: 24px; margin: -40px 0 48px; text-align: center; color: var(--accent); font-weight: 500; }
     @media (max-width: 640px) {
       .wrap { padding: 40px 18px 72px; }
       header { margin-bottom: 40px; }
@@ -72,8 +73,8 @@
       <h1>One flat rate. No throttling.</h1>
       <p>Start free. Pick a paid tier the day you outgrow it. Switch yearly billing for two months off.</p>
       <div class="toggle">
-        <button class="active">Monthly</button>
-        <button>Yearly · save 17%</button>
+        <button type="button" class="active" data-ipw-toggle="monthly" aria-pressed="true">Monthly</button>
+        <button type="button" data-ipw-toggle="yearly" aria-pressed="false">Yearly · save 17%</button>
       </div>
     </header>
 
@@ -81,20 +82,20 @@
       <div class="tier">
         <h2>Solo</h2>
         <p class="desc">For individuals.</p>
-        <div class="price">$8 <small>/ month</small></div>
+        <div class="price" data-monthly="$8" data-yearly="$80">$8 <small>/ month</small></div>
         <ul>
           <li>1 TB storage</li>
           <li>Block-level sync</li>
           <li>2 devices</li>
           <li>Email support</li>
         </ul>
-        <button class="cta cta-secondary">Choose Solo</button>
+        <button type="button" class="cta cta-secondary" data-ipw-action-message="Solo plan selected. Connect this button to your checkout flow.">Choose Solo</button>
       </div>
       <div class="tier featured">
         <span class="featured-pill">Recommended</span>
         <h2>Team</h2>
         <p class="desc">For teams up to 50 people.</p>
-        <div class="price">$14 <small>/ seat / month</small></div>
+        <div class="price" data-monthly="$14" data-yearly="$140">$14 <small>/ seat / month</small></div>
         <ul>
           <li>5 TB pooled storage</li>
           <li>Shared folders & granular roles</li>
@@ -102,7 +103,7 @@
           <li>Audit log + usage analytics</li>
           <li>Priority support</li>
         </ul>
-        <button class="cta cta-primary">Choose Team</button>
+        <button type="button" class="cta cta-primary" data-ipw-action-message="Team plan selected. Connect this button to your checkout flow.">Choose Team</button>
       </div>
       <div class="tier">
         <h2>Enterprise</h2>
@@ -114,9 +115,10 @@
           <li>On-prem encryption keys</li>
           <li>Dedicated CSM</li>
         </ul>
-        <button class="cta cta-secondary">Talk to sales</button>
+        <button type="button" class="cta cta-secondary" data-ipw-action-message="Sales request started. Connect this button to your contact form.">Talk to sales</button>
       </div>
     </section>
+    <p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>
 
     <section class="compare" data-od-id="compare">
       <h3>Plan comparison</h3>
@@ -143,5 +145,28 @@
       <details><summary>How does seat-based billing work for Team?</summary><p>You pay per active seat per month. Inactive seats automatically free up after 30 days; we'll prorate the credit.</p></details>
     </section>
   </div>
+  <script>
+    (() => {
+      const status = document.querySelector('[data-ipw-action-status]');
+      const toggles = document.querySelectorAll('[data-ipw-toggle]');
+      const prices = document.querySelectorAll('.price[data-monthly][data-yearly]');
+      const selectBilling = (period) => {
+        toggles.forEach((button) => {
+          const selected = button.dataset.ipwToggle === period;
+          button.classList.toggle('active', selected);
+          button.setAttribute('aria-pressed', String(selected));
+        });
+        prices.forEach((price) => {
+          price.firstChild.textContent = `${period === 'yearly' ? price.dataset.yearly : price.dataset.monthly} `;
+          const suffix = price.querySelector('small');
+          if (suffix) suffix.textContent = period === 'yearly' ? '/ year' : price.dataset.monthly === '$14' ? '/ seat / month' : '/ month';
+        });
+      };
+      toggles.forEach((button) => button.addEventListener('click', () => selectBilling(button.dataset.ipwToggle)));
+      document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+        button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/apps/server/bundled-templates/ipollowork.html-anything.prototype-web/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.prototype-web/entry.html
@@ -16,6 +16,8 @@
   details summary { cursor:pointer; list-style:none; }
   .card-rise { transition:transform 0.25s ease, box-shadow 0.25s ease; }
   .card-rise:hover { transform:translateY(-4px); box-shadow:0 30px 60px -30px rgba(21,20,15,0.2); }
+  .demo-play { border:0; background:transparent; color:white; cursor:pointer; }
+  .action-status { min-height:24px; margin:16px auto 0; text-align:center; color:#c96442; font-weight:600; }
   .mobile-nav-toggle { display:none; position:relative; width:42px; height:42px; flex:0 0 42px; border:1px solid #e7e5e0; border-radius:12px; background:rgba(255,255,255,.82); color:#15140f; }
   .mobile-nav-toggle span, .mobile-nav-toggle::before, .mobile-nav-toggle::after { content:""; position:absolute; left:12px; width:16px; height:1.5px; border-radius:2px; background:currentColor; transition:top .2s ease, transform .2s ease, opacity .2s ease; }
   .mobile-nav-toggle::before { top:13px; }
@@ -49,7 +51,7 @@
 
 <nav class="sticky top-0 z-30 glass">
   <div class="nav-inner max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-    <a href="#" class="flex items-center gap-2.5 font-bold tracking-tight">
+    <a href="#top" class="flex items-center gap-2.5 font-bold tracking-tight">
       <div class="w-8 h-8 rounded-lg bg-gradient-to-br from-[#c96442] to-[#e9b94a] grid place-items-center text-white font-black">Ⅰ</div>
       <span>Inkstack</span>
     </a>
@@ -61,14 +63,14 @@
       <a href="#cta" class="hover:text-[#15140f] md:hidden">Contact</a>
     </div>
     <div class="flex items-center gap-2">
-      <a href="#" class="hidden sm:inline text-sm font-medium text-[#5a564e] hover:text-[#15140f] px-3 py-2">About</a>
+      <a href="#features" class="hidden sm:inline text-sm font-medium text-[#5a564e] hover:text-[#15140f] px-3 py-2">About</a>
       <a href="#cta" class="text-sm font-semibold bg-[#15140f] text-white px-4 py-2 rounded-full hover:bg-[#2a2620] transition-colors">Contact</a>
       <button class="mobile-nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false"><span></span></button>
     </div>
   </div>
 </nav>
 
-<section class="gradient-bg pt-24 pb-32 px-6">
+<section id="top" class="gradient-bg pt-24 pb-32 px-6">
   <div class="max-w-5xl mx-auto text-center">
     <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/70 border border-[#e7e5e0] text-xs font-medium text-[#5a564e] mb-7">
       <span class="w-1.5 h-1.5 rounded-full bg-[#c96442]"></span>
@@ -92,15 +94,16 @@
       <div class="rounded-2xl bg-white shadow-[0_50px_100px_-30px_rgba(21,20,15,0.25)] border border-[#e7e5e0] p-2">
         <div class="rounded-xl bg-[#15140f] aspect-video grid place-items-center relative overflow-hidden">
           <div class="absolute inset-0 opacity-20" style="background-image:linear-gradient(#fff 1px,transparent 1px),linear-gradient(90deg,#fff 1px,transparent 1px); background-size:32px 32px;"></div>
-          <div class="text-center relative z-10">
-            <div class="text-7xl mb-3">▶</div>
-            <div class="text-white/60 text-sm">A clearer way to move forward</div>
-          </div>
+          <button type="button" class="demo-play text-center relative z-10" data-ipw-action-message="Demo only — no video is connected yet. Add your product video before publishing.">
+            <span class="block text-7xl mb-3" aria-hidden="true">▶</span>
+            <span class="block text-white/60 text-sm">Play: A clearer way to move forward</span>
+          </button>
         </div>
       </div>
     </div>
   </div>
 </section>
+<p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>
 
 <section id="features" class="py-24 px-6">
   <div class="max-w-6xl mx-auto">
@@ -209,7 +212,7 @@
         <ul class="space-y-2 text-sm text-[#262421] mb-6">
           <li>Customers</li><li>About</li><li>Contact</li>
         </ul>
-        <button class="w-full py-2.5 rounded-full border border-[#15140f]/15 hover:border-[#15140f]/40 font-medium text-sm">Get started</button>
+        <a href="#cta" class="block w-full py-2.5 rounded-full border border-[#15140f]/15 hover:border-[#15140f]/40 font-medium text-sm text-center">Get started</a>
       </div>
       <div class="p-8 rounded-2xl bg-[#15140f] text-white border border-[#15140f] ring-2 ring-[#c96442]/30 relative">
         <div class="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 rounded-full bg-[#c96442] text-white text-[10px] font-bold tracking-wider">Learn more</div>
@@ -219,7 +222,7 @@
         <ul class="space-y-2 text-sm opacity-90 mb-6">
           <li>Product</li><li>Solutions</li><li>Customers</li>
         </ul>
-        <button class="w-full py-2.5 rounded-full bg-[#c96442] hover:bg-[#b25737] font-semibold text-sm">About</button>
+        <a href="#features" class="block w-full py-2.5 rounded-full bg-[#c96442] hover:bg-[#b25737] font-semibold text-sm text-center">About</a>
       </div>
       <div class="p-8 rounded-2xl bg-white border border-[#e7e5e0]">
         <div class="text-sm font-semibold text-[#5a564e] mb-2">Team</div>
@@ -228,7 +231,7 @@
         <ul class="space-y-2 text-sm text-[#262421] mb-6">
           <li>Learn more</li><li>Home</li><li>Product</li>
         </ul>
-        <button class="w-full py-2.5 rounded-full border border-[#15140f]/15 hover:border-[#15140f]/40 font-medium text-sm">Solutions</button>
+        <a href="#voices" class="block w-full py-2.5 rounded-full border border-[#15140f]/15 hover:border-[#15140f]/40 font-medium text-sm text-center">Solutions</a>
       </div>
     </div>
   </div>
@@ -237,7 +240,7 @@
 <section id="cta" class="py-32 px-6 text-center">
   <h2 class="text-5xl md:text-6xl font-extrabold tracking-tight mb-5">Everything you need to grow</h2>
   <p class="text-lg text-[#5a564e] mb-8">Build what matters.</p>
-  <a href="#" class="inline-flex items-center gap-2 bg-[#c96442] text-white font-semibold px-7 py-3.5 rounded-full hover:bg-[#b25737] transition-colors shadow-[0_14px_32px_-16px_rgba(201,100,66,0.85)]">
+  <a href="#pricing" class="inline-flex items-center gap-2 bg-[#c96442] text-white font-semibold px-7 py-3.5 rounded-full hover:bg-[#b25737] transition-colors shadow-[0_14px_32px_-16px_rgba(201,100,66,0.85)]">
     Customers
   </a>
 </section>
@@ -250,9 +253,9 @@
       <span class="opacity-50">© 2026</span>
     </div>
     <div class="flex gap-5">
-      <a href="#" class="hover:text-[#15140f]">About</a>
-      <a href="#" class="hover:text-[#15140f]">Contact</a>
-      <a href="#" class="hover:text-[#15140f]">Get started</a>
+      <a href="#features" class="hover:text-[#15140f]">About</a>
+      <a href="#voices" class="hover:text-[#15140f]">Contact</a>
+      <a href="#cta" class="hover:text-[#15140f]">Get started</a>
     </div>
   </div>
 </footer>
@@ -271,6 +274,10 @@
     nav.querySelectorAll('.mobile-menu a').forEach((item) => item.addEventListener('click', () => setOpen(false)));
     document.addEventListener('click', (event) => { if (!nav.contains(event.target)) setOpen(false); });
     document.addEventListener('keydown', (event) => { if (event.key === 'Escape') setOpen(false); });
+    const status = document.querySelector('[data-ipw-action-status]');
+    document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+      button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+    });
   })();
 </script>
 

--- a/apps/server/bundled-templates/ipollowork.html-anything.saas-landing/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.saas-landing/entry.html
@@ -50,6 +50,7 @@
     .closing h2 { font-size: 38px; letter-spacing: -0.02em; margin: 0 0 14px; }
     .closing p { opacity: 0.85; margin: 0 0 28px; }
     .closing button { background: white; color: var(--accent); border: none; }
+    .action-status { min-height: 24px; margin: 22px auto; padding: 0 18px; text-align: center; color: var(--accent); font-weight: 600; }
     footer { padding: 28px 0; color: var(--muted); font-size: 13px; text-align: center; }
     .mobile-nav-toggle { position: relative; display: none; width: 42px; height: 42px; padding: 0; place-items: center; border: 1px solid var(--border); background: color-mix(in srgb, var(--surface) 78%, transparent); color: var(--fg); }
     .mobile-nav-toggle span, .mobile-nav-toggle::before, .mobile-nav-toggle::after { content: ""; position: absolute; left: 12px; display: block; width: 16px; height: 1.5px; border-radius: 2px; background: currentColor; transition: top .2s ease, transform .2s ease, opacity .2s ease; }
@@ -87,15 +88,15 @@
         <a href="#features">Features</a>
         <a href="#pricing">Pricing</a>
         <a href="#docs">Docs</a>
-        <button class="btn-secondary" style="margin-left: 12px;">Sign in</button>
+        <button type="button" class="btn-secondary" style="margin-left: 12px;" data-ipw-action-message="Sign-in demo opened. Connect this button to your authentication page.">Sign in</button>
       </nav>
     </header>
     <section class="hero" data-od-id="hero">
       <h1>File sync that doesn't eat your bandwidth.</h1>
       <p>Block-level deltas, end-to-end encryption, and a pricing model that doesn't punish you for working with video.</p>
       <div class="cta">
-        <button class="btn-primary">Get iPolloWork</button>
-        <button class="btn-link">Read the whitepaper →</button>
+        <button type="button" class="btn-primary" data-ipw-action-message="Trial selected. Connect this button to your signup flow.">Get iPolloWork</button>
+        <button type="button" class="btn-link" data-ipw-action-message="Whitepaper requested. Connect this button to your document download.">Read the whitepaper →</button>
       </div>
     </section>
   </div>
@@ -138,7 +139,7 @@
           <li>Block-level sync</li>
           <li>Email support</li>
         </ul>
-        <button class="btn-secondary" style="width: 100%;">Choose Solo</button>
+        <button type="button" class="btn-secondary" style="width: 100%;" data-ipw-action-message="Solo plan selected. Connect this button to your checkout flow.">Choose Solo</button>
       </div>
       <div class="tier featured">
         <h3>Team</h3>
@@ -150,7 +151,7 @@
           <li>Priority support</li>
           <li>Audit log</li>
         </ul>
-        <button class="btn-primary" style="width: 100%;">Choose Team</button>
+        <button type="button" class="btn-primary" style="width: 100%;" data-ipw-action-message="Team plan selected. Connect this button to your checkout flow.">Choose Team</button>
       </div>
       <div class="tier">
         <h3>Enterprise</h3>
@@ -161,19 +162,20 @@
           <li>SAML / SCIM</li>
           <li>Dedicated support</li>
         </ul>
-        <button class="btn-secondary" style="width: 100%;">Talk to sales</button>
+        <button type="button" class="btn-secondary" style="width: 100%;" data-ipw-action-message="Sales request started. Connect this button to your contact form.">Talk to sales</button>
       </div>
     </div>
   </section>
 
-  <section class="closing" data-od-id="closing">
+  <section class="closing" id="docs" data-od-id="closing">
     <div class="wrap">
       <h2>Sync less, ship more.</h2>
       <p>14-day free trial. No credit card needed.</p>
-      <button>Get iPolloWork</button>
+      <button type="button" data-ipw-action-message="Trial selected. Connect this button to your signup flow.">Get iPolloWork</button>
     </div>
   </section>
 
+  <p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>
   <footer class="wrap" data-od-id="footer">© iPolloWork · Privacy · Terms · Status</footer>
   <script>
     (() => {
@@ -189,6 +191,10 @@
       header.querySelectorAll('nav a, nav button').forEach((item) => item.addEventListener('click', () => setOpen(false)));
       document.addEventListener('click', (event) => { if (!header.contains(event.target)) setOpen(false); });
       document.addEventListener('keydown', (event) => { if (event.key === 'Escape') setOpen(false); });
+      const status = document.querySelector('[data-ipw-action-status]');
+      document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+        button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+      });
     })();
   </script>
 </body>

--- a/apps/server/bundled-templates/ipollowork.html-anything.waitlist-page/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.waitlist-page/entry.html
@@ -319,7 +319,7 @@
       <input type="email" name="email" placeholder="Work email" autocomplete="email" required>
       <button type="submit">Join the Waitlist</button>
     </form>
-    <p class="success-msg" id="success-msg" role="status">You're on the list! We'll be in touch.</p>
+    <p class="success-msg" id="success-msg" role="status">Demo only — no information was sent. Connect this form to your signup service before publishing.</p>
   </section>
 
   <div class="deco-section">
@@ -402,15 +402,19 @@
   </div>
 
   <script>
-    document.getElementById('waitlist-form').addEventListener('submit', function(e) {
-      e.preventDefault();
-      if (!this.checkValidity()) {
-        this.reportValidity();
-        return;
-      }
-      this.style.display = 'none';
-      document.getElementById('success-msg').classList.add('visible');
-    });
+    (() => {
+      const form = document.getElementById('waitlist-form');
+      if (!form) return;
+      form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        if (!this.checkValidity()) {
+          this.reportValidity();
+          return;
+        }
+        this.style.display = 'none';
+        document.getElementById('success-msg')?.classList.add('visible');
+      });
+    })();
   </script>
 </body>
 </html>

--- a/apps/server/bundled-templates/ipollowork.html-anything.web-proto-editorial/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.web-proto-editorial/entry.html
@@ -255,6 +255,7 @@
     /* ============ MOTION (entry, subtle) ============ */
     .reveal { opacity: 0; transform: translateY(12px); transition: opacity 600ms cubic-bezier(0.16,1,0.3,1), transform 600ms cubic-bezier(0.16,1,0.3,1); }
     .reveal.is-in { opacity: 1; transform: none; }
+    .action-status { min-height: 24px; margin: 18px auto 0; text-align: center; color: var(--accent); font-weight: 600; }
     @media (prefers-reduced-motion: reduce) {
       .reveal { opacity: 1; transform: none; transition: none; }
     }
@@ -268,11 +269,11 @@
       <li><a href="#bento">Surfaces</a></li>
       <li><a href="#contrast">What it isn't</a></li>
       <li><a href="#pricing">Plans</a></li>
-      <li><a href="#changelog">Changelog</a></li>
+      <li><a href="#bento-history">Changelog</a></li>
       <li class="mobile-cta"><a href="#bento">Open workspace</a></li>
     </ul>
     <button class="mobile-nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false"><span></span></button>
-    <button class="cta">Open workspace</button>
+    <button type="button" class="cta" data-ipw-action-message="Workspace preview opened. Connect this button to your app entry point.">Open workspace</button>
   </header>
 
   <main>
@@ -281,8 +282,8 @@
       <h1>A quiet place to write the <em>docs nobody read</em>, and have them read.</h1>
       <p class="lede">Quartz is a workspace for technical writers who'd rather ship a clean changelog than win a Notion-template contest. Outline, draft, review, publish - without leaving the keyboard.</p>
       <div class="actions">
-        <button class="btn btn-primary">Request access</button>
-        <button class="btn-link">Read the manual</button>
+        <button type="button" class="btn btn-primary" data-ipw-action-message="Access request prepared. Connect this button to your request form.">Request access</button>
+        <a class="btn-link" href="#bento">Read the manual</a>
         <span class="keystroke">⌘ K</span>
       </div>
     </section>
@@ -311,7 +312,7 @@
           <h4>Markdown out, always</h4>
           <p>Export round-trips: a doc opened in Quartz writes the same .md it read.</p>
         </div>
-        <div class="cell cell--small" data-od-id="bento-history">
+        <div class="cell cell--small" id="bento-history" data-od-id="bento-history">
           <span class="num">04 / history</span>
           <span class="chip chip--yellow">Audit</span>
           <h4 style="margin-top: 8px;">Git-grade history</h4>
@@ -376,7 +377,7 @@
             <li>Markdown export & import</li>
             <li>Three custom themes</li>
           </ul>
-          <button class="btn btn-ghost">Start solo</button>
+          <button type="button" class="btn btn-ghost" data-ipw-action-message="Solo plan selected. Connect this button to your signup flow.">Start solo</button>
         </div>
         <div class="tier tier--highlight">
           <h3>Studio</h3>
@@ -389,7 +390,7 @@
             <li>Audit log with diff history</li>
             <li>Static-site publish target</li>
           </ul>
-          <button class="btn btn-primary">Start studio</button>
+          <button type="button" class="btn btn-primary" data-ipw-action-message="Studio plan selected. Connect this button to your signup flow.">Start studio</button>
         </div>
         <div class="tier">
           <h3>Press</h3>
@@ -401,17 +402,18 @@
             <li>Custom export pipelines</li>
             <li>Named support engineer</li>
           </ul>
-          <button class="btn btn-ghost">Open a thread</button>
+          <button type="button" class="btn btn-ghost" data-ipw-action-message="Sales conversation prepared. Connect this button to your contact flow.">Open a thread</button>
         </div>
       </div>
     </section>
   </main>
+  <p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>
 
   <footer>
     <div class="wrap row">
       <span>Quartz · Bordeaux, FR · v0.4.7 · 2026</span>
       <span>
-        <a href="#">Manual</a> · <a href="#">Changelog</a> · <a href="#">Status</a> · <a href="#">Privacy</a>
+        <a href="#bento">Manual</a> · <a href="#bento-history">Changelog</a> · <a href="#contrast">Status</a> · <a href="#pricing">Privacy</a>
       </span>
     </div>
   </footer>
@@ -430,7 +432,10 @@
       nav.querySelectorAll('a').forEach((item) => item.addEventListener('click', () => setOpen(false)));
       document.addEventListener('click', (event) => { if (!nav.contains(event.target)) setOpen(false); });
       document.addEventListener('keydown', (event) => { if (event.key === 'Escape') setOpen(false); });
-    })();
+      const status = document.querySelector('[data-ipw-action-status]');
+      document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+        button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+      });
     // Intersection-observer reveal - never window scroll listeners.
     const io = new IntersectionObserver((entries) => {
       for (const e of entries) {
@@ -438,6 +443,7 @@
       }
     }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
     document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+    })();
   </script>
 </body>
 </html>

--- a/apps/server/bundled-templates/ipollowork.html-anything.web-proto-soft/entry.html
+++ b/apps/server/bundled-templates/ipollowork.html-anything.web-proto-soft/entry.html
@@ -408,13 +408,14 @@
     /* ============ MOTION ENTRY ============ */
     .reveal { opacity: 0; transform: translateY(18px); filter: blur(6px); transition: opacity 800ms var(--ease), transform 800ms var(--ease), filter 800ms var(--ease); }
     .reveal.is-in { opacity: 1; transform: none; filter: none; }
+    .action-status { min-height: 24px; margin: 18px auto; padding-inline: 18px; text-align: center; color: var(--accent); font-weight: 650; }
     @media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; filter: none; transition: none; } }
   </style>
 <link rel="stylesheet" href="design-tokens.css"></head>
 <body><div class="ipw-brand-slot" data-ipw-brand-slot><img src="assets/ipollowork-logo.svg" alt="iPolloWork logo" data-ipw-logo><span data-ipw-text="brand.name">iPolloWork</span></div>
   <div class="mesh" aria-hidden="true"></div>
 
-  <div class="nav-shell" data-od-id="topnav">
+  <div class="nav-shell" id="topnav" data-od-id="topnav">
     <header class="nav">
       <span class="brand"><span class="brand-mark"></span>Halcyon</span>
       <ul>
@@ -425,7 +426,7 @@
         <li class="mobile-cta"><a href="#docs">Get started</a></li>
       </ul>
       <button class="mobile-nav-toggle" type="button" aria-label="Open navigation" aria-expanded="false"><span></span></button>
-      <button class="pill">
+      <button type="button" class="pill" data-ipw-action-message="Getting-started flow opened. Connect this button to your signup page.">
         <span>Get started</span>
         <span class="icon-wrap"><svg viewBox="0 0 12 12" stroke-width="1.6"><path d="M2.5 6h7M6 2.5L9.5 6 6 9.5"/></svg></span>
       </button>
@@ -439,13 +440,11 @@
         <h1>Calmer infrastructure for the agents <span class="soft">already running your business.</span></h1>
         <p class="lede">Halcyon is a runtime for long-running AI agents that need stable identity, predictable cost, and an audit trail you can hand to legal. We replace the YAML scaffolding teams keep rebuilding from scratch.</p>
         <div class="actions">
-          <button class="pill">
+          <button type="button" class="pill" data-ipw-action-message="Console preview opened. Connect this button to your application console.">
             <span>Open the console</span>
             <span class="icon-wrap"><svg viewBox="0 0 12 12" stroke-width="1.6"><path d="M2.5 6h7M6 2.5L9.5 6 6 9.5"/></svg></span>
           </button>
-          <button class="ghost">
-            Read the runtime spec
-          </button>
+          <a class="ghost" href="#bento">Read the runtime spec</a>
         </div>
       </div>
 
@@ -549,29 +548,30 @@
       </div>
     </section>
 
-    <section class="marquee reveal">
+    <section class="marquee reveal" id="metrics">
       <div class="marquee-track">
         <span class="marquee-item">Anthropic<em>·</em>Stripe<em>·</em>Linear<em>·</em>Vercel<em>·</em>Cursor<em>·</em>Brex<em>·</em>Ramp<em>·</em>Replicate<em>·</em>Hex<em>·</em>Notion<em>·</em></span>
         <span class="marquee-item" aria-hidden="true">Anthropic<em>·</em>Stripe<em>·</em>Linear<em>·</em>Vercel<em>·</em>Cursor<em>·</em>Brex<em>·</em>Ramp<em>·</em>Replicate<em>·</em>Hex<em>·</em>Notion<em>·</em></span>
       </div>
     </section>
 
-    <section class="closing reveal" data-od-id="closing">
+    <section class="closing reveal" id="docs" data-od-id="closing">
       <div class="closing-inner">
         <h2>Less duct tape between the model and the bill.</h2>
         <p>14-day evaluation, then choose pay-as-you-go or annual. We'll send a real engineer for setup. No SDR funnel.</p>
-        <button class="pill">
+        <button type="button" class="pill" data-ipw-action-message="Engineer conversation prepared. Connect this button to your contact form.">
           <span>Talk to an engineer</span>
           <span class="icon-wrap"><svg viewBox="0 0 12 12" stroke-width="1.6"><path d="M2.5 6h7M6 2.5L9.5 6 6 9.5"/></svg></span>
         </button>
       </div>
     </section>
   </main>
+  <p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>
 
-  <footer>
+  <footer id="changelog">
     <div class="row">
       <span>Halcyon Runtime · SOC 2 · ISO 27001 · v2026.05</span>
-      <span><a href="#">Docs</a> · <a href="#">Changelog</a> · <a href="#">Status</a> · <a href="#">Privacy</a> · <a href="#">Contact</a></span>
+      <span><a href="#docs">Docs</a> · <a href="#changelog">Changelog</a> · <a href="#metrics">Status</a> · <a href="#topnav">Privacy</a> · <a href="#docs">Contact</a></span>
     </div>
   </footer>
 
@@ -589,13 +589,17 @@
       nav.querySelectorAll('a').forEach((item) => item.addEventListener('click', () => setOpen(false)));
       document.addEventListener('click', (event) => { if (!nav.contains(event.target)) setOpen(false); });
       document.addEventListener('keydown', (event) => { if (event.key === 'Escape') setOpen(false); });
-    })();
+      const status = document.querySelector('[data-ipw-action-status]');
+      document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+        button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+      });
     const io = new IntersectionObserver((entries) => {
       for (const e of entries) {
         if (e.isIntersecting) { e.target.classList.add('is-in'); io.unobserve(e.target); }
       }
     }, { threshold: 0.1, rootMargin: '0px 0px -10% 0px' });
     document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+    })();
   </script>
 </body>
 </html>

--- a/apps/server/bundled-templates/ipollowork.saas-landing/entry.html
+++ b/apps/server/bundled-templates/ipollowork.saas-landing/entry.html
@@ -51,6 +51,7 @@
     .closing h2 { font-size: 38px; letter-spacing: -0.02em; margin: 0 0 14px; }
     .closing p { opacity: 0.85; margin: 0 0 28px; }
     .closing button { background: white; color: var(--accent); border: none; }
+    .action-status { min-height: 24px; margin: 22px auto; padding: 0 18px; text-align: center; color: var(--accent); font-weight: 600; }
     footer { padding: 28px 0; color: var(--muted); font-size: 13px; text-align: center; }
     .mobile-nav-toggle { position: relative; display: none; width: 38px; height: 38px; padding: 0; place-items: center; border: 1px solid var(--border); background: color-mix(in srgb, var(--surface) 78%, transparent); color: var(--fg); }
     .mobile-nav-toggle span, .mobile-nav-toggle::before, .mobile-nav-toggle::after { content: ""; position: absolute; left: 10px; display: block; width: 16px; height: 1.5px; border-radius: 2px; background: currentColor; transition: top .2s ease, transform .2s ease, opacity .2s ease; }
@@ -87,15 +88,15 @@
         <a href="#features">Features</a>
         <a href="#pricing">Pricing</a>
         <a href="#docs">Docs</a>
-        <button class="btn-secondary" style="margin-left: 12px;">Sign in</button>
+        <button type="button" class="btn-secondary" style="margin-left: 12px;" data-ipw-action-message="Sign-in demo opened. Connect this button to your authentication page.">Sign in</button>
       </nav>
     </header>
     <section class="hero" data-od-id="hero">
       <h1>File sync that doesn't eat your bandwidth.</h1>
       <p>Block-level deltas, end-to-end encryption, and a pricing model that doesn't punish you for working with video.</p>
       <div class="cta">
-        <button class="btn-primary">Get Filebase</button>
-        <button class="btn-link">Read the whitepaper →</button>
+        <button type="button" class="btn-primary" data-ipw-action-message="Trial selected. Connect this button to your signup flow.">Get Filebase</button>
+        <button type="button" class="btn-link" data-ipw-action-message="Whitepaper requested. Connect this button to your document download.">Read the whitepaper →</button>
       </div>
     </section>
   </div>
@@ -138,7 +139,7 @@
           <li>Block-level sync</li>
           <li>Email support</li>
         </ul>
-        <button class="btn-secondary" style="width: 100%;">Choose Solo</button>
+        <button type="button" class="btn-secondary" style="width: 100%;" data-ipw-action-message="Solo plan selected. Connect this button to your checkout flow.">Choose Solo</button>
       </div>
       <div class="tier featured">
         <h3>Team</h3>
@@ -150,7 +151,7 @@
           <li>Priority support</li>
           <li>Audit log</li>
         </ul>
-        <button class="btn-primary" style="width: 100%;">Choose Team</button>
+        <button type="button" class="btn-primary" style="width: 100%;" data-ipw-action-message="Team plan selected. Connect this button to your checkout flow.">Choose Team</button>
       </div>
       <div class="tier">
         <h3>Enterprise</h3>
@@ -161,7 +162,7 @@
           <li>SAML / SCIM</li>
           <li>Dedicated support</li>
         </ul>
-        <button class="btn-secondary" style="width: 100%;">Talk to sales</button>
+        <button type="button" class="btn-secondary" style="width: 100%;" data-ipw-action-message="Sales request started. Connect this button to your contact form.">Talk to sales</button>
       </div>
     </div>
   </section>
@@ -170,10 +171,11 @@
     <div class="wrap">
       <h2>Sync less, ship more.</h2>
       <p>14-day free trial. No credit card needed.</p>
-      <button>Get Filebase</button>
+      <button type="button" data-ipw-action-message="Trial selected. Connect this button to your signup flow.">Get Filebase</button>
     </div>
   </section>
 
+  <p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>
   <footer class="wrap" data-od-id="footer">© Filebase · Privacy · Terms · Status</footer>
   <script>
     (() => {
@@ -189,6 +191,10 @@
       header.querySelectorAll('nav a, nav button').forEach((item) => item.addEventListener('click', () => setOpen(false)));
       document.addEventListener('click', (event) => { if (!header.contains(event.target)) setOpen(false); });
       document.addEventListener('keydown', (event) => { if (event.key === 'Escape') setOpen(false); });
+      const status = document.querySelector('[data-ipw-action-status]');
+      document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+        button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+      });
     })();
   </script>
 </body>

--- a/apps/server/src/templates.test.ts
+++ b/apps/server/src/templates.test.ts
@@ -78,6 +78,57 @@ function importedTemplateId(id: string) {
   return `test.${id.replace(/^ipollowork\./, "")}`;
 }
 
+function htmlAttribute(tag: string, name: string) {
+  return tag.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*["']([^"']*)["']`, "i"))?.[1]?.trim() ?? "";
+}
+
+function websiteInteractionProblems(entry: string) {
+  const ids = new Set(Array.from(entry.matchAll(/\sid=["']([^"']+)["']/gi), (match) => match[1]));
+  const buttons = Array.from(entry.matchAll(/<button\b[^>]*>/gi), (match) => match[0]);
+  const links = Array.from(entry.matchAll(/<a\b[^>]*>/gi), (match) => match[0]);
+  const scripts = Array.from(
+    entry.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+    (match) => match[1],
+  );
+  const inertButtons = buttons.filter((tag) => {
+    const type = htmlAttribute(tag, "type");
+    return !(
+      tag.includes("mobile-nav-toggle")
+      || type === "submit"
+      || htmlAttribute(tag, "data-ipw-action-message")
+      || htmlAttribute(tag, "data-ipw-toggle")
+    );
+  });
+  const badLinks = links.filter((tag) => {
+    const href = htmlAttribute(tag, "href");
+    return !href || href === "#" || (href.startsWith("#") && !ids.has(href.slice(1)));
+  });
+  const fallbackButtons = buttons.filter((tag) => htmlAttribute(tag, "data-ipw-action-message"));
+  const scriptIsIsolated = (script: string) => /^\s*\(\(\)\s*=>\s*\{[\s\S]*\}\)\(\);?\s*$/.test(script);
+  return {
+    inertButtons,
+    badLinks,
+    hasFallbackStatus: fallbackButtons.length === 0 || /<(?:p|div)\b[^>]*(?:role=["']status["']|aria-live=["']polite["'])/i.test(entry),
+    scriptsParseTogether: (() => {
+      try { new Function(scripts.join("\n")); return true; } catch { return false; }
+    })(),
+    scriptsAreIsolated: scripts.every(scriptIsIsolated),
+  };
+}
+
+function interactiveButton(dataset: Record<string, string>) {
+  const attributes = new Map<string, string>();
+  const listeners = new Map<string, () => void>();
+  return {
+    dataset,
+    attributes,
+    listeners,
+    classList: { toggle: (_name: string, _active: boolean) => undefined },
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+    addEventListener: (type: string, listener: () => void) => listeners.set(type, listener),
+  };
+}
+
 async function readPackageFiles(root: string, relative = ""): Promise<Record<string, Buffer>> {
   const files: Record<string, Buffer> = {};
   for (const entry of await readdir(join(root, relative), { withFileTypes: true })) {
@@ -261,7 +312,7 @@ describe("template installations", () => {
     }
   });
 
-  test("ships every website template with an explicit mobile layout and accessible navigation", async () => {
+  test("ships every website template with accessible navigation and observable actions", async () => {
     const directories = (await readdir(bundledTemplatesRoot)).filter((name) => !name.startsWith("."));
     const websites: Array<{ manifest: TemplateManifestV1; entry: string }> = [];
     for (const directory of directories) {
@@ -280,7 +331,88 @@ describe("template installations", () => {
         expect(entry).toContain('aria-expanded="false"');
       }
       expect(manifest.minimumAppVersion).toBeTruthy();
+      const problems = websiteInteractionProblems(entry);
+      expect(problems.inertButtons).toEqual([]);
+      expect(problems.badLinks).toEqual([]);
+      expect(problems.hasFallbackStatus).toBe(true);
+      expect(problems.scriptsParseTogether).toBe(true);
+      expect(problems.scriptsAreIsolated).toBe(true);
+      if (manifest.id === "ipollowork.html-anything.prototype-web") {
+        expect(entry).toContain('data-ipw-action-message="Demo only — no video is connected yet. Add your product video before publishing."');
+      }
+      if (manifest.id === "ipollowork.html-anything.waitlist-page") {
+        expect(entry).not.toContain("You're on the list!");
+        expect(entry).toContain("Demo only — no information was sent. Connect this form to your signup service before publishing.");
+      }
     }
+  });
+
+  test("runs website toggle and fallback interactions without leaking globals", async () => {
+    const entry = await readFile(join(bundledTemplatesRoot, "ipollowork.html-anything.pricing-page", "entry.html"), "utf8");
+    const scripts = Array.from(
+      entry.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+      (match) => match[1],
+    );
+    const script = scripts.at(-1);
+    if (!script) throw new Error("Pricing interaction script is missing");
+
+    const monthly = interactiveButton({ ipwToggle: "monthly" });
+    const yearly = interactiveButton({ ipwToggle: "yearly" });
+    const team = interactiveButton({ ipwActionMessage: "Team plan selected. Connect this button to your checkout flow." });
+    const status = { textContent: "" };
+    const soloSuffix = { textContent: "/ month" };
+    const teamSuffix = { textContent: "/ seat / month" };
+    const soloPrice = { dataset: { monthly: "$8", yearly: "$80" }, firstChild: { textContent: "$8 " }, querySelector: () => soloSuffix };
+    const teamPrice = { dataset: { monthly: "$14", yearly: "$140" }, firstChild: { textContent: "$14 " }, querySelector: () => teamSuffix };
+    const documentFixture = {
+      querySelector: (selector: string) => selector === "[data-ipw-action-status]" ? status : null,
+      querySelectorAll: (selector: string) => {
+        if (selector === "[data-ipw-toggle]") return [monthly, yearly];
+        if (selector === ".price[data-monthly][data-yearly]") return [soloPrice, teamPrice];
+        if (selector === "[data-ipw-action-message]") return [team];
+        return [];
+      },
+    };
+
+    new Function("document", script)(documentFixture);
+    yearly.listeners.get("click")?.();
+    team.listeners.get("click")?.();
+
+    expect(yearly.attributes.get("aria-pressed")).toBe("true");
+    expect(monthly.attributes.get("aria-pressed")).toBe("false");
+    expect(soloPrice.firstChild.textContent).toBe("$80 ");
+    expect(soloSuffix.textContent).toBe("/ year");
+    expect(status.textContent).toBe("Team plan selected. Connect this button to your checkout flow.");
+  });
+
+  test("submits the waitlist form with visible success feedback", async () => {
+    const entry = await readFile(join(bundledTemplatesRoot, "ipollowork.html-anything.waitlist-page", "entry.html"), "utf8");
+    const script = Array.from(
+      entry.matchAll(/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi),
+      (match) => match[1],
+    ).at(-1);
+    if (!script) throw new Error("Waitlist interaction script is missing");
+
+    let submit: ((event: { preventDefault: () => void }) => void) | undefined;
+    let prevented = false;
+    let visible = false;
+    const form = {
+      style: { display: "block" },
+      checkValidity: () => true,
+      reportValidity: () => undefined,
+      addEventListener: (_type: string, listener: typeof submit) => { submit = listener; },
+    };
+    const success = { classList: { add: (name: string) => { visible = name === "visible"; } } };
+    const documentFixture = {
+      getElementById: (id: string) => id === "waitlist-form" ? form : id === "success-msg" ? success : null,
+    };
+
+    new Function("document", script)(documentFixture);
+    submit?.call(form, { preventDefault: () => { prevented = true; } });
+
+    expect(prevented).toBe(true);
+    expect(form.style.display).toBe("none");
+    expect(visible).toBe(true);
   });
 
   test("ships every bundled template with a real 960 by 540 PNG cover", async () => {

--- a/docs/superpowers/plans/2026-07-21-website-template-cta-interactions.md
+++ b/docs/superpowers/plans/2026-07-21-website-template-cta-interactions.md
@@ -1,0 +1,708 @@
+# Website Template CTA Interactions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every visually actionable control in all nine bundled `site` templates produce an observable, accessible result.
+
+**Architecture:** Keep behavior inside each self-contained template: native links and forms remain native, explicit `data-ipw-action-message` attributes identify demonstration-only calls to action, and one isolated inline runtime updates a shared `role="status"` element. Extend the server template-market test as the catalog admission gate, then prove representative interactions through the production Design preview with fraimz.
+
+**Tech Stack:** Static HTML/CSS/JavaScript templates, TypeScript, Bun test, Electron/Chromium CDP, iPolloWork fraimz.
+
+## Global Constraints
+
+- Every control that visually presents itself as actionable must produce an observable result.
+- Prefer real navigation, toggle, or form semantics; use fallback acknowledgement only when no real destination exists.
+- Fallback acknowledgement must be visible and exposed through `role="status"` or `aria-live="polite"`; do not use browser `alert`.
+- Fallback messages must not claim that an account, purchase, or external request completed.
+- Repeated activations update one status region instead of creating duplicate UI.
+- Every button has an explicit `type`; no button may accidentally submit a surrounding form.
+- All template scripts execute inside an isolated function scope and must parse together in document order.
+- Do not add backend signup, authentication, billing, or sales integrations.
+- Do not change slide, poster, app, or video templates.
+- Preserve unrelated dirty-worktree changes and use `pnpm`, never npm or yarn.
+
+---
+
+### Task 1: Add the website-template interaction admission gate
+
+**Files:**
+- Modify: `apps/server/src/templates.test.ts:269`
+
+**Interfaces:**
+- Consumes: bundled `TemplateManifestV1` manifests and their `entry.html` files.
+- Produces: one catalog test that rejects inert buttons, empty or broken fragment links, unisolated inline scripts, and missing fallback status regions.
+
+- [ ] **Step 1: Replace the current website structural test with a failing interaction contract**
+
+Add these helpers above the test suite:
+
+```ts
+function attribute(tag: string, name: string) {
+  return tag.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*["']([^"']*)["']`, "i"))?.[1]?.trim() ?? "";
+}
+
+function websiteInteractionProblems(entry: string) {
+  const ids = new Set(Array.from(entry.matchAll(/\\bid=["']([^"']+)["']/gi), (match) => match[1]));
+  const buttons = Array.from(entry.matchAll(/<button\\b[^>]*>/gi), (match) => match[0]);
+  const links = Array.from(entry.matchAll(/<a\\b[^>]*>/gi), (match) => match[0]);
+  const scripts = Array.from(
+    entry.matchAll(/<script(?![^>]*\\bsrc=)[^>]*>([\\s\\S]*?)<\\/script>/gi),
+    (match) => match[1],
+  );
+  const inertButtons = buttons.filter((tag) => {
+    const type = attribute(tag, "type");
+    return !(
+      tag.includes("mobile-nav-toggle")
+      || type === "submit"
+      || attribute(tag, "data-ipw-action-message")
+      || attribute(tag, "data-ipw-toggle")
+    );
+  });
+  const badLinks = links.filter((tag) => {
+    const href = attribute(tag, "href");
+    return !href || href === "#" || (href.startsWith("#") && !ids.has(href.slice(1)));
+  });
+  const fallbackButtons = buttons.filter((tag) => attribute(tag, "data-ipw-action-message"));
+  return {
+    inertButtons,
+    badLinks,
+    hasFallbackStatus: fallbackButtons.length === 0 || /<(?:p|div)\\b[^>]*(?:role=["']status["']|aria-live=["']polite["'])/i.test(entry),
+    scriptsParseTogether: (() => {
+      try { new Function(scripts.join("\\n")); return true; } catch { return false; }
+    })(),
+    scriptsAreIsolated: scripts.every((script) => script.trimStart().startsWith("(() => {")),
+  };
+}
+```
+
+Replace the existing website test body with:
+
+```ts
+test("ships every website template with accessible navigation and observable actions", async () => {
+  const directories = (await readdir(bundledTemplatesRoot)).filter((name) => !name.startsWith("."));
+  const websites: Array<{ manifest: TemplateManifestV1; entry: string }> = [];
+  for (const directory of directories) {
+    const root = join(bundledTemplatesRoot, directory);
+    const manifest = JSON.parse(await readFile(join(root, "manifest.json"), "utf8")) as TemplateManifestV1;
+    if (manifest.category !== "site") continue;
+    websites.push({ manifest, entry: await readFile(join(root, manifest.entry), "utf8") });
+  }
+  expect(websites).toHaveLength(9);
+  for (const { manifest, entry } of websites) {
+    expect(entry).toContain('name="viewport"');
+    expect(entry).toContain('data-ipw-mobile-ready="true"');
+    expect(entry).toMatch(/@media\\s*\\(max-width:/);
+    if (/<nav\\b|<header\\s+class="nav"/.test(entry)) {
+      expect(entry).toContain("mobile-nav-toggle");
+      expect(entry).toContain('aria-expanded="false"');
+    }
+    expect(manifest.minimumAppVersion).toBeTruthy();
+    const problems = websiteInteractionProblems(entry);
+    expect(problems.inertButtons).toEqual([]);
+    expect(problems.badLinks).toEqual([]);
+    expect(problems.hasFallbackStatus).toBe(true);
+    expect(problems.scriptsParseTogether).toBe(true);
+    expect(problems.scriptsAreIsolated).toBe(true);
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused test and confirm the admission gate fails for existing inert controls**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions"
+```
+
+Expected: FAIL at `problems.inertButtons` and `problems.badLinks`; the output names the existing unannotated buttons and `href="#"` or missing fragment destinations.
+
+- [ ] **Step 3: Commit the red test only**
+
+```powershell
+git add apps/server/src/templates.test.ts
+git commit -m "test: require interactive website template actions"
+```
+
+---
+
+### Task 2: Make pricing and SaaS template actions observable
+
+**Files:**
+- Modify: `apps/server/bundled-templates/ipollowork.html-anything.pricing-page/entry.html:75`
+- Modify: `apps/server/bundled-templates/ipollowork.html-anything.saas-landing/entry.html:85`
+- Modify: `apps/server/bundled-templates/ipollowork.saas-landing/entry.html:85`
+- Test: `apps/server/src/templates.test.ts`
+
+**Interfaces:**
+- Consumes: `data-ipw-toggle="monthly|yearly"` for pricing switches and `data-ipw-action-message="..."` for demonstration-only CTAs.
+- Produces: `.price[data-monthly][data-yearly]` values, one `[data-ipw-action-status]` live region per template, and isolated event listeners that update selection, prices, or status text.
+
+- [ ] **Step 1: Add a failing focused assertion for real toggle and fallback hooks**
+
+Inside the website catalog test, after loading each entry, add:
+
+```ts
+if (manifest.id === "ipollowork.html-anything.pricing-page") {
+  expect(entry).toContain('data-ipw-toggle="monthly"');
+  expect(entry).toContain('data-ipw-toggle="yearly"');
+  expect(entry).toContain("data-monthly");
+  expect(entry).toContain("data-yearly");
+}
+if (manifest.id === "ipollowork.saas-landing" || manifest.id === "ipollowork.html-anything.saas-landing") {
+  expect(entry).toContain('data-ipw-action-message="Sign-in demo opened. Connect this button to your authentication page."');
+  expect(entry).toContain('data-ipw-action-status');
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify the new assertion fails**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions"
+```
+
+Expected: FAIL because the pricing toggle attributes and SaaS status hooks do not exist.
+
+- [ ] **Step 3: Implement the pricing template's monthly/yearly switch and CTA feedback**
+
+In `ipollowork.html-anything.pricing-page/entry.html`:
+
+- give each button `type="button"`;
+- mark the two billing controls with `data-ipw-toggle="monthly"` and `data-ipw-toggle="yearly"` plus `aria-pressed`;
+- change the two numeric prices to elements with exact pairs `data-monthly="$8" data-yearly="$80"` and `data-monthly="$14" data-yearly="$140"`;
+- mark plan buttons with the exact messages below;
+- add `<p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>` after the tier section;
+- add status styling and this isolated runtime before `</body>`:
+
+```html
+<script>
+  (() => {
+    const status = document.querySelector('[data-ipw-action-status]');
+    const toggles = document.querySelectorAll('[data-ipw-toggle]');
+    const prices = document.querySelectorAll('.price[data-monthly][data-yearly]');
+    const selectBilling = (period) => {
+      toggles.forEach((button) => {
+        const selected = button.dataset.ipwToggle === period;
+        button.classList.toggle('active', selected);
+        button.setAttribute('aria-pressed', String(selected));
+      });
+      prices.forEach((price) => {
+        price.firstChild.textContent = `${period === 'yearly' ? price.dataset.yearly : price.dataset.monthly} `;
+        const suffix = price.querySelector('small');
+        if (suffix) suffix.textContent = period === 'yearly' ? '/ year' : price.dataset.monthly === '$14' ? '/ seat / month' : '/ month';
+      });
+    };
+    toggles.forEach((button) => button.addEventListener('click', () => selectBilling(button.dataset.ipwToggle)));
+    document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+      button.addEventListener('click', () => { if (status) status.textContent = button.dataset.ipwActionMessage || ''; });
+    });
+  })();
+</script>
+```
+
+Use these fallback messages:
+
+```html
+data-ipw-action-message="Solo plan selected. Connect this button to your checkout flow."
+data-ipw-action-message="Team plan selected. Connect this button to your checkout flow."
+data-ipw-action-message="Sales request started. Connect this button to your contact form."
+```
+
+- [ ] **Step 4: Implement equivalent explicit feedback in both SaaS templates**
+
+In both SaaS entry files:
+
+- add `type="button"` and `data-ipw-action-message` to Sign in, both primary start buttons, the whitepaper button, every plan button, and the sales button;
+- add `id="docs"` to the closing section in the `html-anything` copy so the existing Docs fragment resolves;
+- add `<p class="action-status" data-ipw-action-status role="status" aria-live="polite"></p>` before the footer;
+- append this logic inside the existing IIFE after mobile-navigation listeners:
+
+```js
+const status = document.querySelector('[data-ipw-action-status]');
+document.querySelectorAll('[data-ipw-action-message]').forEach((button) => {
+  button.addEventListener('click', () => {
+    if (status) status.textContent = button.dataset.ipwActionMessage || '';
+  });
+});
+```
+
+Use exact intent-matched messages, including:
+
+```html
+data-ipw-action-message="Sign-in demo opened. Connect this button to your authentication page."
+data-ipw-action-message="Trial selected. Connect this button to your signup flow."
+data-ipw-action-message="Whitepaper requested. Connect this button to your document download."
+data-ipw-action-message="Solo plan selected. Connect this button to your checkout flow."
+data-ipw-action-message="Team plan selected. Connect this button to your checkout flow."
+data-ipw-action-message="Sales request started. Connect this button to your contact form."
+```
+
+- [ ] **Step 5: Run the focused test and confirm this template group passes its assertions**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions"
+```
+
+Expected: the pricing/SaaS-specific assertions PASS; the suite may remain red only for controls in Tasks 3 and 4.
+
+- [ ] **Step 6: Commit the pricing and SaaS behavior**
+
+```powershell
+git add apps/server/src/templates.test.ts apps/server/bundled-templates/ipollowork.html-anything.pricing-page/entry.html apps/server/bundled-templates/ipollowork.html-anything.saas-landing/entry.html apps/server/bundled-templates/ipollowork.saas-landing/entry.html
+git commit -m "fix: make SaaS template actions interactive"
+```
+
+---
+
+### Task 3: Repair prototype navigation and CTA behavior
+
+**Files:**
+- Modify: `apps/server/bundled-templates/ipollowork.html-anything.prototype-web/entry.html:52`
+- Modify: `apps/server/bundled-templates/ipollowork.html-anything.web-proto-editorial/entry.html:268`
+- Modify: `apps/server/bundled-templates/ipollowork.html-anything.web-proto-soft/entry.html:421`
+- Test: `apps/server/src/templates.test.ts`
+
+**Interfaces:**
+- Consumes: existing section ids and `data-ipw-action-message` fallback declarations.
+- Produces: no `href="#"`, no missing fragment destination, explicit button types, and shared accessible status feedback in each prototype.
+
+- [ ] **Step 1: Add a failing assertion that these prototypes contain no placeholder links**
+
+Inside the website catalog loop add:
+
+```ts
+if ([
+  "ipollowork.html-anything.prototype-web",
+  "ipollowork.html-anything.web-proto-editorial",
+  "ipollowork.html-anything.web-proto-soft",
+].includes(manifest.id)) {
+  expect(entry).not.toContain('href="#"');
+  expect(entry).toContain('data-ipw-action-status');
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails on placeholder links**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions"
+```
+
+Expected: FAIL because all three prototypes currently contain placeholder or missing fragment links.
+
+- [ ] **Step 3: Convert `prototype-web` controls to real anchors where destinations exist**
+
+Apply these exact mappings:
+
+```text
+logo -> #top
+desktop About -> #features
+pricing Get started -> #cta
+pricing About -> #features
+pricing Solutions -> #voices
+closing CTA -> #cta
+footer About -> #features
+footer Contact -> #voices
+footer Get started -> #cta
+```
+
+Add `id="top"` to the first hero section. Replace the three pricing `<button>` elements with `<a href="...">` while preserving their class lists. This template then uses native section navigation and needs no fallback status region.
+
+- [ ] **Step 4: Repair editorial prototype navigation and annotate fallback CTAs**
+
+In `web-proto-editorial/entry.html`:
+
+- change Changelog navigation to `href="#bento-history"`;
+- change footer Manual, Changelog, Status, Privacy to existing sections `#bento`, `#bento-history`, `#contrast`, `#pricing`;
+- map Read the manual to a native `<a class="btn-link" href="#bento">`;
+- add `type="button"` and exact `data-ipw-action-message` values to Open workspace, Request access, Start solo, Start studio, and Open a thread;
+- add one `[data-ipw-action-status]` live region before the footer;
+- keep the existing nav and observer code inside its IIFE and append the shared status listener before `})();`.
+
+Use exact messages such as `Workspace preview opened. Connect this button to your app entry point.` and `Access request prepared. Connect this button to your request form.` without claiming external completion.
+
+- [ ] **Step 5: Repair soft prototype navigation and annotate fallback CTAs**
+
+In `web-proto-soft/entry.html`:
+
+- add `id="metrics"` to the marquee section, `id="docs"` to the closing section, and `id="changelog"` to the footer;
+- replace footer `href="#"` values with `#docs`, `#changelog`, `#metrics`, `#topnav`, and `#closing` in displayed order;
+- map Read the runtime spec to `<a class="ghost" href="#bento">`;
+- add `type="button"` and explicit fallback messages to Get started, Open the console, and Talk to an engineer;
+- add one shared live status region before the footer;
+- append the status listener inside the existing IIFE before `})();`.
+
+- [ ] **Step 6: Run the focused test and confirm every website now passes the admission gate**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions"
+```
+
+Expected: the three prototype-specific assertions PASS; the suite remains red only because the waitlist script is not isolated until Task 4.
+
+- [ ] **Step 7: Commit the prototype fixes**
+
+```powershell
+git add apps/server/src/templates.test.ts apps/server/bundled-templates/ipollowork.html-anything.prototype-web/entry.html apps/server/bundled-templates/ipollowork.html-anything.web-proto-editorial/entry.html apps/server/bundled-templates/ipollowork.html-anything.web-proto-soft/entry.html
+git commit -m "fix: wire website prototype entry actions"
+```
+
+---
+
+### Task 4: Isolate the waitlist form and add runtime behavior tests
+
+**Files:**
+- Modify: `apps/server/src/templates.test.ts:269`
+- Modify: `apps/server/bundled-templates/ipollowork.html-anything.waitlist-page/entry.html:406`
+- Verify unchanged: `apps/server/bundled-templates/ipollowork.html-anything.web-proto-brutalist/entry.html`
+- Verify unchanged: `apps/server/bundled-templates/ipollowork.html-anything.wireframe-sketch/entry.html`
+
+**Interfaces:**
+- Consumes: the final nine website entries and Bun's ability to execute isolated runtime snippets with a minimal DOM fixture.
+- Produces: an isolated waitlist form runtime plus focused behavior coverage for navigation declarations, pricing toggle state, valid form submission, and fallback CTA status updates.
+
+- [ ] **Step 1: Add focused behavior assertions for the native controls**
+
+Add a separate test:
+
+```ts
+test("keeps native website interactions explicit", async () => {
+  const waitlist = await readFile(join(bundledTemplatesRoot, "ipollowork.html-anything.waitlist-page", "entry.html"), "utf8");
+  const brutalist = await readFile(join(bundledTemplatesRoot, "ipollowork.html-anything.web-proto-brutalist", "entry.html"), "utf8");
+  const wireframe = await readFile(join(bundledTemplatesRoot, "ipollowork.html-anything.wireframe-sketch", "entry.html"), "utf8");
+  expect(waitlist).toContain('id="waitlist-form"');
+  expect(waitlist).toContain("checkValidity()");
+  expect(waitlist).toContain("success-msg");
+  expect(brutalist).toContain('href="#abstract"');
+  expect(brutalist).toContain('href="#specimen"');
+  expect(brutalist).toContain("mobile-nav-toggle");
+  expect(wireframe).not.toMatch(/<button\\b|<a\\b/i);
+});
+```
+
+- [ ] **Step 2: Run the website tests and confirm the isolation gate fails on the waitlist script**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions|native website interactions"
+```
+
+Expected: the native-interaction assertions PASS, while the admission gate fails at `scriptsAreIsolated` for the waitlist template.
+
+- [ ] **Step 3: Wrap the waitlist submit handler in an isolated scope**
+
+Replace its inline script with:
+
+```html
+<script>
+  (() => {
+    const form = document.getElementById('waitlist-form');
+    if (!form) return;
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      if (!this.checkValidity()) {
+        this.reportValidity();
+        return;
+      }
+      this.style.display = 'none';
+      document.getElementById('success-msg')?.classList.add('visible');
+    });
+  })();
+</script>
+```
+
+- [ ] **Step 4: Add a runtime test for the pricing switch and fallback status listener**
+
+Add this test fixture and test inside `templates.test.ts`; it extracts the final inline script from `pricing-page`, executes it against local test doubles, and invokes the captured yearly and CTA click handlers:
+
+```ts
+function interactiveButton(dataset: Record<string, string>) {
+  const attributes = new Map<string, string>();
+  const listeners = new Map<string, () => void>();
+  return {
+    dataset,
+    attributes,
+    listeners,
+    classList: { toggle: (_name: string, _active: boolean) => undefined },
+    setAttribute: (name: string, value: string) => attributes.set(name, value),
+    addEventListener: (type: string, listener: () => void) => listeners.set(type, listener),
+  };
+}
+
+test("runs website toggle and fallback interactions without leaking globals", async () => {
+  const entry = await readFile(
+    join(bundledTemplatesRoot, "ipollowork.html-anything.pricing-page", "entry.html"),
+    "utf8",
+  );
+  const scripts = Array.from(
+    entry.matchAll(/<script(?![^>]*\\bsrc=)[^>]*>([\\s\\S]*?)<\\/script>/gi),
+    (match) => match[1],
+  );
+  const script = scripts.at(-1);
+  if (!script) throw new Error("Pricing interaction script is missing");
+
+  const monthly = interactiveButton({ ipwToggle: "monthly" });
+  const yearly = interactiveButton({ ipwToggle: "yearly" });
+  const team = interactiveButton({ ipwActionMessage: "Team plan selected. Connect this button to your checkout flow." });
+  const status = { textContent: "" };
+  const soloSuffix = { textContent: "/ month" };
+  const teamSuffix = { textContent: "/ seat / month" };
+  const soloPrice = {
+    dataset: { monthly: "$8", yearly: "$80" },
+    firstChild: { textContent: "$8 " },
+    querySelector: (selector: string) => selector === "small" ? soloSuffix : null,
+  };
+  const teamPrice = {
+    dataset: { monthly: "$14", yearly: "$140" },
+    firstChild: { textContent: "$14 " },
+    querySelector: (selector: string) => selector === "small" ? teamSuffix : null,
+  };
+  const documentFixture = {
+    querySelector: (selector: string) => selector === "[data-ipw-action-status]" ? status : null,
+    querySelectorAll: (selector: string) => {
+      if (selector === "[data-ipw-toggle]") return [monthly, yearly];
+      if (selector === ".price[data-monthly][data-yearly]") return [soloPrice, teamPrice];
+      if (selector === "[data-ipw-action-message]") return [team];
+      return [];
+    },
+  };
+
+  new Function("document", script)(documentFixture);
+  yearly.listeners.get("click")?.();
+  team.listeners.get("click")?.();
+
+expect(yearly.attributes.get("aria-pressed")).toBe("true");
+expect(monthly.attributes.get("aria-pressed")).toBe("false");
+expect(soloPrice.firstChild.textContent).toBe("$80 ");
+expect(status.textContent).toBe("Team plan selected. Connect this button to your checkout flow.");
+});
+```
+
+Do not add a browser DOM dependency.
+
+- [ ] **Step 5: Run both focused interaction tests**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "website toggle|native website"
+```
+
+Expected: 2 PASS, 0 FAIL.
+
+- [ ] **Step 6: Run the complete server template suite**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts
+```
+
+Expected: all template tests PASS with no syntax error or unhandled rejection.
+
+- [ ] **Step 7: Commit the isolated form and behavior coverage**
+
+```powershell
+git add apps/server/src/templates.test.ts apps/server/bundled-templates/ipollowork.html-anything.waitlist-page/entry.html
+git commit -m "test: cover website template interactions"
+```
+
+---
+
+### Task 5: Prove the real Design-preview interaction path with fraimz
+
+**Files:**
+- Modify: `apps/app/src/react-app/domains/session/chat/session-page.tsx:1040`
+- Modify: `apps/app/tests/design-html-runtime.test.ts:1`
+- Create: `evals/voiceovers/website-template-actions.md`
+- Create: `evals/flows/website-template-actions.flow.mjs`
+
+**Interfaces:**
+- Consumes: the existing development-only `window.__ipolloworkControl` API and the production `ipollowork.saas-landing` materialization path.
+- Produces: development action `eval.design.seed_website_actions` returning `{ path: string }` and fraimz frames proving a native section link and fallback CTA acknowledgement inside the real Design iframe.
+
+- [ ] **Step 1: Add a failing source-level test for the new deterministic eval action**
+
+In `apps/app/tests/design-html-runtime.test.ts`, add:
+
+```ts
+test("keeps the website action eval on the real bundled template path", async () => {
+  const source = await Bun.file(new URL(
+    "../src/react-app/domains/session/chat/session-page.tsx",
+    import.meta.url,
+  )).text();
+  expect(source).toContain('id: "eval.design.seed_website_actions"');
+  expect(source).toContain('"ipollowork.saas-landing"');
+  const actionStart = source.indexOf('id: "eval.design.seed_website_actions"');
+  const actionEnd = source.indexOf('id: "eval.design.seed_deck"', actionStart);
+  expect(source.slice(actionStart, actionEnd)).not.toContain("const content = `<!doctype html>");
+});
+```
+
+- [ ] **Step 2: Run the focused app test and confirm it fails because the action does not exist**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test tests/design-html-runtime.test.ts --test-name-pattern "website action eval"
+```
+
+Expected: FAIL because `eval.design.seed_website_actions` is absent.
+
+- [ ] **Step 3: Add the deterministic development-only control action**
+
+Next to `seedDesignHtmlControlAction`, add `seedWebsiteActionsControlAction` with:
+
+```ts
+const seedWebsiteActionsControlAction = useMemo<iPolloWorkControlAction | null>(() => {
+  if (!import.meta.env.DEV) return null;
+  return {
+    id: "eval.design.seed_website_actions",
+    label: "Seed interactive website template",
+    description: "Materialize the bundled interactive website template in Design.",
+    sideEffect: "mutation",
+    disabled: !props.ipolloworkServerClient || !props.runtimeWorkspaceId || !props.selectedSessionId || props.selectedWorkspaceDisplay.workspaceType === "remote",
+    execute: async () => {
+      if (!props.ipolloworkServerClient || !props.runtimeWorkspaceId || !props.selectedSessionId) {
+        return { ok: false, error: "Workspace client is not ready." };
+      }
+      await props.ipolloworkServerClient.installTemplate(props.runtimeWorkspaceId, "ipollowork.saas-landing");
+      const materialized = await props.ipolloworkServerClient.materializeTemplate(
+        props.runtimeWorkspaceId,
+        "ipollowork.saas-landing",
+        props.selectedSessionId,
+      );
+      setSessionType(props.selectedSessionId, sessionTypeForTemplate(materialized.manifest));
+      setTemplateSessionData({ ...materialized, hasBrief: true });
+      setSessionTypeRevision((value) => value + 1);
+      setTemplateSessionRevision((value) => value + 1);
+      setCurrentSidePanel("design");
+      return { ok: true, path: materialized.state.entry };
+    },
+  };
+}, [props.ipolloworkServerClient, props.runtimeWorkspaceId, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, setCurrentSidePanel]);
+```
+
+Register it beside the existing eval actions in the control action array. Do not write or replace template HTML.
+
+- [ ] **Step 4: Run the focused app test and verify it passes**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test tests/design-html-runtime.test.ts --test-name-pattern "website action eval"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the approved two-frame voiceover**
+
+Create `evals/voiceovers/website-template-actions.md`:
+
+```markdown
+# website-template-actions — bundled website controls respond in Design
+
+1. I open the bundled SaaS website in Design and use its Pricing navigation; the real page moves to the pricing section instead of ignoring the click.
+
+2. I choose the Team plan and the template immediately acknowledges the selection in the page, without pretending that a purchase completed.
+```
+
+- [ ] **Step 6: Implement the fraimz flow against the real Design iframe**
+
+Create `evals/flows/website-template-actions.flow.mjs` using `design-html-editor.flow.mjs`'s `withPreviewClient` pattern. The flow must:
+
+1. create a task and wait for `eval.design.seed_website_actions`;
+2. execute it and wait for `[data-testid="design-panel"] iframe` to load;
+3. connect to the `about:srcdoc` iframe target;
+4. click `a[href="#pricing"]`, assert `document.getElementById("pricing")` exists and the active scroll position changed toward it, and capture a screenshot;
+5. click `[data-ipw-action-message^="Team plan selected"]`, assert `[data-ipw-action-status].textContent` equals the declared message, and capture a screenshot.
+
+Use `loadVoiceoverParagraphs("website-template-actions")`, `ctx.prove`, and observable assertions in both frames.
+
+- [ ] **Step 7: Run unit/type validation before the UI proof**
+
+Run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test tests/design-html-runtime.test.ts
+& 'C:\Users\Lenovo\AppData\Roaming\npm\pnpm.cmd' --filter @ipollowork/app typecheck
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 8: Run fraimz against a development Electron app**
+
+With the app running on its configured CDP port, run:
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\pnpm.cmd' fraimz --flow website-template-actions --cdp-url http://127.0.0.1:9823
+```
+
+Expected: verdict `PASSED`, two validated screenshot frames, and a reported `evals/results/<run-id>/fraimz.html` path. If the local Electron app cannot be started, report the proof as `Incomplete` with this exact reproduction command; do not claim end-to-end success.
+
+- [ ] **Step 9: Commit the production-path proof harness**
+
+```powershell
+git add apps/app/src/react-app/domains/session/chat/session-page.tsx apps/app/tests/design-html-runtime.test.ts evals/voiceovers/website-template-actions.md evals/flows/website-template-actions.flow.mjs
+git commit -m "test: prove website template actions in Design"
+```
+
+---
+
+### Task 6: Final verification and scope audit
+
+**Files:**
+- Verify: all files changed in Tasks 1–5.
+
+**Interfaces:**
+- Consumes: the complete implementation and tests.
+- Produces: a clean, evidence-backed handoff with no unrelated files staged or committed.
+
+- [ ] **Step 1: Run the complete targeted verification set**
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test tests/design-html-runtime.test.ts
+& 'C:\Users\Lenovo\AppData\Roaming\npm\pnpm.cmd' --filter @ipollowork/server typecheck
+& 'C:\Users\Lenovo\AppData\Roaming\npm\pnpm.cmd' --filter @ipollowork/app typecheck
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Check formatting and unintended scope**
+
+```powershell
+git diff --check HEAD~5
+git status --short
+git diff --name-only HEAD~5
+```
+
+Expected: no whitespace errors; changed implementation files are limited to the website templates, template tests, the development-only eval hook, and the new fraimz flow/voiceover. Existing unrelated dirty-worktree files remain untouched and unstaged.
+
+- [ ] **Step 3: Re-run the website script/global-scope check explicitly**
+
+```powershell
+& 'C:\Users\Lenovo\AppData\Roaming\npm\bun.cmd' test src/templates.test.ts --test-name-pattern "observable actions"
+```
+
+Expected: PASS for all nine templates, proving combined inline scripts parse and no inline script exposes a top-level lexical declaration.
+
+- [ ] **Step 4: Record the final evidence**
+
+In the handoff, report:
+
+```text
+- server template test command and pass count
+- app runtime test command and pass count
+- both typecheck commands and exit status
+- fraimz verdict and absolute fraimz.html path, or an explicit Incomplete reason
+- exact list of website templates changed
+```

--- a/docs/superpowers/specs/2026-07-21-website-template-cta-interactions-design.md
+++ b/docs/superpowers/specs/2026-07-21-website-template-cta-interactions-design.md
@@ -1,0 +1,48 @@
+# Website Template CTA Interactions
+
+## Goal
+
+Every control in a bundled website template that visually presents itself as actionable must produce an observable result. A template must not ship with decorative buttons that silently ignore clicks.
+
+This applies to all bundled templates whose manifest category is `site`, including desktop and mobile navigation.
+
+## Interaction Rules
+
+Each actionable control uses the most specific available behavior:
+
+1. Navigation controls scroll to an existing section or open the declared local or external destination.
+2. Toggle controls update their selected state and the content or values they govern.
+3. Forms validate their inputs and show an inline success result after a valid submission.
+4. Calls to action without a real destination show a concise, template-local acknowledgement that matches the label's intent.
+
+The fallback acknowledgement is a visible result, not a browser `alert`. It uses an accessible status element so keyboard and assistive-technology users receive the same feedback. Repeated activations update the same status element instead of creating duplicate UI.
+
+## Template Implementation
+
+Existing native semantics remain the source of truth. Links keep `href`; submit controls remain attached to forms; section links use anchors. A small template-local runtime handles only controls that otherwise have no behavior and interactive demonstrations such as billing-period switches.
+
+Controls declare fallback intent with an explicit data attribute rather than guessing from button text at runtime. This keeps copied or AI-edited templates predictable. Mobile navigation toggles are navigation infrastructure and retain their existing behavior.
+
+All template scripts execute inside an isolated function scope. Templates must not introduce top-level lexical declarations that can conflict with the Design preview runtime or another inline script.
+
+## User Feedback
+
+Fallback feedback appears near the activated control or in one shared page-level status region. It states the observable outcome in plain language, for example that a plan was selected or that a request was received. It does not claim that an account, purchase, or external request was actually completed.
+
+Interaction feedback must be visible, keyboard-operable, and exposed through `role="status"` or `aria-live="polite"`. Buttons receive an explicit `type` so they never submit a surrounding form accidentally.
+
+## Validation
+
+Automated template-market tests cover every bundled `site` template and enforce:
+
+- every visible button has submit, navigation, toggle, or explicit fallback behavior;
+- every link has a non-empty destination;
+- inline scripts parse together in document order without global declaration conflicts;
+- mobile navigation controls retain their accessible expanded state;
+- required fallback status markup and runtime hooks are present when a template uses fallback actions.
+
+Focused behavior tests cover at least one navigation action, one toggle, one valid form submission, and one fallback CTA acknowledgement. The real Design preview is then exercised to confirm the observable interaction path; if the repository's fraimz tooling is unavailable, the limitation and exact manual reproduction steps are reported rather than claiming full end-to-end proof.
+
+## Scope
+
+This change updates bundled website templates and their template validation only. It does not add backend signup, authentication, billing, or sales integrations, and it does not change slide, poster, app, or video templates.


### PR DESCRIPTION
## Summary
- Make bundled website template CTAs interactive.
- Add navigation, pricing toggles, form feedback, and accessible demo states.
- Prevent inert buttons, broken anchors, and global script conflicts.

## Why
Some website templates contained controls that looked clickable but produced no response. Several scripts also exposed ambiguous global variables.

## Issue
- N/A

## Scope
- Updated seven bundled website templates.
- Added accessible `role="status"` feedback.
- Added interaction and template-market regression tests.
- Isolated inline scripts to prevent global conflicts.

## Out of scope
- Authentication, billing, signup, and sales backend integrations.
- Non-website templates.

## Testing

### Ran
```bash
bun test src/templates.test.ts --test-name-pattern "observable actions|website toggle|waitlist form"
pnpm --filter ipollowork-server typecheck