### PR TITLE
Fix templates in headless web mode

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,7 +11,7 @@
     "test": "bun test src",
     "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
     "build": "tsc -p tsconfig.json && node script/copy-bundled-templates.mjs && bun build src/templates.ts --outfile dist/templates.js --target node --format esm --external zod && bun build src/opencode-plugins/ipollowork-extensions-preview.ts src/opencode-plugins/ipollowork-capabilities-knowledge.ts src/opencode-plugins/ipollowork-anthropic-adaptive-thinking.ts src/opencode-plugins/ipollowork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
-    "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/ipollowork-server",
+    "build:bin": "node script/copy-bundled-templates.mjs && bun build --compile src/cli.ts --outfile dist/bin/ipollowork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/server/src/templates.test.ts
+++ b/apps/server/src/templates.test.ts
@@ -1,15 +1,16 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { deflateRawSync } from "node:zlib";
 import { TEMPLATE_STYLE_LABELS, type TemplateManifestV1 } from "@ipollowork/types/templates";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
-import { adoptLegacyVideoSession, importTemplate, listTemplates, materializeTemplate, migrateTemplateSessionSnapshots, readTemplateSession, saveTemplateFromSession, uninstallTemplate } from "./templates.js";
+import { adoptLegacyVideoSession, importTemplate, listTemplates, materializeTemplate, migrateTemplateSessionSnapshots, readTemplateSession, resolveBundledTemplatesRoot, saveTemplateFromSession, uninstallTemplate } from "./templates.js";
 
 const previousRuntimeDb = process.env.IPOLLOWORK_RUNTIME_DB;
+const previousBundledTemplatesDir = process.env.IPOLLOWORK_BUNDLED_TEMPLATES_DIR;
 const crc32Table = Uint32Array.from({ length: 256 }, (_, value) => {
   let entry = value;
   for (let bit = 0; bit < 8; bit += 1) entry = entry & 1 ? 0xedb88320 ^ (entry >>> 1) : entry >>> 1;
@@ -25,6 +26,8 @@ function crc32(data: Uint8Array): number {
 afterEach(() => {
   if (previousRuntimeDb === undefined) delete process.env.IPOLLOWORK_RUNTIME_DB;
   else process.env.IPOLLOWORK_RUNTIME_DB = previousRuntimeDb;
+  if (previousBundledTemplatesDir === undefined) delete process.env.IPOLLOWORK_BUNDLED_TEMPLATES_DIR;
+  else process.env.IPOLLOWORK_BUNDLED_TEMPLATES_DIR = previousBundledTemplatesDir;
 });
 
 function config(root: string): ServerConfig {
@@ -535,6 +538,16 @@ describe("template installations", () => {
     expect(await readFile(join(ws.path, created.state.entry), "utf8")).toContain("<!doctype html>");
     expect((await readTemplateSession(serverConfig, ws, "session_1")).manifest.id).toBe("ipollowork.saas-landing");
     expect(existsSync(join(ws.path, "design", "session_1", "template.json"))).toBe(false);
+  });
+
+  test("resolves an explicit bundled template directory for headless runtimes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ipw-bundled-templates-"));
+    try {
+      process.env.IPOLLOWORK_BUNDLED_TEMPLATES_DIR = root;
+      expect(resolveBundledTemplatesRoot()).toBe(root);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   test("imports a valid local package and rejects traversal", async () => {

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -101,12 +101,14 @@ function templatesRoot(config: ServerConfig): string {
   return join(dirname(runtimeDbPath(config)), "templates");
 }
 
-function bundledRoot(): string {
+export function resolveBundledTemplatesRoot(): string {
   const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const configuredPath = process.env.IPOLLOWORK_BUNDLED_TEMPLATES_DIR?.trim();
   const resourcesPath = typeof process.resourcesPath === "string" && process.resourcesPath.trim()
     ? process.resourcesPath.trim()
     : "";
   const candidates = [
+    ...(configuredPath ? [resolve(configuredPath)] : []),
     ...(resourcesPath ? [join(resourcesPath, "server", "dist", "bundled-templates")] : []),
     join(moduleDir, "bundled-templates"),
     join(moduleDir, "..", "bundled-templates"),
@@ -414,7 +416,7 @@ async function copyTemplateSource(sourceDirectory: string, destination: string) 
 }
 
 async function loadBundledTemplates(): Promise<BundledTemplate[]> {
-  const root = bundledRoot();
+  const root = resolveBundledTemplatesRoot();
   const items: BundledTemplate[] = [];
   for (const name of await readdir(root)) {
     const directory = join(root, name);

--- a/scripts/dev-headless-web.ts
+++ b/scripts/dev-headless-web.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 
 const cwd = process.cwd();
 const tmpDir = path.join(cwd, "tmp");
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 
 const ensureTmp = async () => {
   await mkdir(tmpDir, { recursive: true });
@@ -128,8 +129,9 @@ const ipolloworkToken = process.env.IPOLLOWORK_TOKEN ?? randomUUID();
 const ipolloworkHostToken = process.env.IPOLLOWORK_HOST_TOKEN ?? randomUUID();
 const ipolloworkServerBin = path.join(
   cwd,
-  "apps/server/dist/bin/ipollowork-server",
+  `apps/server/dist/bin/ipollowork-server${process.platform === "win32" ? ".exe" : ""}`,
 );
+const bundledTemplatesDir = path.join(cwd, "apps/server/dist/bundled-templates");
 
 const ensureiPolloWorkServer = async () => {
   try {
@@ -158,7 +160,7 @@ const ensureiPolloWorkServer = async () => {
       "[dev:headless-web] Auto-building: pnpm --filter ipollowork-server build:bin",
     );
     try {
-      await runCommand("pnpm", ["--filter", "ipollowork-server", "build:bin"]);
+      await runCommand(pnpmCommand, ["--filter", "ipollowork-server", "build:bin"]);
       await access(ipolloworkServerBin);
     } catch (error) {
       logLine(
@@ -188,6 +190,7 @@ const headlessEnv = {
   IPOLLOWORK_TOKEN: ipolloworkToken,
   IPOLLOWORK_HOST_TOKEN: ipolloworkHostToken,
   IPOLLOWORK_SERVER_BIN: ipolloworkServerBin,
+  IPOLLOWORK_BUNDLED_TEMPLATES_DIR: bundledTemplatesDir,
   IPOLLOWORK_SIDECAR_SOURCE: process.env.IPOLLOWORK_SIDECAR_SOURCE ?? "external",
 };
 
@@ -209,7 +212,7 @@ logLine(
 );
 
 const webProcess = spawnLogged(
-  "pnpm",
+  pnpmCommand,
   [
     "--filter",
     "@ipollowork/app",
@@ -226,7 +229,7 @@ const webProcess = spawnLogged(
 );
 
 const headlessProcess = spawnLogged(
-  "pnpm",
+  pnpmCommand,
   [
     "--filter",
     "ipollowork-orchestrator",


### PR DESCRIPTION
## Summary

- make the Windows headless web launcher resolve `pnpm.cmd` and the `.exe` server binary
- copy bundled templates during standalone server builds
- pass an explicit bundled template directory from the headless launcher to the server

## Root cause

The standalone headless server could not resolve the bundled template directory outside Electron, so the templates endpoint returned `500 bundled_templates_missing`. The Windows launcher also looked for an extensionless server binary and spawned `pnpm` instead of `pnpm.cmd`.

## Impact

Headless web mode on Windows now starts through the supported entrypoint and exposes all 74 bundled templates. Electron code and desktop lifecycle behavior are unchanged.

## Validation

- `pnpm --filter ipollowork-server typecheck`
- `pnpm --filter ipollowork-server build:bin`
- `pnpm --filter ipollowork-server exec bun test src/templates.test.ts` (27 passed)
- `pnpm dev:headless-web`
- `GET /workspace/:id/templates` returned 200 with 74 templates
- the first template cover returned 200
- Chrome Headless rendered the web app with the Templates navigation item and no Vite error overlay

## Evidence limitations

The repository's `fraimz` skill and the `agent-browser` CLI were unavailable in this environment, so validation used the real headless runtime, direct API assertions, and Chrome Headless.