### PR TITLE
fix: recover desktop workspace and cloud settings

### DIFF
--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -159,15 +159,33 @@ export function mergeRouteWorkspaces(
       return path ? [path] : [];
     }),
   );
+  const hasServerLocalWorkspace = filteredServer.some((workspace) => workspace.workspaceType === "local");
 
   const missingDesktop = desktopWorkspaces.filter((workspace) => {
     if (mergedIds.has(workspace.id)) return false;
     const normalizedPath = normalizeDirectoryPath(workspace.path ?? "");
     if (normalizedPath && mergedPaths.has(normalizedPath)) return false;
+    // A running local server has its own persisted workspace registry. A
+    // desktop-only local record cannot be addressed by that server, so showing
+    // it here would make the shell fetch a guaranteed 404. Remote workspaces
+    // remain desktop-owned and must stay visible.
+    if (hasServerLocalWorkspace && workspace.workspaceType === "local") return false;
     return true;
   });
 
   return [...mergedServer, ...missingDesktop];
+}
+
+export function resolveKnownWorkspaceId(
+  workspaces: Array<Pick<RouteWorkspace, "id">>,
+  candidates: Array<string | null | undefined>,
+) {
+  const knownIds = new Set(workspaces.map((workspace) => workspace.id));
+  for (const candidate of candidates) {
+    const id = candidate?.trim() ?? "";
+    if (id && knownIds.has(id)) return id;
+  }
+  return "";
 }
 
 export function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: string[]): RouteWorkspace[] {

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -41,6 +41,7 @@ import {
   mapDesktopWorkspace,
   mergeRouteWorkspaces,
   orderRouteWorkspaces,
+  resolveKnownWorkspaceId,
   type RouteSession,
   type RouteWorkspace,
 } from "./route-workspaces";
@@ -376,17 +377,13 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // the user's last-active workspace from localStorage, the desktop's
       // activeId, the server's activeId, then the first known workspace.
       const persistedActiveId = readActiveWorkspaceId();
-      let nextWorkspaceId =
-        (routeWorkspaceId && nextWorkspaces.some((w) => w.id === routeWorkspaceId)
-          ? routeWorkspaceId
-          : "") ||
-        (persistedActiveId && nextWorkspaces.some((w) => w.id === persistedActiveId)
-          ? persistedActiveId
-          : "") ||
-        resolveWorkspaceListSelectedId(desktopList) ||
-        list.activeId?.trim() ||
-        nextWorkspaces[0]?.id ||
-        "";
+      let nextWorkspaceId = resolveKnownWorkspaceId(nextWorkspaces, [
+        routeWorkspaceId,
+        persistedActiveId,
+        resolveWorkspaceListSelectedId(desktopList),
+        list.activeId,
+        nextWorkspaces[0]?.id,
+      ]);
       if (selectedSessionId) {
         const match = cachedEntries.find((entry) =>
           entry.sessions.some((session) => session?.id === selectedSessionId),

--- a/apps/app/tests/route-workspaces.test.ts
+++ b/apps/app/tests/route-workspaces.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WorkspaceInfo } from "../src/app/lib/desktop-types";
+import {
+  mapDesktopWorkspace,
+  mergeRouteWorkspaces,
+  resolveKnownWorkspaceId,
+} from "../src/react-app/shell/route-workspaces";
+
+function localWorkspace(id: string, path: string): WorkspaceInfo {
+  return {
+    id,
+    name: id,
+    path,
+    preset: "starter",
+    workspaceType: "local",
+  };
+}
+
+function remoteWorkspace(id: string): WorkspaceInfo {
+  return {
+    id,
+    name: id,
+    path: "",
+    preset: "starter",
+    workspaceType: "remote",
+    remoteType: "ipollowork",
+    baseUrl: "https://worker.example.com",
+  };
+}
+
+describe("route workspaces", () => {
+  test("uses the running server registry instead of stale local desktop records", () => {
+    const server = [localWorkspace("ws_live", "/Users/example/current")];
+    const desktop = [
+      mapDesktopWorkspace(localWorkspace("ws_stale", "/Users/example/legacy")),
+      mapDesktopWorkspace(remoteWorkspace("ws_remote")),
+    ];
+
+    expect(mergeRouteWorkspaces(server, desktop).map((workspace) => workspace.id)).toEqual([
+      "ws_live",
+      "ws_remote",
+    ]);
+  });
+
+  test("keeps desktop local workspaces before a local server registry exists", () => {
+    const desktop = [mapDesktopWorkspace(localWorkspace("ws_local", "/Users/example/local"))];
+
+    expect(mergeRouteWorkspaces([], desktop).map((workspace) => workspace.id)).toEqual(["ws_local"]);
+  });
+
+  test("falls through from a stale remembered workspace to a current server workspace", () => {
+    const workspaces = [mapDesktopWorkspace(localWorkspace("ws_live", "/Users/example/current"))];
+
+    expect(resolveKnownWorkspaceId(workspaces, ["ws_stale", "ws_live"])).toBe("ws_live");
+  });
+});

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -11,6 +11,9 @@ const electronSidecarDir = resolve(desktopRoot, "resources", "sidecars");
 const electronHelperDir = resolve(desktopRoot, "resources", "helpers");
 const hyperframesRoot = resolve(repoRoot, "vendor", "hyperframes");
 const hyperframesCli = resolve(hyperframesRoot, "packages", "cli", "bin", "hyperframes.mjs");
+const hyperframesCliBuild = resolve(hyperframesRoot, "packages", "cli", "dist", "cli.js");
+const hyperframesRuntimeVersion = resolve(hyperframesRoot, "packages", "cli", "dist", "runtimeVersion.js");
+const hyperframesDependencies = resolve(hyperframesRoot, "node_modules", ".bun");
 const hyperframesDevProjectDir = resolve(repoRoot, ".ipollowork-dev", "hyperframes-preview");
 const hyperframesDevProjectName = ".ipollowork-dev/hyperframes-preview";
 const defaultDevDataDir = resolve(
@@ -20,6 +23,7 @@ const defaultDevDataDir = resolve(
 );
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const bunCmd = process.platform === "win32" ? "bun.exe" : "bun";
 const nodeCmd = process.execPath;
 const portValue = Number.parseInt(process.env.PORT ?? "", 10);
 const devPort = Number.isFinite(portValue) && portValue > 0 ? portValue : 5173;
@@ -81,6 +85,19 @@ function ensureHyperframesDevProject() {
     },
   });
   ensureVisibleHyperframesStarter(hyperframesDevProjectDir);
+}
+
+function ensureHyperframesDevBuild() {
+  if (!shouldStartHyperframes) return;
+
+  if (!existsSync(hyperframesDependencies)) {
+    console.log("[electron-dev] Installing HyperFrames dependencies...");
+    runSync(bunCmd, ["install", "--frozen-lockfile"], { cwd: hyperframesRoot });
+  }
+  if (!existsSync(hyperframesCliBuild) || !existsSync(hyperframesRuntimeVersion)) {
+    console.log("[electron-dev] Building HyperFrames Studio...");
+    runSync(bunCmd, ["run", "build:local-studio"], { cwd: hyperframesRoot });
+  }
 }
 
 function ensureVisibleHyperframesStarter(projectDir) {
@@ -291,6 +308,7 @@ if (process.env.IPOLLOWORK_ELECTRON_SKIP_SHARED_PREPARE !== "1") {
 }
 
 // Build the server TS → JS so Electron can import it in-process
+ensureHyperframesDevBuild();
 hyperframesChild = startHyperframesDevServer();
 
 console.log("[electron-dev] Building ipollowork-server (tsc)...");

--- a/vendor/hyperframes/packages/cli/scripts/build-copy.mjs
+++ b/vendor/hyperframes/packages/cli/scripts/build-copy.mjs
@@ -67,7 +67,10 @@ async function main() {
   copyDirContents(studioDist, join(DIST, "studio"));
 
   for (const tmpl of ["blank", "_shared"]) {
-    copyDir(join(CLI_ROOT, "src", "templates", tmpl), join(DIST, "templates", tmpl));
+    const source = join(CLI_ROOT, "src", "templates", tmpl);
+    if (existsSync(source)) {
+      copyDir(source, join(DIST, "templates", tmpl));
+    }
   }
 
   // Bundle warm-grain from the repo registry so the built CLI can scaffold it


### PR DESCRIPTION
## Summary
- recover to a server-backed workspace when legacy Electron state contains obsolete local workspace IDs
- prepare HyperFrames dependencies/build artifacts on a clean dev checkout and tolerate absent optional shared templates
- restore the local-only Cloud sign-in card instead of opening real Cloud authentication
- restore the compact settings navigation: no redundant Settings overview or Advanced item; Preferences remains the default entry

## Root cause
A persisted local-server workspace registry can differ from legacy Electron state. Separately, the Cloud sign-in and compact-settings changes existed on the release line but were not merged back into `main`, so the current main branch exposed the older Cloud auth and Advanced settings behavior.

## Validation
- `bun test tests/cloud-signin-coming-soon-dialog.test.ts tests/settings-route.test.ts` (4 passed)
- `pnpm --filter @ipollowork/app typecheck`
- live Electron settings check: Advanced is absent from the Settings sidebar
- `pnpm --filter @ipollowork/app test`: 314 passed; 5 pre-existing unrelated failures remain (composer queue, design export menu x2, managed brand header, permission approval modal)
- prior workspace/startup regression checks remain recorded in this PR.