### PR TITLE
Polish language submenu alignment

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -4,7 +4,6 @@ import {
   AlertCircle,
   Archive,
   ArchiveRestore,
-  Check,
   ChevronRight,
   FolderPlus,
   Loader2,
@@ -78,6 +77,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
@@ -919,19 +920,17 @@ export function AppSidebar(props: AppSidebarProps) {
                     <DropdownMenuSubTrigger>
                       <Languages className="size-4" />
                       {t("settings.language")}
-                      <span className="ml-auto text-xs font-normal text-muted-foreground">
-                        {language === "zh" ? "中文" : "English"}
-                      </span>
                     </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="w-36 min-w-36">
-                      <DropdownMenuItem onClick={() => switchLanguage("zh")}>
-                        中文
-                        {language === "zh" ? <Check className="ml-auto size-3.5" /> : null}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => switchLanguage("en")}>
-                        English
-                        {language === "en" ? <Check className="ml-auto size-3.5" /> : null}
-                      </DropdownMenuItem>
+                    <DropdownMenuSubContent className="w-40 min-w-40">
+                      <DropdownMenuRadioGroup
+                        value={language}
+                        onValueChange={(value) => {
+                          if (value === "zh" || value === "en") switchLanguage(value);
+                        }}
+                      >
+                        <DropdownMenuRadioItem value="zh">中文</DropdownMenuRadioItem>
+                        <DropdownMenuRadioItem value="en">English</DropdownMenuRadioItem>
+                      </DropdownMenuRadioGroup>
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
                 </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- remove the current language label from the parent Language trigger so the chevron stays aligned within the menu
- use semantic radio menu items for language choices and keep the selected checkmark aligned on the right
- widen the submenu slightly to preserve comfortable spacing at compact window sizes

## Root cause
The fixed-width parent menu row contained an icon, the Language label, the current language value, and the submenu chevron. That combination exceeded the available horizontal space and caused poor alignment and visual overflow.

## Validation
- `pnpm --filter @ipollowork/app typecheck` - passed
- `pnpm --filter @ipollowork/app build:web` - passed
- Playwright at 1440x900 - passed; parent label contains only Language, all menu bounds remain inside the viewport, current selection is checked, and language switching works
- Playwright at 900x640 - passed; parent menu and submenu remain fully inside the viewport
- no framework error overlay was present

## Notes
The standalone web renderer reported an expected backend connection refusal because no local server was running. This did not affect the menu rendering or interaction validation.