### PR TITLE
Fix FAQ IME input and group language settings

### DIFF
--- a/apps/app/src/react-app/domains/help/help-route.tsx
+++ b/apps/app/src/react-app/domains/help/help-route.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, ArrowUpRight, BookOpen, HelpCircle, Search, X } from "lucide-react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
@@ -54,17 +54,36 @@ export function HelpRoute() {
   const navigate = useNavigate();
   const platform = usePlatform();
   const [searchParams, setSearchParams] = useSearchParams();
-  const query = searchParams.get("q") ?? "";
+  const urlQuery = searchParams.get("q") ?? "";
+  const [query, setQuery] = useState(urlQuery);
+  const [isComposing, setIsComposing] = useState(false);
+  const isComposingRef = useRef(false);
   const requestedCategory = searchParams.get("category");
   const category = requestedCategory && faqDocument.categories.includes(requestedCategory)
     ? requestedCategory
     : null;
   const hashId = location.hash.replace(/^#/, "");
   const [openItems, setOpenItems] = useState<string[]>(hashId ? [hashId] : []);
+  const updateSearchParam = useCallback((key: "q" | "category", value: string | null) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setSearchParams(next, { replace: true });
+  }, [searchParams, setSearchParams]);
   const filteredItems = useMemo(
     () => searchFaqItems(faqDocument.items, query, category),
     [category, query],
   );
+
+  useEffect(() => {
+    if (!isComposingRef.current) setQuery(urlQuery);
+  }, [urlQuery]);
+
+  useEffect(() => {
+    if (isComposing || query === urlQuery) return;
+    const timeout = window.setTimeout(() => updateSearchParam("q", query), 200);
+    return () => window.clearTimeout(timeout);
+  }, [isComposing, query, updateSearchParam, urlQuery]);
 
   useEffect(() => {
     if (!hashId || !faqDocument.items.some((item) => item.id === hashId)) return;
@@ -73,13 +92,6 @@ export function HelpRoute() {
       document.getElementById(hashId)?.scrollIntoView({ block: "center" });
     });
   }, [hashId]);
-
-  const updateSearchParam = (key: "q" | "category", value: string | null) => {
-    const next = new URLSearchParams(searchParams);
-    if (value) next.set(key, value);
-    else next.delete(key);
-    setSearchParams(next, { replace: true });
-  };
 
   const handleOpenItemsChange = (values: string[]) => {
     setOpenItems(values);
@@ -126,7 +138,16 @@ export function HelpRoute() {
               <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
                 value={query}
-                onChange={(event) => updateSearchParam("q", event.currentTarget.value)}
+                onChange={(event) => setQuery(event.currentTarget.value)}
+                onCompositionStart={() => {
+                  isComposingRef.current = true;
+                  setIsComposing(true);
+                }}
+                onCompositionEnd={(event) => {
+                  isComposingRef.current = false;
+                  setIsComposing(false);
+                  setQuery(event.currentTarget.value);
+                }}
                 placeholder={t("help.search_placeholder")}
                 aria-label={t("help.search_placeholder")}
                 className="h-11 rounded-xl pl-9"
@@ -177,7 +198,14 @@ export function HelpRoute() {
                   </p>
                 </div>
                 {query ? (
-                  <Button variant="ghost" size="sm" onClick={() => updateSearchParam("q", null)}>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      setQuery("");
+                      updateSearchParam("q", null);
+                    }}
+                  >
                     {t("help.clear_search")}
                   </Button>
                 ) : null}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -905,7 +905,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 >
                   <Settings className="size-4" />
                 </DropdownMenuTrigger>
-                <DropdownMenuContent side="top" align="end" className="w-36 min-w-36">
+                <DropdownMenuContent side="top" align="end" className="w-44 min-w-44">
                   <DropdownMenuItem onClick={() => props.onOpenSettings("/settings/general")}>
                     <Settings className="size-4" />
                     {t("status.settings")}
@@ -915,16 +915,25 @@ export function AppSidebar(props: AppSidebarProps) {
                     {t("help.title")}
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => switchLanguage("zh")}>
-                    <Languages className="size-4" />
-                    中文
-                    {language === "zh" ? <Check className="ml-auto size-3.5" /> : null}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => switchLanguage("en")}>
-                    <Languages className="size-4" />
-                    English
-                    {language === "en" ? <Check className="ml-auto size-3.5" /> : null}
-                  </DropdownMenuItem>
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>
+                      <Languages className="size-4" />
+                      {t("settings.language")}
+                      <span className="ml-auto text-xs font-normal text-muted-foreground">
+                        {language === "zh" ? "中文" : "English"}
+                      </span>
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="w-36 min-w-36">
+                      <DropdownMenuItem onClick={() => switchLanguage("zh")}>
+                        中文
+                        {language === "zh" ? <Check className="ml-auto size-3.5" /> : null}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => switchLanguage("en")}>
+                        English
+                        {language === "en" ? <Check className="ml-auto size-3.5" /> : null}
+                      </DropdownMenuItem>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
                 </DropdownMenuContent>
               </DropdownMenu>
               <NotificationBell className="shrink-0 rounded-lg text-sidebar-foreground/65 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" />


### PR DESCRIPTION
## Summary
- keep FAQ search input local while IME composition is active and debounce URL synchronization
- group language choices under a dedicated submenu while showing the current language

## Root cause
The controlled FAQ search field updated React Router search parameters on every input event. Those route updates interrupted Chinese IME composition and leaked intermediate pinyin into the field. Language choices were also presented as peer actions alongside Settings and Help center.

## Validation
- `pnpm --filter @ipollowork/app exec bun test --isolate tests/faq.test.ts` — passed (2 tests)
- `pnpm --filter @ipollowork/app typecheck` — passed
- `pnpm --filter @ipollowork/app build:web` — passed
- `.\ipollowork.cmd package:dir` — passed after retrying the existing HyperFrames font-generation race
- Playwright web validation — passed for Chinese composition, debounced URL synchronization, the language submenu, and language switching
- Playwright Electron validation against the packaged EXE — passed with no console errors

## Known unrelated issues
- The full App suite currently has 5 failures on `main` in composer queue, Design export, managed brand header, and permission approval assertions; 314 of 319 tests pass.
- `dev:headless-web` starts the web renderer, but the orchestrator exits with `Unable to connect`; the renderer interactions above were still validated.
- The repository's `voiceover` and `fraimz` skills were unavailable in this environment, so local Playwright screenshots were used as UI evidence.
- Local screenshots were captured for both web and packaged Electron; CLI asset upload was not available.

## Reproduction
1. Open Help center.
2. Enter a Chinese greeting with a Chinese IME and confirm the field contains only the committed characters.
3. Open the settings menu and hover Language.
4. Confirm Simplified Chinese and English appear only in the submenu and that switching languages updates the UI.