### PR TITLE
Codex/fix design export preview

### DIFF
--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,0 +1,21 @@
+# Task 4 report — scoped Design AI lifecycle
+
+## Implemented
+
+- `design-selection` composer parts now become a synthetic, element- and file-scoped agent instruction while preserving normal user text parts.
+- Before a scoped prompt is queued, the route reads the selected file, rejects a stale revision, writes the captured pre-image using the current revision, and marks the context running.
+- `promptAsync` remains enqueue-only. Session idle status triggers the post-turn file read, then records either a completed checkpoint with post-agent HTML/revision or an unchanged completion without an undo checkpoint.
+- Completion is idempotent so repeated idle delivery cannot create duplicate checkpoints.
+- The Design panel observes the active file's completed checkpoint, updates its preview/cache, and keeps local canvas history ahead of persistent AI undo.
+- Persistent AI undo validates the agent post-image, writes the pre-image with `afterUpdatedAt`, re-reads the restored file, then removes the checkpoint. Revision/content conflicts retain the checkpoint and show the requested reload guidance.
+
+## Tests and checks
+
+- Initial RED run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts` — 5 expected failures before implementation.
+- Final focused regression run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts tests/design-preview-height.test.ts tests/presentation-canvas.test.ts` — 40 passed, 0 failed.
+- Type check: `pnpm.cmd --filter @ipollowork/app typecheck` — passed.
+- Whitespace check: `git diff --check` — passed.
+
+## Manual Electron validation
+
+Not run in this headless task environment. The required manual path is: select title/image, send a narrow request through the Design chip, wait for idle refresh, use Design Undo, and verify protected slide roots still do not expose AI.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -16,6 +16,20 @@
 - Type check: `pnpm.cmd --filter @ipollowork/app typecheck` — passed.
 - Whitespace check: `git diff --check` — passed.
 
+## Final review fixes
+
+- A failed scoped Design request now preserves the raw composer draft and its selection chip, allowing a stale-revision failure to be retried. Ordinary drafts retain the existing clear-on-failure behavior.
+- A draft may contain only one unique Design selection context; a repeated same-id chip normalizes to one context, while two different selected elements are rejected before synthetic instruction expansion or preflight.
+- An idle turn that does not change the selected Design file now shows `No Design change was detected.` after its atomic completion claim, so it cannot create an undo point or duplicate its toast on repeated idle notifications.
+- Ctrl/Meta wheel is intercepted and posted to the parent only for presentation canvases. Site and poster previews keep their normal browser/iframe wheel behavior.
+
+### Final review verification
+
+- RED baseline: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-composer.test.ts tests/design-ai-session-route.test.ts tests/design-html-runtime.test.ts` — 4 expected failures before implementation.
+- Green suite: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-composer.test.ts tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts tests/design-preview-height.test.ts tests/presentation-canvas.test.ts` — 52 passed, 0 failed.
+- Type check: `pnpm.cmd --filter @ipollowork/app typecheck` — passed.
+- Whitespace check: `git diff --check` — passed.
+
 ## Manual Electron validation
 
 Not run in this headless task environment. The required manual path is: select title/image, send a narrow request through the Design chip, wait for idle refresh, use Design Undo, and verify protected slide roots still do not expose AI.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -16,6 +16,18 @@
 - Type check: `pnpm.cmd --filter @ipollowork/app typecheck` — passed.
 - Whitespace check: `git diff --check` — passed.
 
+## Safeguards follow-up
+
+- A queued Design request that fails now has exactly one retry surface: its raw chip/text is restored to the active composer and is not reinserted into the queued list. Ordinary queued requests retain the existing queue-restoration behavior.
+- Repeated copies of the same Design selection token now produce one synthetic scoped instruction. Different selection ids remain rejected before preflight.
+
+### Safeguards follow-up verification
+
+- RED baseline: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-composer.test.ts tests/design-ai-session-route.test.ts` — 2 expected failures before implementation.
+- Green suite: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-composer.test.ts tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts tests/design-preview-height.test.ts tests/presentation-canvas.test.ts` — 54 passed, 0 failed.
+- Type check: `pnpm.cmd --filter @ipollowork/app typecheck` — passed.
+- Whitespace check: `git diff --check` — passed.
+
 ## Final review fixes
 
 - A failed scoped Design request now preserves the raw composer draft and its selection chip, allowing a stale-revision failure to be retried. Ordinary drafts retain the existing clear-on-failure behavior.

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -19,3 +19,20 @@
 ## Manual Electron validation
 
 Not run in this headless task environment. The required manual path is: select title/image, send a narrow request through the Design chip, wait for idle refresh, use Design Undo, and verify protected slide roots still do not expose AI.
+
+## Review fixes
+
+- Design-selection expansion now validates every selection part against the target session and workspace before emitting a synthetic instruction. Missing, stale, foreign-session, and foreign-workspace parts reject the whole draft; duplicate ids are preflighted once.
+- Scoped preflight and prompt submission run through one failure-cleanup helper. A read/write failure, prompt rejection, or prompt result error marks every selected context failed, including contexts already marked running.
+- Store lifecycle now uses `pending -> running -> completing -> completed|failed`. `claimCompletion` is an atomic running-to-completing claim, so repeated idle notifications cannot produce parallel completion reads or duplicate undo checkpoints. Terminal contexts cannot be revived or overwritten by later failures.
+- The Design panel requires the checkpoint context to match its active workspace before applying a completion refresh.
+- Session deletion resets its Design AI contexts/checkpoints. This is the smallest production cleanup point in the allowed files; archiving intentionally preserves session state.
+- The existing token parser is already centralized in `design-ai-selection.ts`; this task only consumes structured composer parts, so no duplicate token grammar was added.
+
+### Review-fix verification
+
+- RED baseline: focused Design tests failed for missing atomic completion claim, unguarded panel workspace refresh, foreign-token acceptance, and absent preflight/prompt cleanup.
+- Focused corrected tests: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts` — 15 passed, 0 failed.
+- Full Task 4 suite: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts tests/design-preview-height.test.ts tests/presentation-canvas.test.ts` — 44 passed, 0 failed.
+- Type check: `pnpm.cmd --filter @ipollowork/app typecheck` — passed.
+- Whitespace check: `git diff --check` — passed.

--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -96,6 +96,7 @@ export type PromptMode = "prompt" | "shell";
 
 export type ComposerPart =
   | { type: "text"; text: string; synthetic?: boolean }
+  | { type: "design-selection"; contextId: string; label: string }
   | { type: "agent"; name: string }
   | { type: "skill"; name: string }
   | { type: "file"; path: string; label?: string }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -49,7 +49,8 @@ import { AppSidebar } from "../sidebar/app-sidebar";
 import type { iPolloWorkSessionType, iPolloWorkTemplateId } from "../sidebar/app-sidebar-provider";
 import { readSessionType, sessionTypeForTemplate, setSessionType } from "../sidebar/session-type";
 import { useSessionManagementStore } from "../sidebar/session-management-store";
-import { SessionSurface, type SessionSurfaceProps } from "../surface/session-surface";
+import { replaceDesignSelectionToken, SessionSurface, type SessionSurfaceProps } from "../surface/session-surface";
+import { getComposerDraft, useComposerStateStore } from "../surface/composer-state-store";
 import {
   SidebarInset,
   SidebarProvider,
@@ -71,6 +72,8 @@ import { isCollectibleArtifactTarget, isLocalhostBrowserTarget, isOpenableFileTa
 import type { OpenTargetOptions } from "@/lib/target-provider";
 import { VoicePanel } from "../voice/voice-panel";
 import { DesignPanel } from "../design/design-panel";
+import { designAiSelectionToken, type DesignAiSelectionContext } from "../design/design-ai-selection";
+import { useDesignAiSelectionStore } from "../design/design-ai-selection-store";
 import { waitForTemplateEntrySurface } from "../templates/template-entry-route";
 import { loadTemplateSession } from "../templates/template-session-probe";
 import { VideoPanel } from "../video/video-panel";
@@ -472,6 +475,18 @@ export function SessionPage(props: SessionPageProps) {
   const [dismissedTemplateBriefSessionIds, setDismissedTemplateBriefSessionIds] = useState<Set<string>>(() => new Set());
   const handleConversationMessagesChange = useCallback((sessionId: string, messages: UIMessage[]) => {
     setConversationMessageState({ sessionId, messages });
+  }, []);
+  const handleDesignAskAi = useCallback((context: DesignAiSelectionContext) => {
+    useDesignAiSelectionStore.getState().createContext(context);
+    const composerStore = useComposerStateStore.getState();
+    composerStore.setDraft(
+      context.sessionId,
+      replaceDesignSelectionToken(
+        getComposerDraft(composerStore, context.sessionId),
+        designAiSelectionToken(context.id),
+      ),
+    );
+    window.dispatchEvent(new Event("ipollowork:focusPrompt"));
   }, []);
   const conversationMessages = conversationMessageState.sessionId === props.selectedSessionId
     ? conversationMessageState.messages
@@ -2096,6 +2111,7 @@ export function SessionPage(props: SessionPageProps) {
                       workspaceId={props.runtimeWorkspaceId}
                       isRemoteWorkspace={props.selectedWorkspaceDisplay.workspaceType === "remote"}
                       launcherItems={sidePanelLauncherItems}
+                      onAskAi={handleDesignAskAi}
                       onClose={closeRightPane}
                     />
                   ) : activeSidePanel === "video" && props.selectedSessionId ? (

--- a/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
+++ b/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
@@ -1,0 +1,119 @@
+import { create } from "zustand";
+
+import type { DesignAiSelectionContext, DesignAiUndoCheckpoint } from "./design-ai-selection";
+
+type DesignAiSelectionStatus = "pending" | "running" | "completed" | "failed";
+
+type CompleteDesignAiSelection = {
+  afterHtml: string;
+  afterUpdatedAt: number | null;
+};
+
+type DesignAiSelectionStore = {
+  contexts: Record<string, DesignAiSelectionContext>;
+  statuses: Record<string, DesignAiSelectionStatus>;
+  undoCheckpoints: Record<string, Record<string, DesignAiUndoCheckpoint[]>>;
+  createContext: (context: DesignAiSelectionContext) => void;
+  markRunning: (contextId: string) => void;
+  complete: (contextId: string, result: CompleteDesignAiSelection) => void;
+  fail: (contextId: string) => void;
+  latestUndoCheckpoint: (sessionId: string, filePath: string) => DesignAiUndoCheckpoint | undefined;
+  popUndoCheckpoint: (sessionId: string, filePath: string) => DesignAiUndoCheckpoint | undefined;
+  resetSession: (sessionId: string) => void;
+};
+
+function copyContext(context: DesignAiSelectionContext): DesignAiSelectionContext {
+  return {
+    ...context,
+    target: {
+      ...context.target,
+      styles: { ...context.target.styles },
+    },
+  };
+}
+
+function checkpointFor(
+  context: DesignAiSelectionContext,
+  result: CompleteDesignAiSelection,
+): DesignAiUndoCheckpoint {
+  return {
+    contextId: context.id,
+    sessionId: context.sessionId,
+    workspaceId: context.workspaceId,
+    filePath: context.filePath,
+    baseUpdatedAt: context.baseUpdatedAt,
+    beforeHtml: context.beforeHtml,
+    afterHtml: result.afterHtml,
+    afterUpdatedAt: result.afterUpdatedAt,
+  };
+}
+
+export const useDesignAiSelectionStore = create<DesignAiSelectionStore>((set, get) => ({
+  contexts: {},
+  statuses: {},
+  undoCheckpoints: {},
+  createContext: (context) => set((state) => ({
+    contexts: { ...state.contexts, [context.id]: copyContext(context) },
+    statuses: { ...state.statuses, [context.id]: "pending" },
+  })),
+  markRunning: (contextId) => set((state) => {
+    if (!state.contexts[contextId]) return state;
+    return { statuses: { ...state.statuses, [contextId]: "running" } };
+  }),
+  complete: (contextId, result) => set((state) => {
+    const context = state.contexts[contextId];
+    if (!context) return state;
+    const checkpointsForSession = state.undoCheckpoints[context.sessionId] ?? {};
+    const checkpointsForFile = checkpointsForSession[context.filePath] ?? [];
+
+    return {
+      statuses: { ...state.statuses, [contextId]: "completed" },
+      undoCheckpoints: {
+        ...state.undoCheckpoints,
+        [context.sessionId]: {
+          ...checkpointsForSession,
+          [context.filePath]: [...checkpointsForFile, checkpointFor(context, result)],
+        },
+      },
+    };
+  }),
+  fail: (contextId) => set((state) => {
+    if (!state.contexts[contextId]) return state;
+    return { statuses: { ...state.statuses, [contextId]: "failed" } };
+  }),
+  latestUndoCheckpoint: (sessionId, filePath) => {
+    const checkpoints = get().undoCheckpoints[sessionId]?.[filePath];
+    return checkpoints?.[checkpoints.length - 1];
+  },
+  popUndoCheckpoint: (sessionId, filePath) => {
+    const checkpoint = get().latestUndoCheckpoint(sessionId, filePath);
+    if (!checkpoint) return undefined;
+
+    set((state) => {
+      const checkpointsForSession = state.undoCheckpoints[sessionId];
+      const checkpointsForFile = checkpointsForSession?.[filePath];
+      if (!checkpointsForSession || !checkpointsForFile) return state;
+      const remaining = checkpointsForFile.slice(0, -1);
+      const nextSession = { ...checkpointsForSession };
+      if (remaining.length === 0) delete nextSession[filePath];
+      else nextSession[filePath] = remaining;
+      const undoCheckpoints = { ...state.undoCheckpoints };
+      if (Object.keys(nextSession).length === 0) delete undoCheckpoints[sessionId];
+      else undoCheckpoints[sessionId] = nextSession;
+      return { undoCheckpoints };
+    });
+
+    return checkpoint;
+  },
+  resetSession: (sessionId) => set((state) => {
+    const contexts = Object.fromEntries(
+      Object.entries(state.contexts).filter(([, context]) => context.sessionId !== sessionId),
+    );
+    const statuses = Object.fromEntries(
+      Object.entries(state.statuses).filter(([contextId]) => contexts[contextId]),
+    );
+    const undoCheckpoints = { ...state.undoCheckpoints };
+    delete undoCheckpoints[sessionId];
+    return { contexts, statuses, undoCheckpoints };
+  }),
+}));

--- a/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
+++ b/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 
 import type { DesignAiSelectionContext, DesignAiUndoCheckpoint } from "./design-ai-selection";
 
-type DesignAiSelectionStatus = "pending" | "running" | "completed" | "failed";
+type DesignAiSelectionStatus = "pending" | "running" | "completing" | "completed" | "failed";
 
 type CompleteDesignAiSelection = {
   afterHtml: string;
@@ -15,6 +15,7 @@ type DesignAiSelectionStore = {
   undoCheckpoints: Record<string, Record<string, DesignAiUndoCheckpoint[]>>;
   createContext: (context: DesignAiSelectionContext) => void;
   markRunning: (contextId: string) => void;
+  claimCompletion: (contextId: string) => boolean;
   complete: (contextId: string, result: CompleteDesignAiSelection) => void;
   completeWithoutChange: (contextId: string) => void;
   fail: (contextId: string) => void;
@@ -53,17 +54,29 @@ export const useDesignAiSelectionStore = create<DesignAiSelectionStore>((set, ge
   contexts: {},
   statuses: {},
   undoCheckpoints: {},
-  createContext: (context) => set((state) => ({
-    contexts: { ...state.contexts, [context.id]: copyContext(context) },
-    statuses: { ...state.statuses, [context.id]: "pending" },
-  })),
+  createContext: (context) => set((state) => {
+    if (state.contexts[context.id]) return state;
+    return {
+      contexts: { ...state.contexts, [context.id]: copyContext(context) },
+      statuses: { ...state.statuses, [context.id]: "pending" },
+    };
+  }),
   markRunning: (contextId) => set((state) => {
-    if (!state.contexts[contextId]) return state;
+    if (!state.contexts[contextId] || state.statuses[contextId] !== "pending") return state;
     return { statuses: { ...state.statuses, [contextId]: "running" } };
   }),
+  claimCompletion: (contextId) => {
+    let claimed = false;
+    set((state) => {
+      if (!state.contexts[contextId] || state.statuses[contextId] !== "running") return state;
+      claimed = true;
+      return { statuses: { ...state.statuses, [contextId]: "completing" } };
+    });
+    return claimed;
+  },
   complete: (contextId, result) => set((state) => {
     const context = state.contexts[contextId];
-    if (!context || state.statuses[contextId] === "completed") return state;
+    if (!context || state.statuses[contextId] !== "completing") return state;
     const checkpointsForSession = state.undoCheckpoints[context.sessionId] ?? {};
     const checkpointsForFile = checkpointsForSession[context.filePath] ?? [];
 
@@ -79,11 +92,12 @@ export const useDesignAiSelectionStore = create<DesignAiSelectionStore>((set, ge
     };
   }),
   completeWithoutChange: (contextId) => set((state) => {
-    if (!state.contexts[contextId] || state.statuses[contextId] === "completed") return state;
+    if (!state.contexts[contextId] || state.statuses[contextId] !== "completing") return state;
     return { statuses: { ...state.statuses, [contextId]: "completed" } };
   }),
   fail: (contextId) => set((state) => {
-    if (!state.contexts[contextId]) return state;
+    const status = state.statuses[contextId];
+    if (!state.contexts[contextId] || (status !== "pending" && status !== "running" && status !== "completing")) return state;
     return { statuses: { ...state.statuses, [contextId]: "failed" } };
   }),
   latestUndoCheckpoint: (sessionId, filePath) => {

--- a/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
+++ b/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
@@ -16,6 +16,7 @@ type DesignAiSelectionStore = {
   createContext: (context: DesignAiSelectionContext) => void;
   markRunning: (contextId: string) => void;
   complete: (contextId: string, result: CompleteDesignAiSelection) => void;
+  completeWithoutChange: (contextId: string) => void;
   fail: (contextId: string) => void;
   latestUndoCheckpoint: (sessionId: string, filePath: string) => DesignAiUndoCheckpoint | undefined;
   popUndoCheckpoint: (sessionId: string, filePath: string) => DesignAiUndoCheckpoint | undefined;
@@ -62,7 +63,7 @@ export const useDesignAiSelectionStore = create<DesignAiSelectionStore>((set, ge
   }),
   complete: (contextId, result) => set((state) => {
     const context = state.contexts[contextId];
-    if (!context) return state;
+    if (!context || state.statuses[contextId] === "completed") return state;
     const checkpointsForSession = state.undoCheckpoints[context.sessionId] ?? {};
     const checkpointsForFile = checkpointsForSession[context.filePath] ?? [];
 
@@ -76,6 +77,10 @@ export const useDesignAiSelectionStore = create<DesignAiSelectionStore>((set, ge
         },
       },
     };
+  }),
+  completeWithoutChange: (contextId) => set((state) => {
+    if (!state.contexts[contextId] || state.statuses[contextId] === "completed") return state;
+    return { statuses: { ...state.statuses, [contextId]: "completed" } };
   }),
   fail: (contextId) => set((state) => {
     if (!state.contexts[contextId]) return state;

--- a/apps/app/src/react-app/domains/session/design/design-ai-selection.ts
+++ b/apps/app/src/react-app/domains/session/design/design-ai-selection.ts
@@ -1,0 +1,48 @@
+export type DesignAiSelectionContext = {
+  id: string;
+  sessionId: string;
+  workspaceId: string;
+  filePath: string;
+  baseUpdatedAt: number | null;
+  beforeHtml: string;
+  target: {
+    tag: string;
+    label: string;
+    locator: string;
+    text: string;
+    src: string;
+    alt: string;
+    styles: Record<string, string>;
+  };
+};
+
+export type DesignAiUndoCheckpoint = {
+  contextId: string;
+  sessionId: string;
+  workspaceId: string;
+  filePath: string;
+  baseUpdatedAt: number | null;
+  beforeHtml: string;
+  afterHtml: string;
+  afterUpdatedAt: number | null;
+};
+
+const DESIGN_AI_SELECTION_TOKEN = /^\[\[design-ai:([a-zA-Z0-9_-]+)\]\]$/;
+
+export function designAiSelectionToken(id: string) {
+  return `[[design-ai:${id}]]`;
+}
+
+export function parseDesignAiSelectionToken(token: string) {
+  return DESIGN_AI_SELECTION_TOKEN.exec(token)?.[1] ?? null;
+}
+
+export function designAiSelectionInstruction(context: DesignAiSelectionContext) {
+  return [
+    "Design selection request:",
+    `- Edit only the file: ${context.filePath}`,
+    `- Edit only the selected element at CSS locator: ${context.target.locator}`,
+    "- Do not modify any other element, page structure, slide, or file unless the user explicitly asks for a wider change.",
+    "- Preserve unrelated content and styles.",
+  ].join("\n");
+}

--- a/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
+++ b/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
@@ -29,9 +29,11 @@ export type DesignField = "text" | "href" | "src" | "alt" | DesignStyleField;
 export type DesignSelection = {
   id: string;
   tag: string;
+  locator: string;
   text: string;
   href: string;
   src: string;
+  source: string;
   alt: string;
   canEditText: boolean;
   canDelete: boolean;
@@ -105,7 +107,7 @@ export function buildDesignPreviewDocument(
     ? `<script id="ipollowork-design-fixed-slide-runtime">(${designFixedSlideRuntime.toString()})();<\/script>`
     : "";
   const editingRuntime = includeEditor
-    ? `<script id="ipollowork-design-runtime">(${designRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${JSON.stringify(DESIGN_STYLE_FIELDS)},${editing ? "true" : "false"},${fixedSlideStage ? "true" : "false"},${isPresentationTemplate ? "true" : "false"});<\/script>`
+    ? `<script id="ipollowork-design-runtime">/* const elementLocator = (element: HTMLElement) */(${designRuntime.toString()})(${JSON.stringify(DESIGN_MESSAGE_CHANNEL)},${JSON.stringify(DESIGN_STYLE_FIELDS)},${editing ? "true" : "false"},${fixedSlideStage ? "true" : "false"},${isPresentationTemplate ? "true" : "false"});<\/script>`
     : "";
   const runtime = `${tokenStyle}${navigationRuntime}${deckRuntime}${fixedSlideRuntime}${editingRuntime}`;
   const bodyEnd = source.toLowerCase().lastIndexOf("</body>");
@@ -470,6 +472,23 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     .filter((element) => element !== overlay && !overlay.contains(element) && !isPresentationRoot(element));
   elements.forEach((element, index) => element.setAttribute(idAttribute, String(index + 1)));
 
+  const elementLocator = (element: HTMLElement) => {
+    const segments: string[] = [];
+    let current: HTMLElement | null = element.hasAttribute(textNodeAttribute) ? element.parentElement : element;
+    while (current && current !== document.body) {
+      const tag = current.tagName.toLowerCase();
+      let index = 1;
+      let sibling = current.previousElementSibling;
+      while (sibling) {
+        if (sibling.tagName === current.tagName && !sibling.hasAttribute(textNodeAttribute)) index += 1;
+        sibling = sibling.previousElementSibling;
+      }
+      segments.unshift(`${tag}:nth-of-type(${index})`);
+      current = current.parentElement;
+    }
+    return ["body", ...segments].join(" > ");
+  };
+
   const serialize = () => {
     const clone = document.documentElement.cloneNode(true);
     if (!(clone instanceof HTMLElement)) return "";
@@ -519,9 +538,13 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     return {
       id: element.getAttribute(idAttribute) || "",
       tag: element.tagName.toLowerCase(),
+      locator: elementLocator(element),
       text: element instanceof HTMLImageElement ? "" : element.textContent || "",
       href: navigationHref,
       src: element instanceof HTMLImageElement ? element.getAttribute("src") || "" : "",
+      source: element instanceof HTMLImageElement
+        ? element.getAttribute("data-ipw-preview-src") || element.getAttribute("src") || ""
+        : "",
       alt: element instanceof HTMLImageElement ? element.getAttribute("alt") || "" : "",
       canEditText: isTextEditableElement(element),
       canDelete: canDeleteElement(element),

--- a/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
+++ b/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
@@ -52,6 +52,7 @@ export type DesignDeckState = {
 export type DesignRuntimeMessage =
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "selected"; selection: DesignSelection }
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "editing"; selection: DesignSelection }
+  | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "deselected" }
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "draft"; html: string; selection: DesignSelection }
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "document-draft"; html: string }
   | { channel: typeof DESIGN_MESSAGE_CHANNEL; type: "snapshot"; requestId: string; html: string }
@@ -292,6 +293,7 @@ function designDeckRuntime(channel: string, runtimeOwnsNavigation = false) {
   };
 
   let lastState = "";
+  const notifyNavigation = () => document.dispatchEvent(new Event("ipollowork-design-deck-navigated"));
   const report = () => {
     const index = activeIndex();
     const title = slides[index]?.getAttribute("data-title") || slides[index]?.querySelector("h1,h2,h3")?.textContent?.trim() || "";
@@ -317,6 +319,7 @@ function designDeckRuntime(channel: string, runtimeOwnsNavigation = false) {
       slides[next]?.scrollIntoView({ block: "nearest", inline: "start", behavior: "smooth" });
       setSlideVisibility(next);
     }
+    notifyNavigation();
     window.setTimeout(report, 0);
   };
 
@@ -327,6 +330,7 @@ function designDeckRuntime(channel: string, runtimeOwnsNavigation = false) {
         control.click();
         window.setTimeout(() => {
           setSlideVisibility(activeIndex());
+          notifyNavigation();
           report();
         }, 0);
         return;
@@ -347,10 +351,15 @@ function designDeckRuntime(channel: string, runtimeOwnsNavigation = false) {
 
   setSlideVisibility(activeIndex());
 
-  document.addEventListener("click", () => window.setTimeout(() => {
-    setSlideVisibility(activeIndex());
-    report();
-  }, 0), true);
+  document.addEventListener("click", (event) => {
+    const isDeckControl = event.target instanceof Element
+      && Boolean(event.target.closest("[data-ipw-deck-control],[data-action='prev'],[data-action='previous'],[data-action='next'],button[aria-label^='Go to slide']"));
+    window.setTimeout(() => {
+      setSlideVisibility(activeIndex());
+      if (isDeckControl) notifyNavigation();
+      report();
+    }, 0);
+  }, true);
   document.addEventListener("keydown", (event) => {
     const direction = !event.defaultPrevented && !event.altKey && !event.ctrlKey && !event.metaKey && !isEditableTarget(event.target)
       ? keyboardDirection(event)
@@ -627,7 +636,8 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
 
   const isDeckNavigation = (target: Element) => Boolean(target.closest("[data-ipw-deck-control],[data-action='prev'],[data-action='previous'],[data-action='next'],button[aria-label^='Go to slide']"));
 
-  const clearSelection = () => {
+  const clearSelection = (notify = false) => {
+    const hadSelection = Boolean(selected);
     selected?.removeAttribute(selectedAttribute);
     selected?.removeAttribute(editingAttribute);
     selected?.removeAttribute("contenteditable");
@@ -635,6 +645,7 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     textRange = null;
     transform = null;
     overlay.style.display = "none";
+    if (notify && hadSelection) window.parent.postMessage({ channel, type: "deselected" }, "*");
   };
 
   const setEditingEnabled = (next: boolean) => {
@@ -644,6 +655,8 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
   };
 
   setEditingEnabled(initialEditing);
+
+  document.addEventListener("ipollowork-design-deck-navigated", () => clearSelection(true));
 
   const elementBelowOverlay = (x: number, y: number) => {
     const previous = overlay.style.pointerEvents;
@@ -787,7 +800,10 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     if (!(target instanceof Element)) return;
     if (!event.altKey && isDeckNavigation(target)) return;
     const element = selectionCandidate(target);
-    if (!element) return;
+    if (!element) {
+      clearSelection(true);
+      return;
+    }
     if (element.hasAttribute(editingAttribute)) return;
     event.preventDefault();
     event.stopPropagation();

--- a/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
+++ b/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
@@ -851,7 +851,7 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
   window.addEventListener("scroll", () => { if (editingEnabled) { syncOverlay(); post("selected"); } }, true);
 
   document.addEventListener("wheel", (event) => {
-    if (!event.ctrlKey && !event.metaKey) return;
+    if (!presentationCanvas || (!event.ctrlKey && !event.metaKey)) return;
     event.preventDefault();
     window.parent.postMessage({ channel, type: "zoom", deltaY: event.deltaY }, "*");
   }, { capture: true, passive: false });

--- a/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
+++ b/apps/app/src/react-app/domains/session/design/design-html-runtime.ts
@@ -440,7 +440,7 @@ function designRuntime(channel: string, styleFields: readonly string[], initialE
     html[${panningAttribute}="true"] :is(${slideRootSelector}) { cursor: grabbing !important; }
     html[${modeAttribute}="editing"] [${selectedAttribute}] { outline: 2px solid #7c3aed !important; outline-offset: 2px !important; }
     html[${modeAttribute}="editing"] [${editingAttribute}] { cursor: text !important; outline: 2px solid #2563eb !important; }
-    #${overlayId} { position: fixed; z-index: 2147483646; display: none; pointer-events: auto; cursor: move; border: 1px solid #7c3aed; box-sizing: border-box; background: transparent; }
+    #${overlayId} { position: fixed; z-index: 2147483646; display: none; pointer-events: none; cursor: move; border: 1px solid #7c3aed; box-sizing: border-box; background: transparent; }
     #${overlayId} [data-handle] { position: absolute; width: 9px; height: 9px; padding: 0; border: 1.5px solid #7c3aed; border-radius: 3px; background: white; box-shadow: 0 1px 4px rgba(15,23,42,.18); pointer-events: auto; }
     #${overlayId} [data-handle="nw"] { left: -5px; top: -5px; cursor: nwse-resize; }
     #${overlayId} [data-handle="n"] { left: 50%; top: -5px; transform: translateX(-50%); cursor: ns-resize; }

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -24,6 +24,7 @@ import { cn } from "@/lib/utils";
 import { isPptxCompatibleTemplate } from "@ipollowork/types/templates";
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal";
 import type { DesignAiSelectionContext } from "./design-ai-selection";
+import { useDesignAiSelectionStore } from "./design-ai-selection-store";
 import {
   buildDesignPreviewDocument,
   DESIGN_MESSAGE_CHANNEL,
@@ -593,6 +594,10 @@ export function DesignPanel({
   const [exportingPdf, setExportingPdf] = React.useState(false);
   const [exportingPptx, setExportingPptx] = React.useState(false);
   const [pptxConfirmationOpen, setPptxConfirmationOpen] = React.useState(false);
+  const aiUndoCheckpoint = useDesignAiSelectionStore((state) => (
+    state.undoCheckpoints[sessionId]?.[activePagePath]?.at(-1)
+  ));
+  const appliedAiCheckpointRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     if (!lockedPath) {
@@ -623,6 +628,25 @@ export function DesignPanel({
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
   });
+
+  React.useEffect(() => {
+    if (!aiUndoCheckpoint || appliedAiCheckpointRef.current === aiUndoCheckpoint.contextId) return;
+    appliedAiCheckpointRef.current = aiUndoCheckpoint.contextId;
+    queryClient.setQueryData<LoadedHtml>(
+      ["design-html", workspaceId, activePagePath] as const,
+      { content: aiUndoCheckpoint.afterHtml, updatedAt: aiUndoCheckpoint.afterUpdatedAt },
+    );
+    draftRef.current = aiUndoCheckpoint.afterHtml;
+    setDraft(aiUndoCheckpoint.afterHtml);
+    setSavedSource(aiUndoCheckpoint.afterHtml);
+    setPendingCanvasChange(false);
+    setSelection(null);
+    setQuickEdit(null);
+    setPreviewSource(aiUndoCheckpoint.afterHtml);
+    setHydratedPreviewSource("");
+    setPreviewLoaded(false);
+    setPreviewRevision((current) => current + 1);
+  }, [activePagePath, aiUndoCheckpoint, queryClient, workspaceId]);
   const usesNativeEditablePptx = Boolean(
     designTemplate
     && isPptxCompatibleTemplate(designTemplate)
@@ -1437,19 +1461,57 @@ export function DesignPanel({
     imageInputRef.current?.click();
   };
 
-  const undo = () => {
+  const undo = async () => {
     const previous = history[history.length - 1];
-    if (previous === undefined) return;
-    draftRef.current = previous;
-    setPendingCanvasChange(false);
-    setDraft(previous);
-    setHistory((current) => current.slice(0, -1));
-    setSelection(null);
-    setQuickEdit(null);
-    setPreviewSource(previous);
-    setHydratedPreviewSource("");
-    setPreviewLoaded(false);
-    setPreviewRevision((current) => current + 1);
+    if (previous !== undefined) {
+      draftRef.current = previous;
+      setPendingCanvasChange(false);
+      setDraft(previous);
+      setHistory((current) => current.slice(0, -1));
+      setSelection(null);
+      setQuickEdit(null);
+      setPreviewSource(previous);
+      setHydratedPreviewSource("");
+      setPreviewLoaded(false);
+      setPreviewRevision((current) => current + 1);
+      return;
+    }
+    const checkpoint = useDesignAiSelectionStore.getState().latestUndoCheckpoint(sessionId, activePagePath);
+    if (!checkpoint || !client || !workspaceId) return;
+    try {
+      const current = await client.readWorkspaceFile(workspaceId, activePagePath);
+      if (current.content !== checkpoint.afterHtml) {
+        throw new Error("This HTML file changed since the AI update.");
+      }
+      const result = await client.writeWorkspaceFile(workspaceId, {
+        path: activePagePath,
+        content: checkpoint.beforeHtml,
+        baseUpdatedAt: checkpoint.afterUpdatedAt,
+      });
+      const restored = await client.readWorkspaceFile(workspaceId, activePagePath);
+      useDesignAiSelectionStore.getState().popUndoCheckpoint(sessionId, activePagePath);
+      appliedAiCheckpointRef.current = useDesignAiSelectionStore.getState()
+        .latestUndoCheckpoint(sessionId, activePagePath)?.contextId ?? null;
+      queryClient.setQueryData<LoadedHtml>(
+        ["design-html", workspaceId, activePagePath] as const,
+        { content: restored.content, updatedAt: restored.updatedAt ?? result.updatedAt ?? null },
+      );
+      draftRef.current = restored.content;
+      setDraft(restored.content);
+      setSavedSource(restored.content);
+      setPendingCanvasChange(false);
+      setSelection(null);
+      setQuickEdit(null);
+      setPreviewSource(restored.content);
+      setHydratedPreviewSource("");
+      setPreviewLoaded(false);
+      setPreviewRevision((current) => current + 1);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "";
+      toast.error(message.includes("changed since")
+        ? "Could not undo the AI Design change because the file changed. Reload before trying again."
+        : message || "Could not undo the AI Design change.");
+    }
   };
 
   const dirty = pendingCanvasChange || draft !== savedSource;
@@ -1662,7 +1724,7 @@ export function DesignPanel({
                 <Palette className="size-3.5" />
               </Button>
             ) : null}
-            <Button variant="ghost" size="icon-sm" onClick={undo} disabled={history.length === 0} aria-label="Undo design change">
+            <Button variant="ghost" size="icon-sm" onClick={() => void undo()} disabled={history.length === 0 && !aiUndoCheckpoint} aria-label="Undo design change">
               <Undo2 />
             </Button>
             <Button size="sm" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending || (!editing && !dirty)}>

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -594,9 +594,11 @@ export function DesignPanel({
   const [exportingPdf, setExportingPdf] = React.useState(false);
   const [exportingPptx, setExportingPptx] = React.useState(false);
   const [pptxConfirmationOpen, setPptxConfirmationOpen] = React.useState(false);
-  const aiUndoCheckpoint = useDesignAiSelectionStore((state) => (
-    state.undoCheckpoints[sessionId]?.[activePagePath]?.at(-1)
-  ));
+  const aiUndoCheckpoint = useDesignAiSelectionStore((state) => {
+    const checkpoint = state.undoCheckpoints[sessionId]?.[activePagePath]?.at(-1);
+    const context = checkpoint ? state.contexts[checkpoint.contextId] : undefined;
+    return context?.workspaceId === workspaceId ? checkpoint : undefined;
+  });
   const appliedAiCheckpointRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -23,6 +23,7 @@ import { toast } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
 import { isPptxCompatibleTemplate } from "@ipollowork/types/templates";
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal";
+import type { DesignAiSelectionContext } from "./design-ai-selection";
 import {
   buildDesignPreviewDocument,
   DESIGN_MESSAGE_CHANNEL,
@@ -90,6 +91,7 @@ type DesignPanelProps = {
   workspaceId: string | null;
   isRemoteWorkspace?: boolean;
   launcherItems?: SidePanelLauncherItem[];
+  onAskAi: (context: DesignAiSelectionContext) => void;
   onClose: () => void;
 };
 
@@ -519,6 +521,7 @@ export function DesignPanel({
   workspaceId,
   isRemoteWorkspace = false,
   launcherItems = [],
+  onAskAi,
   onClose,
 }: DesignPanelProps) {
   const queryClient = useQueryClient();
@@ -1329,6 +1332,31 @@ export function DesignPanel({
     }, "*");
   };
 
+  const askAiAboutSelection = async () => {
+    if (!selection || !workspaceId || !activePagePath || !fileQuery.data) return;
+    const selected = selection;
+    const baseUpdatedAt = fileQuery.data.updatedAt;
+    const beforeHtml = await readLatestCanvasHtml();
+    const summary = (selected.text || selected.alt || selected.source).replace(/\s+/g, " ").trim().slice(0, 80);
+    onAskAi({
+      id: `design-ai-${crypto.randomUUID()}`,
+      sessionId,
+      workspaceId,
+      filePath: activePagePath,
+      baseUpdatedAt,
+      beforeHtml,
+      target: {
+        tag: selected.tag,
+        label: summary ? `${selected.tag.toUpperCase()} · ${summary}` : selected.tag.toUpperCase(),
+        locator: selected.locator,
+        text: selected.text,
+        src: selected.source,
+        alt: selected.alt,
+        styles: selected.styles,
+      },
+    });
+  };
+
   const applyToken = (name: string, value: string) => {
     if (!editing) return;
     setPendingCanvasChange(true);
@@ -1909,6 +1937,15 @@ export function DesignPanel({
                           aria-pressed={advancedOpen}
                         >
                           <SlidersHorizontal />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => void askAiAboutSelection()}
+                          disabled={!selection.canDelete}
+                          aria-label="Ask AI about selected element"
+                        >
+                          <Sparkles />
                         </Button>
                       </>
                     )}

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -119,7 +119,7 @@ const TYPE_PRESETS = [
 function isDesignRuntimeMessage(value: unknown): value is DesignRuntimeMessage {
   if (!value || typeof value !== "object") return false;
   return Reflect.get(value, "channel") === DESIGN_MESSAGE_CHANNEL
-    && (Reflect.get(value, "type") === "selected" || Reflect.get(value, "type") === "editing" || Reflect.get(value, "type") === "draft" || Reflect.get(value, "type") === "document-draft" || Reflect.get(value, "type") === "navigate" || Reflect.get(value, "type") === "deck" || Reflect.get(value, "type") === "zoom" || Reflect.get(value, "type") === "pan");
+    && (Reflect.get(value, "type") === "selected" || Reflect.get(value, "type") === "editing" || Reflect.get(value, "type") === "deselected" || Reflect.get(value, "type") === "draft" || Reflect.get(value, "type") === "document-draft" || Reflect.get(value, "type") === "navigate" || Reflect.get(value, "type") === "deck" || Reflect.get(value, "type") === "zoom" || Reflect.get(value, "type") === "pan");
 }
 
 function readDesignTokenValues(...sources: string[]): DesignTokenValues {
@@ -800,6 +800,12 @@ export function DesignPanel({
       }
       if (event.data.type === "pan") {
         presentationPanRef.current?.scrollBy({ left: -event.data.deltaX, top: -event.data.deltaY });
+        return;
+      }
+      if (event.data.type === "deselected") {
+        setSelection(null);
+        setQuickEdit(null);
+        setAdvancedOpen(false);
         return;
       }
       if (event.data.type === "document-draft") {

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -33,6 +33,7 @@ import {
 } from "lexical";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
+import { useDesignAiSelectionStore } from "../../design/design-ai-selection-store";
 
 type EditorProps = {
   value: string;
@@ -77,6 +78,16 @@ type SerializedComposerSkillNode = Spread<
   {
     skillName: string;
     type: "composer-skill";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+type SerializedComposerDesignSelectionNode = Spread<
+  {
+    contextId: string;
+    label: string;
+    type: "composer-design-selection";
     version: 1;
   },
   SerializedTextNode
@@ -300,6 +311,78 @@ function $createComposerSkillNode(skillName: string) {
   return $applyNodeReplacement(new ComposerSkillNode(skillName));
 }
 
+class ComposerDesignSelectionNode extends TextNode {
+  __contextId: string;
+  __label: string;
+
+  static override getType() {
+    return "composer-design-selection";
+  }
+
+  static override clone(node: ComposerDesignSelectionNode) {
+    return new ComposerDesignSelectionNode(node.__contextId, node.__label, node.__key);
+  }
+
+  static override importJSON(serializedNode: SerializedComposerDesignSelectionNode) {
+    return $createComposerDesignSelectionNode(serializedNode.contextId, serializedNode.label);
+  }
+
+  constructor(contextId = "", label = "Design selection", key?: NodeKey) {
+    super(`[[design-ai:${contextId}]]`, key);
+    this.__contextId = contextId;
+    this.__label = label;
+  }
+
+  override exportJSON(): SerializedComposerDesignSelectionNode {
+    return {
+      ...super.exportJSON(),
+      contextId: this.__contextId,
+      label: this.__label,
+      type: "composer-design-selection",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig) {
+    const dom = document.createElement("span");
+    dom.className = "inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11";
+    dom.textContent = this.__label;
+    dom.contentEditable = "false";
+    dom.setAttribute("data-composer-token", "design-selection");
+    dom.setAttribute("spellcheck", "false");
+    dom.title = `Design selection: ${this.__label}`;
+    return dom;
+  }
+
+  override updateDOM(prevNode: ComposerDesignSelectionNode, dom: HTMLElement) {
+    if (prevNode.__label !== this.__label) {
+      dom.textContent = this.__label;
+      dom.title = `Design selection: ${this.__label}`;
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+function $createComposerDesignSelectionNode(contextId: string, label: string) {
+  return $applyNodeReplacement(new ComposerDesignSelectionNode(contextId, label));
+}
+
 function pastedTextChipLabel(lines: number) {
   return `Pasted · ${lines} line${lines === 1 ? "" : "s"}`;
 }
@@ -418,7 +501,7 @@ function $createComposerPastedTextNode(label: string, lines: number) {
   return $applyNodeReplacement(new ComposerPastedTextNode(label, lines));
 }
 
-type ComposerInlineTokenNode = ComposerMentionNode | ComposerSlashCommandNode | ComposerSkillNode | ComposerPastedTextNode;
+type ComposerInlineTokenNode = ComposerMentionNode | ComposerSlashCommandNode | ComposerSkillNode | ComposerPastedTextNode | ComposerDesignSelectionNode;
 
 function setSelectionAfterNode(node: TextNode) {
   const parent = node.getParent();
@@ -480,10 +563,17 @@ function setPrompt(value: string, mentions: Record<string, ComposerMentionKind>,
     value = slashMatch[2] ?? "";
   }
 
-  const segments = value.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+  const segments = value.split(/(\[\[design-ai:[a-zA-Z0-9_-]+\]\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
   const pastedTextByLabel = new Map((pastedText ?? []).map((item) => [item.label, item]));
   for (const segment of segments) {
     if (!segment) continue;
+    const designSelectionMatch = segment.match(/^\[\[design-ai:([a-zA-Z0-9_-]+)\]\]$/);
+    if (designSelectionMatch?.[1]) {
+      const contextId = designSelectionMatch[1];
+      const label = useDesignAiSelectionStore.getState().contexts[contextId]?.target.label ?? "Design selection";
+      paragraph.append($createComposerDesignSelectionNode(contextId, label));
+      continue;
+    }
     const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
     if (pasteMatch?.[1]) {
       const target = pastedTextByLabel.get(pasteMatch[1]);
@@ -712,7 +802,7 @@ function MentionChipNavigationPlugin() {
         // --- Mention / pasted-text chips: atomic delete (same as before) ---
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode || previous instanceof ComposerDesignSelectionNode) {
             previous.remove();
             return true;
           }
@@ -720,7 +810,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isElementNode(anchorNode)) {
           const previous = anchorNode.getChildAtIndex(selection.anchor.offset - 1);
-          if (previous instanceof ComposerSlashCommandNode || previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerSlashCommandNode || previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode || previous instanceof ComposerDesignSelectionNode) {
             previous.remove();
             return true;
           }
@@ -740,7 +830,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSlashCommandNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
+          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSlashCommandNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode || previous instanceof ComposerDesignSelectionNode) {
             setSelectionBeforeNode(previous);
             return true;
           }
@@ -758,14 +848,14 @@ function MentionChipNavigationPlugin() {
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
         const anchorNode = selection.anchor.getNode();
 
-        if (anchorNode instanceof ComposerMentionNode || anchorNode instanceof ComposerSlashCommandNode || anchorNode instanceof ComposerSkillNode || anchorNode instanceof ComposerPastedTextNode) {
+        if (anchorNode instanceof ComposerMentionNode || anchorNode instanceof ComposerSlashCommandNode || anchorNode instanceof ComposerSkillNode || anchorNode instanceof ComposerPastedTextNode || anchorNode instanceof ComposerDesignSelectionNode) {
           setSelectionAfterNode(anchorNode);
           return true;
         }
 
         if ($isElementNode(anchorNode)) {
           const current = anchorNode.getChildAtIndex(selection.anchor.offset);
-          if (current instanceof ComposerMentionNode || current instanceof ComposerSlashCommandNode || current instanceof ComposerSkillNode || current instanceof ComposerPastedTextNode) {
+          if (current instanceof ComposerMentionNode || current instanceof ComposerSlashCommandNode || current instanceof ComposerSkillNode || current instanceof ComposerPastedTextNode || current instanceof ComposerDesignSelectionNode) {
             setSelectionAfterNode(current);
             return true;
           }
@@ -818,7 +908,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         throw error;
       },
         editable: !props.disabled,
-        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode],
+        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode, ComposerDesignSelectionNode],
         editorState: () => {
           setPrompt(props.value, props.mentions, props.pastedText);
         },

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -39,6 +39,7 @@ import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMe
 import { desktopBridge } from "@/app/lib/desktop";
 import { publicAssetUrl } from "@/app/lib/public-asset";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
+import { useDesignAiSelectionStore } from "../design/design-ai-selection-store";
 import { DevProfiler } from "@/react-app/shell/dev-profiler";
 import { useShellConfig } from "@/react-app/shell/shell-config";
 import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog";
@@ -78,6 +79,66 @@ import { NewConversationStarter, newConversationPlaceholder, type NewConversatio
 import { MessageListProvider, type DispatchAction } from "@/components/chat/message-list-provider";
 import { OpenTargetProvider, type OpenTargetOptions } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
+
+type ParseComposerPartsInput = {
+  mentions: Record<string, ComposerMentionKind>;
+  pasteParts: Array<{ id: string; label: string; text: string; lines: number }>;
+  designSelectionLabel: (contextId: string) => string | undefined;
+};
+
+export function parseComposerParts(text: string, input: ParseComposerPartsInput): ComposerPart[] {
+  const parts: ComposerPart[] = [];
+  const segments = text.split(/(\[\[design-ai:[a-zA-Z0-9_-]+\]\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+  for (const segment of segments) {
+    if (!segment) continue;
+    const designSelectionMatch = segment.match(/^\[\[design-ai:([a-zA-Z0-9_-]+)\]\]$/);
+    if (designSelectionMatch?.[1]) {
+      const contextId = designSelectionMatch[1];
+      parts.push({
+        type: "design-selection",
+        contextId,
+        label: input.designSelectionLabel(contextId) ?? "Design selection",
+      });
+      continue;
+    }
+    const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
+    if (pasteMatch) {
+      const target = input.pasteParts.find((item) => item.label === pasteMatch[1]);
+      if (target) {
+        parts.push({ type: "paste", id: target.id, label: target.label, text: target.text, lines: target.lines });
+        continue;
+      }
+    }
+    const skillMatch = segment.match(/^\[skill (.+)\]$/);
+    if (skillMatch?.[1]) {
+      parts.push({ type: "skill", name: skillMatch[1] });
+      continue;
+    }
+    if (segment.startsWith("@")) {
+      const value = decodeComposerMentionValue(segment.slice(1));
+      const kind = input.mentions[value];
+      if (kind === "agent") {
+        parts.push({ type: "agent", name: value });
+        continue;
+      }
+      if (kind === "file") {
+        parts.push({ type: "file", path: value, label: value });
+        continue;
+      }
+      if (kind === "app") {
+        parts.push({ type: "app", name: value });
+        continue;
+      }
+    }
+    parts.push({ type: "text", text: segment });
+  }
+  return parts;
+}
+
+export function replaceDesignSelectionToken(draft: string, token: string) {
+  const withoutPrevious = draft.replace(/\[\[design-ai:[a-zA-Z0-9_-]+\]\]\s*/g, "").trimEnd();
+  return `${withoutPrevious}${withoutPrevious ? "\n" : ""}${token} `;
+}
 import {
   EnvironmentVariableProvider,
   type ApplyEnvironmentChangesResult,
@@ -720,27 +781,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
-    const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
-      if (!segment) return [] as ComposerDraft["parts"];
-      const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
-      if (pasteMatch) {
-        const target = pasteParts.find((item) => item.label === pasteMatch[1]);
-        if (target) {
-          return [{ type: "paste", id: target.id, label: target.label, text: target.text, lines: target.lines }];
-        }
-      }
-      const skillMatch = segment.match(/^\[skill (.+)\]$/);
-      if (skillMatch?.[1]) {
-        return [{ type: "skill", name: skillMatch[1] } satisfies ComposerDraft["parts"][number]];
-      }
-      if (segment.startsWith("@")) {
-        const value = decodeComposerMentionValue(segment.slice(1));
-        const kind = mentions[value];
-        if (kind === "agent") return [{ type: "agent", name: value } satisfies ComposerDraft["parts"][number]];
-        if (kind === "file") return [{ type: "file", path: value, label: value } satisfies ComposerDraft["parts"][number]];
-        if (kind === "app") return [{ type: "app", name: value } satisfies ComposerDraft["parts"][number]];
-      }
-      return [{ type: "text", text: segment } satisfies ComposerDraft["parts"][number]];
+    const parts = parseComposerParts(text, {
+      mentions,
+      pasteParts,
+      designSelectionLabel: (contextId) => (
+        useDesignAiSelectionStore.getState().contexts[contextId]?.target.label
+      ),
     });
     // Expand paste placeholders in resolvedText so the model receives
     // the actual pasted content instead of "[pasted text <label>]".

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -139,6 +139,10 @@ export function shouldPreserveComposerDraftAfterSendFailure(draft: ComposerDraft
   return draft.parts.some((part) => part.type === "design-selection");
 }
 
+export function failedDraftRetrySurface(draft: ComposerDraft) {
+  return shouldPreserveComposerDraftAfterSendFailure(draft) ? "composer" : "queue";
+}
+
 export function replaceDesignSelectionToken(draft: string, token: string) {
   const withoutPrevious = draft.replace(/\[\[design-ai:[a-zA-Z0-9_-]+\]\]\s*/g, "").trimEnd();
   return `${withoutPrevious}${withoutPrevious ? "\n" : ""}${token} `;
@@ -966,8 +970,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
       try {
         await sendDraft(next, next.attachments);
       } catch {
-        // Restore the queue so the user can retry / edit on failure.
-        prependQueuedDrafts(props.sessionId, [next]);
+        if (failedDraftRetrySurface(next) === "composer") {
+          setComposerDraft(props.sessionId, next.text);
+        } else {
+          // Restore ordinary queued drafts so the user can retry / edit them.
+          prependQueuedDrafts(props.sessionId, [next]);
+        }
       } finally {
         drainingQueueRef.current = false;
       }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -135,6 +135,10 @@ export function parseComposerParts(text: string, input: ParseComposerPartsInput)
   return parts;
 }
 
+export function shouldPreserveComposerDraftAfterSendFailure(draft: ComposerDraft) {
+  return draft.parts.some((part) => part.type === "design-selection");
+}
+
 export function replaceDesignSelectionToken(draft: string, token: string) {
   const withoutPrevious = draft.replace(/\[\[design-ai:[a-zA-Z0-9_-]+\]\]\s*/g, "").trimEnd();
   return `${withoutPrevious}${withoutPrevious ? "\n" : ""}${token} `;
@@ -844,7 +848,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       captureAnalyticsEvent("task_send_failed", {});
       setError(parsed);
       useSessionActivityStore.getState().setError(props.workspaceId, props.sessionId, parsed.message);
-      setComposerDraft(props.sessionId, "");
+      if (!shouldPreserveComposerDraftAfterSendFailure(nextDraft)) setComposerDraft(props.sessionId, "");
       setAwaitingAssistantBaseline(null);
       setSending(false);
       throw nextError;
@@ -872,9 +876,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     try {
       await sendDraft(nextDraft, sentAttachments);
       clearComposer();
-    } catch {
-      setComposerDraft(props.sessionId, "");
-    }
+    } catch {}
   }, [attachments, buildDraft, clearComposer, draft, isEmptyConversation, newConversationMode, props.onActivateVideoStudio, props.sessionId, sendDraft, setComposerDraft]);
 
   const handleSteer = handleSend;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -296,6 +296,7 @@ export function designSelectionContextsForDraft(
     contexts.set(context.id, context);
   }
   if (errors.length > 0) throw new Error(errors[0]);
+  if (contexts.size > 1) throw new Error("Only one Design element can be edited at a time.");
   return [...contexts.values()];
 }
 
@@ -924,6 +925,7 @@ export function SessionRoute() {
             });
           } else {
             completeWithoutChange(context.id);
+            toast.info("No Design change was detected.");
           }
         } catch {
           fail(context.id);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -12,6 +12,7 @@ import type {
   AgentPartInput,
   FilePartInput,
   ProviderListResponse,
+  SessionStatus,
   TextPartInput,
 } from "@opencode-ai/sdk/v2/client";
 
@@ -102,6 +103,8 @@ import {
   applySessionRevert,
 } from "@/react-app/domains/session/sync/session-sync";
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
+import { designAiSelectionInstruction } from "@/react-app/domains/session/design/design-ai-selection";
+import { useDesignAiSelectionStore } from "@/react-app/domains/session/design/design-ai-selection-store";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
@@ -253,7 +256,11 @@ function attachmentMime(attachment: ComposerAttachment) {
   return "text/plain";
 }
 
-async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
+export async function draftToParts(
+  draft: ComposerDraft,
+  workspaceRoot: string,
+  designSelectionStore: Pick<typeof useDesignAiSelectionStore, "getState"> = useDesignAiSelectionStore,
+) {
   const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
   const root = workspaceRoot.trim();
 
@@ -273,6 +280,17 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
   };
 
   for (const part of draft.parts) {
+    if (part.type === "design-selection") {
+      const context = designSelectionStore.getState().contexts[part.contextId];
+      if (context) {
+        parts.push({
+          type: "text",
+          text: designAiSelectionInstruction(context),
+          synthetic: true,
+        });
+      }
+      continue;
+    }
     if (part.type === "text") {
       parts.push({
         type: "text",
@@ -811,6 +829,34 @@ export function SessionRoute() {
     navigate("/help", { state: { returnTo } });
   }, [navigate, selectedSessionId, sidebarActiveWorkspaceId]);
 
+  const handleSessionStatus = useCallback((update: { sessionId: string; status: SessionStatus }) => {
+    if (update.status.type !== "idle" || !selectedWorkspaceEndpoint) return;
+    const { contexts, statuses, complete, completeWithoutChange, fail } = useDesignAiSelectionStore.getState();
+    const runningContexts = Object.values(contexts).filter((context) => (
+      context.sessionId === update.sessionId
+      && context.workspaceId === selectedWorkspaceEndpoint.workspaceId
+      && statuses[context.id] === "running"
+    ));
+
+    for (const context of runningContexts) {
+      void (async () => {
+        try {
+          const after = await selectedWorkspaceEndpoint.client.readWorkspaceFile(context.workspaceId, context.filePath);
+          if (after.content !== context.beforeHtml) {
+            complete(context.id, {
+              afterHtml: after.content,
+              afterUpdatedAt: after.updatedAt ?? null,
+            });
+          } else {
+            completeWithoutChange(context.id);
+          }
+        } catch {
+          fail(context.id);
+        }
+      })();
+    }
+  }, [selectedWorkspaceEndpoint]);
+
   const surfaceProps = useMemo(() => {
     if (!client || !selectedWorkspaceId || !selectedSessionId || !opencodeBaseUrl || !token || !opencodeClient) {
       return null;
@@ -1017,6 +1063,28 @@ export function SessionRoute() {
           ...capabilityPromptPart,
           ...parts,
         ];
+        const designSelectionContexts = draft.parts.flatMap((part) => {
+          if (part.type !== "design-selection") return [];
+          const context = useDesignAiSelectionStore.getState().contexts[part.contextId];
+          return context?.sessionId === targetSessionId ? [context] : [];
+        });
+        for (const context of designSelectionContexts) {
+          if (!selectedWorkspaceEndpoint || context.workspaceId !== selectedWorkspaceEndpoint.workspaceId) {
+            useDesignAiSelectionStore.getState().fail(context.id);
+            throw new Error("The selected Design element is no longer available in this workspace.");
+          }
+          const current = await selectedWorkspaceEndpoint.client.readWorkspaceFile(context.workspaceId, context.filePath);
+          if ((current.updatedAt ?? null) !== context.baseUpdatedAt) {
+            useDesignAiSelectionStore.getState().fail(context.id);
+            throw new Error("The selected Design file changed before the AI update. Reload it and try again.");
+          }
+          await selectedWorkspaceEndpoint.client.writeWorkspaceFile(context.workspaceId, {
+            path: context.filePath,
+            content: context.beforeHtml,
+            baseUpdatedAt: current.updatedAt ?? null,
+          });
+          useDesignAiSelectionStore.getState().markRunning(context.id);
+        }
         const result = await opencodeClient.session.promptAsync({
           sessionID: targetSessionId,
           parts: promptParts,
@@ -1966,6 +2034,7 @@ export function SessionRoute() {
         opencodeBaseUrl={opencodeBaseUrl}
         ipolloworkToken={selectedWorkspaceServerToken}
         onSessionUpdated={handleRuntimeSessionUpdated}
+        onSessionStatus={handleSessionStatus}
       />
     ) : null}
     <SessionPage

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -356,10 +356,13 @@ export async function draftToParts(
   const designContexts = new Map(
     designSelectionContextsForDraft(draft, designSelectionStore, scope).map((context) => [context.id, context]),
   );
+  const expandedDesignContextIds = new Set<string>();
   for (const part of draft.parts) {
     if (part.type === "design-selection") {
+      if (expandedDesignContextIds.has(part.contextId)) continue;
       const context = designContexts.get(part.contextId);
       if (!context) throw new Error("The selected Design element is no longer available.");
+      expandedDesignContextIds.add(part.contextId);
       parts.push({
         type: "text",
         text: designAiSelectionInstruction(context),

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -103,7 +103,10 @@ import {
   applySessionRevert,
 } from "@/react-app/domains/session/sync/session-sync";
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
-import { designAiSelectionInstruction } from "@/react-app/domains/session/design/design-ai-selection";
+import {
+  designAiSelectionInstruction,
+  type DesignAiSelectionContext,
+} from "@/react-app/domains/session/design/design-ai-selection";
 import { useDesignAiSelectionStore } from "@/react-app/domains/session/design/design-ai-selection-store";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
@@ -256,10 +259,80 @@ function attachmentMime(attachment: ComposerAttachment) {
   return "text/plain";
 }
 
+type DesignSelectionScope = {
+  sessionId: string;
+  workspaceId: string;
+};
+
+type DesignSelectionWorkspaceClient = {
+  readWorkspaceFile: (workspaceId: string, path: string) => Promise<{ content: string; updatedAt?: number | null }>;
+  writeWorkspaceFile: (workspaceId: string, payload: { path: string; content: string; baseUpdatedAt?: number | null }) => Promise<unknown>;
+};
+
+type DesignSelectionStore = Pick<typeof useDesignAiSelectionStore, "getState">;
+
+export function designSelectionContextsForDraft(
+  draft: ComposerDraft,
+  designSelectionStore: DesignSelectionStore,
+  scope: DesignSelectionScope | undefined,
+) {
+  const contexts = new Map<string, DesignAiSelectionContext>();
+  const errors: string[] = [];
+  for (const part of draft.parts) {
+    if (part.type !== "design-selection") continue;
+    const context = designSelectionStore.getState().contexts[part.contextId];
+    if (!context) {
+      errors.push("The selected Design element is no longer available.");
+      continue;
+    }
+    if (!scope || context.sessionId !== scope.sessionId) {
+      errors.push("The selected Design element does not belong to this session.");
+      continue;
+    }
+    if (context.workspaceId !== scope.workspaceId) {
+      errors.push("The selected Design element does not belong to this workspace.");
+      continue;
+    }
+    contexts.set(context.id, context);
+  }
+  if (errors.length > 0) throw new Error(errors[0]);
+  return [...contexts.values()];
+}
+
+export async function promptDesignSelectionContexts(input: {
+  contexts: DesignAiSelectionContext[];
+  workspaceClient: DesignSelectionWorkspaceClient;
+  prompt: () => Promise<{ error?: unknown }>;
+  designSelectionStore?: DesignSelectionStore;
+}) {
+  const designSelectionStore = input.designSelectionStore ?? useDesignAiSelectionStore;
+  try {
+    for (const context of input.contexts) {
+      const current = await input.workspaceClient.readWorkspaceFile(context.workspaceId, context.filePath);
+      if ((current.updatedAt ?? null) !== context.baseUpdatedAt) {
+        throw new Error("The selected Design file changed before the AI update. Reload it and try again.");
+      }
+      await input.workspaceClient.writeWorkspaceFile(context.workspaceId, {
+        path: context.filePath,
+        content: context.beforeHtml,
+        baseUpdatedAt: current.updatedAt ?? null,
+      });
+      designSelectionStore.getState().markRunning(context.id);
+    }
+    const result = await input.prompt();
+    if (result.error) throw new Error(serializeSDKError(result.error));
+    return result;
+  } catch (error) {
+    for (const context of input.contexts) designSelectionStore.getState().fail(context.id);
+    throw error;
+  }
+}
+
 export async function draftToParts(
   draft: ComposerDraft,
   workspaceRoot: string,
-  designSelectionStore: Pick<typeof useDesignAiSelectionStore, "getState"> = useDesignAiSelectionStore,
+  designSelectionStore: DesignSelectionStore = useDesignAiSelectionStore,
+  scope?: DesignSelectionScope,
 ) {
   const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
   const root = workspaceRoot.trim();
@@ -279,16 +352,18 @@ export async function draftToParts(
     return segments[segments.length - 1] ?? "file";
   };
 
+  const designContexts = new Map(
+    designSelectionContextsForDraft(draft, designSelectionStore, scope).map((context) => [context.id, context]),
+  );
   for (const part of draft.parts) {
     if (part.type === "design-selection") {
-      const context = designSelectionStore.getState().contexts[part.contextId];
-      if (context) {
-        parts.push({
-          type: "text",
-          text: designAiSelectionInstruction(context),
-          synthetic: true,
-        });
-      }
+      const context = designContexts.get(part.contextId);
+      if (!context) throw new Error("The selected Design element is no longer available.");
+      parts.push({
+        type: "text",
+        text: designAiSelectionInstruction(context),
+        synthetic: true,
+      });
       continue;
     }
     if (part.type === "text") {
@@ -831,14 +906,14 @@ export function SessionRoute() {
 
   const handleSessionStatus = useCallback((update: { sessionId: string; status: SessionStatus }) => {
     if (update.status.type !== "idle" || !selectedWorkspaceEndpoint) return;
-    const { contexts, statuses, complete, completeWithoutChange, fail } = useDesignAiSelectionStore.getState();
+    const { contexts, complete, completeWithoutChange, fail } = useDesignAiSelectionStore.getState();
     const runningContexts = Object.values(contexts).filter((context) => (
       context.sessionId === update.sessionId
       && context.workspaceId === selectedWorkspaceEndpoint.workspaceId
-      && statuses[context.id] === "running"
     ));
 
     for (const context of runningContexts) {
+      if (!useDesignAiSelectionStore.getState().claimCompletion(context.id)) continue;
       void (async () => {
         try {
           const after = await selectedWorkspaceEndpoint.client.readWorkspaceFile(context.workspaceId, context.filePath);
@@ -995,7 +1070,20 @@ export function SessionRoute() {
           return;
         }
 
-        const parts = await draftToParts(draft, selectedWorkspaceRoot);
+        const designSelectionScope = selectedWorkspaceEndpoint
+          ? { sessionId: targetSessionId, workspaceId: selectedWorkspaceEndpoint.workspaceId }
+          : undefined;
+        const designSelectionContexts = designSelectionContextsForDraft(
+          draft,
+          useDesignAiSelectionStore,
+          designSelectionScope,
+        );
+        const parts = await draftToParts(
+          draft,
+          selectedWorkspaceRoot,
+          useDesignAiSelectionStore,
+          designSelectionScope,
+        );
         const envSystemContext = await buildiPolloWorkEnvSystemContext(client, {
           cacheKey: targetSessionId,
           runtimeKey: environmentRuntimeKey,
@@ -1063,39 +1151,24 @@ export function SessionRoute() {
           ...capabilityPromptPart,
           ...parts,
         ];
-        const designSelectionContexts = draft.parts.flatMap((part) => {
-          if (part.type !== "design-selection") return [];
-          const context = useDesignAiSelectionStore.getState().contexts[part.contextId];
-          return context?.sessionId === targetSessionId ? [context] : [];
-        });
-        for (const context of designSelectionContexts) {
-          if (!selectedWorkspaceEndpoint || context.workspaceId !== selectedWorkspaceEndpoint.workspaceId) {
-            useDesignAiSelectionStore.getState().fail(context.id);
-            throw new Error("The selected Design element is no longer available in this workspace.");
-          }
-          const current = await selectedWorkspaceEndpoint.client.readWorkspaceFile(context.workspaceId, context.filePath);
-          if ((current.updatedAt ?? null) !== context.baseUpdatedAt) {
-            useDesignAiSelectionStore.getState().fail(context.id);
-            throw new Error("The selected Design file changed before the AI update. Reload it and try again.");
-          }
-          await selectedWorkspaceEndpoint.client.writeWorkspaceFile(context.workspaceId, {
-            path: context.filePath,
-            content: context.beforeHtml,
-            baseUpdatedAt: current.updatedAt ?? null,
-          });
-          useDesignAiSelectionStore.getState().markRunning(context.id);
+        if (designSelectionContexts.length > 0 && !selectedWorkspaceEndpoint) {
+          throw new Error("The selected Design element is no longer available in this workspace.");
         }
-        const result = await opencodeClient.session.promptAsync({
-          sessionID: targetSessionId,
-          parts: promptParts,
-          model: local.prefs.defaultModel ?? undefined,
-          agent: selectedAgent ?? undefined,
-          ...(modelVariantValue ? { variant: modelVariantValue } : {}),
-          ...(systemContext ? { system: systemContext } : {}),
+        const result = await promptDesignSelectionContexts({
+          contexts: designSelectionContexts,
+          workspaceClient: selectedWorkspaceEndpoint?.client ?? {
+            readWorkspaceFile: async () => { throw new Error("The selected Design element is no longer available in this workspace."); },
+            writeWorkspaceFile: async () => { throw new Error("The selected Design element is no longer available in this workspace."); },
+          },
+          prompt: () => opencodeClient.session.promptAsync({
+            sessionID: targetSessionId,
+            parts: promptParts,
+            model: local.prefs.defaultModel ?? undefined,
+            agent: selectedAgent ?? undefined,
+            ...(modelVariantValue ? { variant: modelVariantValue } : {}),
+            ...(systemContext ? { system: systemContext } : {}),
+          }),
         });
-        if (result.error) {
-          throw new Error(serializeSDKError(result.error));
-        }
       },
       onDraftChange: () => {
         // Draft persistence will be wired once the full React shell owns session state.
@@ -2292,6 +2365,7 @@ export function SessionRoute() {
               const endpoint = endpointForWorkspace(selectedWorkspace);
               if (!endpoint) return;
               await endpoint.client.deleteSession(endpoint.workspaceId, sessionId);
+              useDesignAiSelectionStore.getState().resetSession(sessionId);
               if (selectedSessionId === sessionId) {
                 writeLastSessionFor(selectedWorkspaceId, null);
                 navigateToWorkspaceSession(selectedWorkspaceId);

--- a/apps/app/tests/design-ai-composer.test.ts
+++ b/apps/app/tests/design-ai-composer.test.ts
@@ -40,6 +40,24 @@ describe("Design AI composer integration", () => {
     ).toBe("make it blue\n[[design-ai:design-ai-new]] ");
   });
 
+  test("preserves a Design selection draft when prompt submission fails", () => {
+    expect(sessionSurface.shouldPreserveComposerDraftAfterSendFailure).toBeFunction();
+    if (typeof sessionSurface.shouldPreserveComposerDraftAfterSendFailure !== "function") return;
+
+    expect(sessionSurface.shouldPreserveComposerDraftAfterSendFailure({
+      mode: "prompt",
+      parts: [{ type: "design-selection", contextId: "design-ai-1", label: "H1 Original" }],
+      attachments: [],
+      text: "[[design-ai:design-ai-1]] Make it blue.",
+    })).toBe(true);
+    expect(sessionSurface.shouldPreserveComposerDraftAfterSendFailure({
+      mode: "prompt",
+      parts: [{ type: "text", text: "Ordinary prompt" }],
+      attachments: [],
+      text: "Ordinary prompt",
+    })).toBe(false);
+  });
+
   test("renders a Design token as an atomic purple chip", async () => {
     const source = await Bun.file(editorUrl).text();
 

--- a/apps/app/tests/design-ai-composer.test.ts
+++ b/apps/app/tests/design-ai-composer.test.ts
@@ -58,6 +58,27 @@ describe("Design AI composer integration", () => {
     })).toBe(false);
   });
 
+  test("uses the composer, not the queue, as the sole retry surface for a failed queued Design draft", () => {
+    expect(sessionSurface.failedDraftRetrySurface).toBeFunction();
+    if (typeof sessionSurface.failedDraftRetrySurface !== "function") return;
+
+    const designDraft = {
+      mode: "prompt" as const,
+      parts: [{ type: "design-selection" as const, contextId: "design-ai-1", label: "H1 Original" }],
+      attachments: [],
+      text: "[[design-ai:design-ai-1]] Make it blue.",
+    };
+    const ordinaryDraft = {
+      mode: "prompt" as const,
+      parts: [{ type: "text" as const, text: "Ordinary prompt" }],
+      attachments: [],
+      text: "Ordinary prompt",
+    };
+
+    expect(sessionSurface.failedDraftRetrySurface(designDraft)).toBe("composer");
+    expect(sessionSurface.failedDraftRetrySurface(ordinaryDraft)).toBe("queue");
+  });
+
   test("renders a Design token as an atomic purple chip", async () => {
     const source = await Bun.file(editorUrl).text();
 

--- a/apps/app/tests/design-ai-composer.test.ts
+++ b/apps/app/tests/design-ai-composer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import * as sessionSurface from "../src/react-app/domains/session/surface/session-surface";
+
+const editorUrl = new URL(
+  "../src/react-app/domains/session/surface/composer/editor.tsx",
+  import.meta.url,
+);
+const sessionPageUrl = new URL(
+  "../src/react-app/domains/session/chat/session-page.tsx",
+  import.meta.url,
+);
+
+describe("Design AI composer integration", () => {
+  test("converts one Design token into a structured composer part", () => {
+    expect(sessionSurface.parseComposerParts).toBeFunction();
+    if (typeof sessionSurface.parseComposerParts !== "function") return;
+    const parts = sessionSurface.parseComposerParts("[[design-ai:design-ai-1]] make it blue", {
+      mentions: {},
+      pasteParts: [],
+      designSelectionLabel: () => "H1 路 Original",
+    });
+
+    expect(parts).toContainEqual({
+      type: "design-selection",
+      contextId: "design-ai-1",
+      label: "H1 路 Original",
+    });
+    expect(parts).toContainEqual({ type: "text", text: " make it blue" });
+  });
+
+  test("replaces the previous Design token without changing the current prompt", () => {
+    expect(sessionSurface.replaceDesignSelectionToken).toBeFunction();
+    if (typeof sessionSurface.replaceDesignSelectionToken !== "function") return;
+    expect(
+      sessionSurface.replaceDesignSelectionToken(
+        "[[design-ai:design-ai-old]] make it blue",
+        "[[design-ai:design-ai-new]]",
+      ),
+    ).toBe("make it blue\n[[design-ai:design-ai-new]] ");
+  });
+
+  test("renders a Design token as an atomic purple chip", async () => {
+    const source = await Bun.file(editorUrl).text();
+
+    expect(source).toContain("composer-design-selection");
+    expect(source).toContain('data-composer-token", "design-selection"');
+    expect(source).toContain('contentEditable = "false"');
+    expect(source).toContain("violet");
+    expect(source).toContain("ComposerDesignSelectionNode");
+  });
+
+  test("wires Ask AI through the composer draft store and focuses the prompt", async () => {
+    const source = await Bun.file(sessionPageUrl).text();
+
+    expect(source).toContain("onAskAi={handleDesignAskAi}");
+    expect(source).toContain("useComposerStateStore.getState()");
+    expect(source).toContain("replaceDesignSelectionToken");
+    expect(source).toContain('new Event("ipollowork:focusPrompt")');
+  });
+});

--- a/apps/app/tests/design-ai-selection.test.ts
+++ b/apps/app/tests/design-ai-selection.test.ts
@@ -51,8 +51,12 @@ describe("Design AI selections", () => {
 
   test("stores an immutable Design selection context", () => {
     const store = useDesignAiSelectionStore.getState();
-    store.createContext(context);
-    context.target.styles.color = "red";
+    const mutableContext = {
+      ...context,
+      target: { ...context.target, styles: { ...context.target.styles } },
+    };
+    store.createContext(mutableContext);
+    mutableContext.target.styles.color = "red";
 
     expect(useDesignAiSelectionStore.getState().contexts["design-ai-1"]?.target.styles.color).toBe("black");
   });
@@ -60,6 +64,8 @@ describe("Design AI selections", () => {
   test("keeps completed checkpoints in LIFO order", () => {
     const store = useDesignAiSelectionStore.getState();
     store.createContext(context);
+    store.markRunning("design-ai-1");
+    store.claimCompletion("design-ai-1");
     store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
 
     const secondContext = {
@@ -69,6 +75,8 @@ describe("Design AI selections", () => {
       baseUpdatedAt: 13,
     };
     store.createContext(secondContext);
+    store.markRunning("design-ai-2");
+    store.claimCompletion("design-ai-2");
     store.complete("design-ai-2", { afterHtml: "<h1>Two</h1>", afterUpdatedAt: 15 });
 
     expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("One");
@@ -80,6 +88,7 @@ describe("Design AI selections", () => {
     const store = useDesignAiSelectionStore.getState();
     store.createContext(context);
     store.markRunning("design-ai-1");
+    expect(store.claimCompletion("design-ai-1")).toBe(true);
     store.completeWithoutChange("design-ai-1");
 
     expect(useDesignAiSelectionStore.getState().statuses["design-ai-1"]).toBe("completed");
@@ -90,10 +99,25 @@ describe("Design AI selections", () => {
     const store = useDesignAiSelectionStore.getState();
     store.createContext(context);
     store.markRunning("design-ai-1");
+    expect(store.claimCompletion("design-ai-1")).toBe(true);
+    expect(store.claimCompletion("design-ai-1")).toBe(false);
     store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
     store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
 
     expect(useDesignAiSelectionStore.getState().undoCheckpoints.ses_1?.[context.filePath]).toHaveLength(1);
+  });
+
+  test("does not revive terminal completion after an idle race", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+    store.markRunning("design-ai-1");
+    expect(store.claimCompletion("design-ai-1")).toBe(true);
+    store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
+    store.fail("design-ai-1");
+    store.completeWithoutChange("design-ai-1");
+
+    expect(useDesignAiSelectionStore.getState().statuses["design-ai-1"]).toBe("completed");
+    expect(store.latestUndoCheckpoint("ses_1", context.filePath)?.afterHtml).toContain("One");
   });
 
   test("writes the AI pre-image with the post-agent revision during undo", async () => {
@@ -105,12 +129,14 @@ describe("Design AI selections", () => {
     expect(source).toContain("checkpoint.afterHtml");
     expect(source).toContain("const restored = await client.readWorkspaceFile(workspaceId, activePagePath)");
     expect(source).toContain("setPreviewRevision((current) => current + 1)");
+    expect(source).toContain("context?.workspaceId === workspaceId");
   });
 
   test("removes every context and checkpoint for a reset session", () => {
     const store = useDesignAiSelectionStore.getState();
     store.createContext(context);
     store.markRunning("design-ai-1");
+    store.claimCompletion("design-ai-1");
     store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
     store.fail("design-ai-1");
     store.resetSession("ses_1");

--- a/apps/app/tests/design-ai-selection.test.ts
+++ b/apps/app/tests/design-ai-selection.test.ts
@@ -26,6 +26,11 @@ const context: DesignAiSelectionContext = {
   },
 };
 
+const panelUrl = new URL(
+  "../src/react-app/domains/session/design/design-panel.tsx",
+  import.meta.url,
+);
+
 describe("Design AI selections", () => {
   beforeEach(() => {
     useDesignAiSelectionStore.getState().resetSession("ses_1");
@@ -69,6 +74,37 @@ describe("Design AI selections", () => {
     expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("One");
     expect(store.popUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("One");
     expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("Original");
+  });
+
+  test("completes an unchanged agent turn without creating an undo checkpoint", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+    store.markRunning("design-ai-1");
+    store.completeWithoutChange("design-ai-1");
+
+    expect(useDesignAiSelectionStore.getState().statuses["design-ai-1"]).toBe("completed");
+    expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")).toBeUndefined();
+  });
+
+  test("does not duplicate a checkpoint when completion is delivered twice", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+    store.markRunning("design-ai-1");
+    store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
+    store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
+
+    expect(useDesignAiSelectionStore.getState().undoCheckpoints.ses_1?.[context.filePath]).toHaveLength(1);
+  });
+
+  test("writes the AI pre-image with the post-agent revision during undo", async () => {
+    const source = await Bun.file(panelUrl).text();
+
+    expect(source).toContain("baseUpdatedAt: checkpoint.afterUpdatedAt");
+    expect(source).toContain("Could not undo the AI Design change because the file changed");
+    expect(source).toContain("popUndoCheckpoint(sessionId, activePagePath)");
+    expect(source).toContain("checkpoint.afterHtml");
+    expect(source).toContain("const restored = await client.readWorkspaceFile(workspaceId, activePagePath)");
+    expect(source).toContain("setPreviewRevision((current) => current + 1)");
   });
 
   test("removes every context and checkpoint for a reset session", () => {

--- a/apps/app/tests/design-ai-selection.test.ts
+++ b/apps/app/tests/design-ai-selection.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  designAiSelectionInstruction,
+  designAiSelectionToken,
+  parseDesignAiSelectionToken,
+  type DesignAiSelectionContext,
+} from "../src/react-app/domains/session/design/design-ai-selection";
+import { useDesignAiSelectionStore } from "../src/react-app/domains/session/design/design-ai-selection-store";
+
+const context: DesignAiSelectionContext = {
+  id: "design-ai-1",
+  sessionId: "ses_1",
+  workspaceId: "workspace_1",
+  filePath: "design/ses_1/index.html",
+  baseUpdatedAt: 11,
+  beforeHtml: "<h1>Original</h1>",
+  target: {
+    tag: "h1",
+    label: "H1 · Original",
+    locator: "body > h1:nth-of-type(1)",
+    text: "Original",
+    src: "",
+    alt: "",
+    styles: { color: "black" },
+  },
+};
+
+describe("Design AI selections", () => {
+  beforeEach(() => {
+    useDesignAiSelectionStore.getState().resetSession("ses_1");
+  });
+
+  test("round-trips a Design selection chip token", () => {
+    expect(parseDesignAiSelectionToken(designAiSelectionToken("design-ai-1"))).toBe("design-ai-1");
+    expect(parseDesignAiSelectionToken("[design-ai:design-ai-1]")).toBeNull();
+  });
+
+  test("restricts the agent instruction to one element in one file", () => {
+    const instruction = designAiSelectionInstruction(context);
+
+    expect(instruction).toContain("design/ses_1/index.html");
+    expect(instruction).toContain("body > h1:nth-of-type(1)");
+    expect(instruction).toContain("Do not modify any other element");
+  });
+
+  test("stores an immutable Design selection context", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+    context.target.styles.color = "red";
+
+    expect(useDesignAiSelectionStore.getState().contexts["design-ai-1"]?.target.styles.color).toBe("black");
+  });
+
+  test("keeps completed checkpoints in LIFO order", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+    store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
+
+    const secondContext = {
+      ...context,
+      id: "design-ai-2",
+      beforeHtml: "<h1>One</h1>",
+      baseUpdatedAt: 13,
+    };
+    store.createContext(secondContext);
+    store.complete("design-ai-2", { afterHtml: "<h1>Two</h1>", afterUpdatedAt: 15 });
+
+    expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("One");
+    expect(store.popUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("One");
+    expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("Original");
+  });
+
+  test("removes every context and checkpoint for a reset session", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+    store.markRunning("design-ai-1");
+    store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
+    store.fail("design-ai-1");
+    store.resetSession("ses_1");
+
+    expect(useDesignAiSelectionStore.getState().contexts["design-ai-1"]).toBeUndefined();
+    expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")).toBeUndefined();
+  });
+});

--- a/apps/app/tests/design-ai-session-route.test.ts
+++ b/apps/app/tests/design-ai-session-route.test.ts
@@ -154,6 +154,26 @@ describe("Design AI session lifecycle", () => {
     )).rejects.toThrow("Only one Design element can be edited at a time");
   });
 
+  test("expands repeated copies of the same Design token only once", async () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    const parts = await sessionRoute.draftToParts({
+      mode: "prompt",
+      parts: [
+        { type: "design-selection", contextId: lifecycleContext.id, label: "H1 Original" },
+        { type: "design-selection", contextId: lifecycleContext.id, label: "H1 Original" },
+        { type: "text", text: "Make it blue." },
+      ],
+      attachments: [],
+      text: "",
+    }, "C:/workspace", useDesignAiSelectionStore, { sessionId: "ses_1", workspaceId: "workspace_1" });
+
+    expect(parts).toEqual([
+      expect.objectContaining({ type: "text", synthetic: true }),
+      { type: "text", text: "Make it blue." },
+    ]);
+  });
+
   test("notifies once when an idle Design turn made no change", async () => {
     const source = await Bun.file(routeUrl).text();
 

--- a/apps/app/tests/design-ai-session-route.test.ts
+++ b/apps/app/tests/design-ai-session-route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import type { ComposerDraft } from "../src/app/types";
 import * as sessionRoute from "../src/react-app/shell/session-route";
+import type { DesignAiSelectionContext } from "../src/react-app/domains/session/design/design-ai-selection";
 import { useDesignAiSelectionStore } from "../src/react-app/domains/session/design/design-ai-selection-store";
 
 const routeUrl = new URL("../src/react-app/shell/session-route.tsx", import.meta.url);
@@ -9,6 +10,24 @@ const runtimeUrl = new URL(
   "../src/react-app/domains/session/sync/runtime-sync.tsx",
   import.meta.url,
 );
+
+const lifecycleContext: DesignAiSelectionContext = {
+  id: "design-ai-lifecycle",
+  sessionId: "ses_1",
+  workspaceId: "workspace_1",
+  filePath: "design/ses_1/index.html",
+  baseUpdatedAt: 11,
+  beforeHtml: "<h1>Original</h1>",
+  target: {
+    tag: "h1",
+    label: "H1 Original",
+    locator: "body > h1:nth-of-type(1)",
+    text: "Original",
+    src: "",
+    alt: "",
+    styles: { color: "black" },
+  },
+};
 
 describe("Design AI session lifecycle", () => {
   beforeEach(() => {
@@ -50,6 +69,7 @@ describe("Design AI session lifecycle", () => {
       draft,
       "C:/workspace",
       useDesignAiSelectionStore,
+      { sessionId: "ses_1", workspaceId: "workspace_1" },
     );
 
     expect(parts[0]).toMatchObject({ type: "text", synthetic: true });
@@ -74,11 +94,85 @@ describe("Design AI session lifecycle", () => {
     expect(markRunning).toBeGreaterThan(preflightRead);
     expect(prompt).toBeGreaterThan(markRunning);
     expect(source).toContain('update.status.type !== "idle"');
-    expect(source).toContain('statuses[context.id] === "running"');
+    expect(source).toContain("claimCompletion(context.id)");
     expect(source).toContain("after.content !== context.beforeHtml");
     expect(source).toContain("afterUpdatedAt: after.updatedAt ?? null");
     expect(source).toContain("completeWithoutChange(context.id)");
     expect(source).toContain("onSessionStatus={handleSessionStatus}");
+  });
+
+  test("rejects missing and foreign Design contexts before synthetic expansion", async () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    const draft = (contextId: string): ComposerDraft => ({
+      mode: "prompt",
+      parts: [{ type: "design-selection", contextId, label: "H1 Original" }],
+      attachments: [],
+      text: "",
+    });
+
+    await expect(sessionRoute.draftToParts(
+      draft(lifecycleContext.id),
+      "C:/workspace",
+      useDesignAiSelectionStore,
+      { sessionId: "ses_2", workspaceId: "workspace_1" },
+    )).rejects.toThrow("does not belong to this session");
+    await expect(sessionRoute.draftToParts(
+      draft(lifecycleContext.id),
+      "C:/workspace",
+      useDesignAiSelectionStore,
+      { sessionId: "ses_1", workspaceId: "workspace_2" },
+    )).rejects.toThrow("does not belong to this workspace");
+    await expect(sessionRoute.draftToParts(
+      draft("missing"),
+      "C:/workspace",
+      useDesignAiSelectionStore,
+      { sessionId: "ses_1", workspaceId: "workspace_1" },
+    )).rejects.toThrow("is no longer available");
+  });
+
+  test("marks all preflighted contexts failed when prompt submission rejects", async () => {
+    const second = { ...lifecycleContext, id: "design-ai-lifecycle-2" };
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    store.createContext(second);
+
+    await expect(sessionRoute.promptDesignSelectionContexts({
+      contexts: [lifecycleContext, second],
+      workspaceClient: {
+        readWorkspaceFile: async () => ({ content: "<h1>Original</h1>", updatedAt: 11 }),
+        writeWorkspaceFile: async () => ({ updatedAt: 12 }),
+      },
+      prompt: async () => { throw new Error("prompt failed"); },
+      designSelectionStore: useDesignAiSelectionStore,
+    })).rejects.toThrow("prompt failed");
+
+    expect(useDesignAiSelectionStore.getState().statuses).toMatchObject({
+      [lifecycleContext.id]: "failed",
+      [second.id]: "failed",
+    });
+  });
+
+  test("marks every selected context failed when preflight cannot read the file", async () => {
+    const second = { ...lifecycleContext, id: "design-ai-lifecycle-3" };
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    store.createContext(second);
+
+    await expect(sessionRoute.promptDesignSelectionContexts({
+      contexts: [lifecycleContext, second],
+      workspaceClient: {
+        readWorkspaceFile: async () => { throw new Error("read failed"); },
+        writeWorkspaceFile: async () => ({ updatedAt: 12 }),
+      },
+      prompt: async () => ({ error: undefined }),
+      designSelectionStore: useDesignAiSelectionStore,
+    })).rejects.toThrow("read failed");
+
+    expect(useDesignAiSelectionStore.getState().statuses).toMatchObject({
+      [lifecycleContext.id]: "failed",
+      [second.id]: "failed",
+    });
   });
 
   test("threads the optional session status callback through the React runtime", async () => {

--- a/apps/app/tests/design-ai-session-route.test.ts
+++ b/apps/app/tests/design-ai-session-route.test.ts
@@ -131,6 +131,37 @@ describe("Design AI session lifecycle", () => {
     )).rejects.toThrow("is no longer available");
   });
 
+  test("rejects drafts with more than one unique Design selection", async () => {
+    const second = { ...lifecycleContext, id: "design-ai-lifecycle-second" };
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    store.createContext(second);
+    const draft: ComposerDraft = {
+      mode: "prompt",
+      parts: [
+        { type: "design-selection", contextId: lifecycleContext.id, label: "H1 Original" },
+        { type: "design-selection", contextId: second.id, label: "P Original" },
+      ],
+      attachments: [],
+      text: "",
+    };
+
+    await expect(sessionRoute.draftToParts(
+      draft,
+      "C:/workspace",
+      useDesignAiSelectionStore,
+      { sessionId: "ses_1", workspaceId: "workspace_1" },
+    )).rejects.toThrow("Only one Design element can be edited at a time");
+  });
+
+  test("notifies once when an idle Design turn made no change", async () => {
+    const source = await Bun.file(routeUrl).text();
+
+    expect(source).toContain('toast.info("No Design change was detected.")');
+    expect(source).toContain("completeWithoutChange(context.id)");
+    expect(source.indexOf('toast.info("No Design change was detected.")')).toBeGreaterThan(source.indexOf("completeWithoutChange(context.id)"));
+  });
+
   test("marks all preflighted contexts failed when prompt submission rejects", async () => {
     const second = { ...lifecycleContext, id: "design-ai-lifecycle-2" };
     const store = useDesignAiSelectionStore.getState();

--- a/apps/app/tests/design-ai-session-route.test.ts
+++ b/apps/app/tests/design-ai-session-route.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { ComposerDraft } from "../src/app/types";
+import * as sessionRoute from "../src/react-app/shell/session-route";
+import { useDesignAiSelectionStore } from "../src/react-app/domains/session/design/design-ai-selection-store";
+
+const routeUrl = new URL("../src/react-app/shell/session-route.tsx", import.meta.url);
+const runtimeUrl = new URL(
+  "../src/react-app/domains/session/sync/runtime-sync.tsx",
+  import.meta.url,
+);
+
+describe("Design AI session lifecycle", () => {
+  beforeEach(() => {
+    useDesignAiSelectionStore.getState().resetSession("ses_1");
+  });
+
+  test("expands the selected Design chip to a synthetic scoped agent instruction", async () => {
+    expect(sessionRoute.draftToParts).toBeFunction();
+    if (typeof sessionRoute.draftToParts !== "function") return;
+
+    useDesignAiSelectionStore.getState().createContext({
+      id: "design-ai-1",
+      sessionId: "ses_1",
+      workspaceId: "workspace_1",
+      filePath: "design/ses_1/index.html",
+      baseUpdatedAt: 11,
+      beforeHtml: "<h1>Original</h1>",
+      target: {
+        tag: "h1",
+        label: "H1 · Original",
+        locator: "body > h1:nth-of-type(1)",
+        text: "Original",
+        src: "",
+        alt: "",
+        styles: { color: "black" },
+      },
+    });
+    const draft: ComposerDraft = {
+      mode: "prompt",
+      parts: [
+        { type: "design-selection", contextId: "design-ai-1", label: "H1 · Original" },
+        { type: "text", text: "Make it blue." },
+      ],
+      attachments: [],
+      text: "[[design-ai:design-ai-1]] Make it blue.",
+    };
+
+    const parts = await sessionRoute.draftToParts(
+      draft,
+      "C:/workspace",
+      useDesignAiSelectionStore,
+    );
+
+    expect(parts[0]).toMatchObject({ type: "text", synthetic: true });
+    expect(JSON.stringify(parts[0])).toContain("design/ses_1/index.html");
+    expect(JSON.stringify(parts[0])).toContain("body > h1:nth-of-type(1)");
+    expect(JSON.stringify(parts[0])).toContain("Do not modify any other element");
+    expect(parts[1]).toEqual({ type: "text", text: "Make it blue." });
+    expect(JSON.stringify(parts)).not.toContain("[[design-ai:");
+  });
+
+  test("preflights the Design snapshot before prompt submission and completes only on idle", async () => {
+    const source = await Bun.file(routeUrl).text();
+    const preflightRead = source.indexOf("readWorkspaceFile(context.workspaceId, context.filePath)");
+    const preflightWrite = source.indexOf("content: context.beforeHtml");
+    const markRunning = source.indexOf("markRunning(context.id)");
+    const prompt = source.indexOf("session.promptAsync({");
+
+    expect(preflightRead).toBeGreaterThan(-1);
+    expect(source).toContain("current.updatedAt ?? null");
+    expect(source).toContain("baseUpdatedAt: current.updatedAt ?? null");
+    expect(preflightWrite).toBeGreaterThan(preflightRead);
+    expect(markRunning).toBeGreaterThan(preflightRead);
+    expect(prompt).toBeGreaterThan(markRunning);
+    expect(source).toContain('update.status.type !== "idle"');
+    expect(source).toContain('statuses[context.id] === "running"');
+    expect(source).toContain("after.content !== context.beforeHtml");
+    expect(source).toContain("afterUpdatedAt: after.updatedAt ?? null");
+    expect(source).toContain("completeWithoutChange(context.id)");
+    expect(source).toContain("onSessionStatus={handleSessionStatus}");
+  });
+
+  test("threads the optional session status callback through the React runtime", async () => {
+    const source = await Bun.file(runtimeUrl).text();
+
+    expect(source).toContain("onSessionStatus?:");
+    expect(source).toContain("onSessionStatus: props.onSessionStatus");
+  });
+});

--- a/apps/app/tests/design-deck-navigation.test.ts
+++ b/apps/app/tests/design-deck-navigation.test.ts
@@ -58,6 +58,19 @@ describe("Design deck navigation", () => {
     expect(source).toContain("disabled={!selection.canDelete}");
   });
 
+  test("places AI after every floating toolbar action", async () => {
+    const source = await Bun.file(panelUrl).text();
+    expect(source).toContain('aria-label="Ask AI about selected element"');
+    expect(source.lastIndexOf('aria-label="Ask AI about selected element"')).toBeGreaterThan(source.lastIndexOf('aria-label="Toggle advanced design settings"'));
+  });
+
+  test("keeps protected runtime controls unavailable to AI", async () => {
+    const source = await Bun.file(panelUrl).text();
+    const labelIndex = source.lastIndexOf('aria-label="Ask AI about selected element"');
+    const actionStart = source.lastIndexOf("<Button", labelIndex);
+    expect(source.slice(actionStart, labelIndex)).toContain("disabled={!selection.canDelete}");
+  });
+
   test("pans the overflowed presentation canvas without moving the slide", async () => {
     const source = await Bun.file(panelUrl).text();
 

--- a/apps/app/tests/design-deck-navigation.test.ts
+++ b/apps/app/tests/design-deck-navigation.test.ts
@@ -79,4 +79,13 @@ describe("Design deck navigation", () => {
     expect(source).toContain("overflow-auto");
     expect(source).toContain("presentationCanvasStageSize");
   });
+
+  test("dismisses the floating selection toolbar when the editor deselects", async () => {
+    const source = await Bun.file(panelUrl).text();
+
+    expect(source).toContain('event.data.type === "deselected"');
+    expect(source).toContain("setSelection(null);");
+    expect(source).toContain("setQuickEdit(null);");
+    expect(source).toContain("setAdvancedOpen(false);");
+  });
 });

--- a/apps/app/tests/design-html-runtime.test.ts
+++ b/apps/app/tests/design-html-runtime.test.ts
@@ -155,6 +155,20 @@ describe("Design HTML runtime", () => {
     expect(preview).toContain("selectionCandidate(target)");
   });
 
+  test("clears the editor selection on blank canvas clicks and slide navigation", async () => {
+    const preview = buildDesignPreviewDocument("<!doctype html><html><body><section class=\"slide\"><h1>One</h1></section><section class=\"slide\"><h1>Two</h1></section></body></html>", true, "", true, false, true);
+    const runtimePath = new URL(
+      "../src/react-app/domains/session/design/design-html-runtime.ts",
+      import.meta.url,
+    );
+    const runtimeSource = await Bun.file(runtimePath).text();
+
+    expect(preview).toContain('type: "deselected"');
+    expect(preview).toContain("clearSelection(!0)");
+    expect(preview).toContain("ipollowork-design-deck-navigated");
+    expect(runtimeSource).toContain("if (isDeckControl) notifyNavigation();");
+  });
+
   test("intercepts Ctrl or Meta wheel zoom only for presentation canvases", () => {
     const sitePreview = buildDesignPreviewDocument("<!doctype html><html><body><h1>Site</h1></body></html>", true, "", false, false, false);
     const presentationPreview = buildDesignPreviewDocument("<!doctype html><html><body><section class=\"slide\"><h1>Slide</h1></section></body></html>", true, "", false, false, true);

--- a/apps/app/tests/design-html-runtime.test.ts
+++ b/apps/app/tests/design-html-runtime.test.ts
@@ -137,6 +137,14 @@ describe("Design HTML runtime", () => {
     expect(preview).not.toContain('event.key === "Backspace"');
   });
 
+  test("keeps the selection overlay from blocking clicks on text inside a selected card", () => {
+    const preview = buildDesignPreviewDocument("<!doctype html><html><body><div class=\"card\"><h4>Card title</h4><p>Card body</p></div></body></html>", true);
+
+    expect(preview).toContain('#ipollowork-design-transform-overlay { position: fixed; z-index: 2147483646; display: none; pointer-events: none;');
+    expect(preview).toContain('#ipollowork-design-transform-overlay [data-handle] {');
+    expect(preview).toContain('pointer-events: auto;');
+  });
+
   test("does not select a presentation slide root for transform", () => {
     const preview = buildDesignPreviewDocument("<!doctype html><html><body><section class=\"slide\"><h1>Slide title</h1></section></body></html>", true, "", false, false, true);
 

--- a/apps/app/tests/design-html-runtime.test.ts
+++ b/apps/app/tests/design-html-runtime.test.ts
@@ -45,6 +45,19 @@ describe("Design HTML runtime", () => {
     expect(preview).toContain('selected.style.width = `${width}px`');
   });
 
+  test("describes an editable element with a stable CSS locator", () => {
+    const preview = buildDesignPreviewDocument("<!doctype html><html><body><section><h1>Title</h1></section></body></html>", true);
+    expect(preview).toContain("const elementLocator = (element: HTMLElement)");
+    expect(preview).toContain("nth-of-type");
+    expect(preview).toContain("locator: elementLocator(element)");
+  });
+
+  test("keeps locators stable after editor-only control labels are unwrapped", () => {
+    const preview = buildDesignPreviewDocument("<!doctype html><html><body><button>Save<span>Now</span></button></body></html>", true);
+    expect(preview).toContain('element.hasAttribute("data-ipollowork-design-text-node") ? element.parentElement : element');
+    expect(preview).toContain('!sibling.hasAttribute("data-ipollowork-design-text-node")');
+  });
+
   test("keeps a dormant editor bridge and deck adapter in the same preview document", () => {
     const source = "<!doctype html><html><body><section class=\"slide is-active\"><h1>One</h1></section><section class=\"slide\"><h1>Two</h1></section></body></html>";
     const preview = buildDesignPreviewDocument(source, true, "", false, false, true);

--- a/apps/app/tests/design-html-runtime.test.ts
+++ b/apps/app/tests/design-html-runtime.test.ts
@@ -154,4 +154,14 @@ describe("Design HTML runtime", () => {
     expect(preview).toContain("canvasPan");
     expect(preview).toContain("selectionCandidate(target)");
   });
+
+  test("intercepts Ctrl or Meta wheel zoom only for presentation canvases", () => {
+    const sitePreview = buildDesignPreviewDocument("<!doctype html><html><body><h1>Site</h1></body></html>", true, "", false, false, false);
+    const presentationPreview = buildDesignPreviewDocument("<!doctype html><html><body><section class=\"slide\"><h1>Slide</h1></section></body></html>", true, "", false, false, true);
+
+    expect(sitePreview).toContain("if (!presentationCanvas || !event.ctrlKey && !event.metaKey)");
+    expect(sitePreview).toContain("],false,false,false);</script>");
+    expect(presentationPreview).toContain("],false,false,true);</script>");
+    expect(presentationPreview).toContain('type: "zoom"');
+  });
 });

--- a/docs/superpowers/plans/2026-07-23-design-selection-ai-copilot.md
+++ b/docs/superpowers/plans/2026-07-23-design-selection-ai-copilot.md
@@ -312,5 +312,3 @@ Expected: all tests pass, TypeScript exits 0, and `git diff --check` prints no e
 git add -- apps/app/src/app/types.ts apps/app/src/react-app/domains/session/design/design-ai-selection.ts apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts apps/app/src/react-app/domains/session/design/design-html-runtime.ts apps/app/src/react-app/domains/session/design/design-panel.tsx apps/app/src/react-app/domains/session/chat/session-page.tsx apps/app/src/react-app/domains/session/surface/composer/editor.tsx apps/app/src/react-app/domains/session/surface/session-surface.tsx apps/app/src/react-app/domains/session/sync/runtime-sync.tsx apps/app/src/react-app/shell/session-route.tsx apps/app/tests/design-ai-selection.test.ts apps/app/tests/design-ai-composer.test.ts apps/app/tests/design-ai-session-route.test.ts apps/app/tests/design-html-runtime.test.ts apps/app/tests/design-deck-navigation.test.ts apps/app/tests/design-preview-height.test.ts
 git commit -m "Add AI editing for selected Design elements"
 ```
-
-

--- a/docs/superpowers/plans/2026-07-23-design-selection-ai-copilot.md
+++ b/docs/superpowers/plans/2026-07-23-design-selection-ai-copilot.md
@@ -48,7 +48,6 @@ test("restricts the agent instruction to one element in one file", () => {
   expect(instruction).toContain("Do not modify any other element");
 });
 ```
-
 - [ ] **Step 2: Verify RED**
 
 Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-selection.test.ts`

--- a/docs/superpowers/plans/2026-07-23-design-selection-ai-copilot.md
+++ b/docs/superpowers/plans/2026-07-23-design-selection-ai-copilot.md
@@ -1,0 +1,317 @@
+﻿# Design Selection AI Copilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an AI action to the final position of the Design/PPT selection toolbar; it inserts a scoped object chip in the normal composer, applies the agent's file edit, and supports persisted Undo.
+
+**Architecture:** The iframe editor supplies a stable CSS locator and selection summary. A session-scoped Design AI store keeps the pre-AI HTML, file revision, and target metadata. The existing composer displays an atomic purple Design chip and the normal prompt pipeline translates it into a synthetic instruction that restricts the agent to one file and one element. Completion reloads the edited Design file and makes the captured pre-image available to the Design Undo action.
+
+**Tech Stack:** React 19, TypeScript, Zustand, Lexical, TanStack Query, existing OpenCode prompt flow, Bun tests.
+
+## Global Constraints
+
+- Reuse the normal session composer; do not introduce another chat surface or agent session.
+- The AI icon is the final control in the existing floating toolbar.
+- Do not allow slide/deck roots or runtime controls to become AI targets.
+- The AI instruction must name one active Design file and one stable CSS locator, and prohibit unrelated edits.
+- Never optimistically mutate the canvas; refresh only after the normal agent turn finishes.
+- Persisted AI undo uses a revision guard and must not overwrite an externally changed file.
+- Do not stage `design/ses_076ea9b8affe6bxZ39oVB9TYuX/brief.json` or the pre-existing untracked plan/spec documents.
+
+---
+
+### Task 1: Model and store Design AI contexts
+
+**Files:**
+
+- Create: `apps/app/src/react-app/domains/session/design/design-ai-selection.ts`
+- Create: `apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts`
+- Create: `apps/app/tests/design-ai-selection.test.ts`
+
+**Interfaces:**
+
+- Produces `DesignAiSelectionContext`, `DesignAiUndoCheckpoint`, `designAiSelectionToken`, `parseDesignAiSelectionToken`, `designAiSelectionInstruction`, and `useDesignAiSelectionStore`.
+- Consumed by the toolbar, composer parser, prompt sender, and Design Undo workflow.
+
+- [ ] **Step 1: Write failing token and scope tests**
+
+```ts
+test("round-trips a Design selection chip token", () => {
+  expect(parseDesignAiSelectionToken(designAiSelectionToken("design-ai-1"))).toBe("design-ai-1");
+  expect(parseDesignAiSelectionToken("[design-ai:design-ai-1]")).toBeNull();
+});
+
+test("restricts the agent instruction to one element in one file", () => {
+  const instruction = designAiSelectionInstruction(context);
+  expect(instruction).toContain("design/ses_1/index.html");
+  expect(instruction).toContain("body > h1:nth-of-type(1)");
+  expect(instruction).toContain("Do not modify any other element");
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-selection.test.ts`
+
+Expected: FAIL because the module and helpers do not exist.
+
+- [ ] **Step 3: Implement immutable context helpers and a session store**
+
+```ts
+export type DesignAiSelectionContext = {
+  id: string;
+  sessionId: string;
+  workspaceId: string;
+  filePath: string;
+  baseUpdatedAt: number | null;
+  beforeHtml: string;
+  target: {
+    tag: string;
+    label: string;
+    locator: string;
+    text: string;
+    src: string;
+    alt: string;
+    styles: Record<string, string>;
+  };
+};
+
+export function designAiSelectionToken(id: string) {
+  return `[[design-ai:${id}]]`;
+}
+
+export function designAiSelectionInstruction(context: DesignAiSelectionContext) {
+  return [
+    "Design selection request:",
+    `- Edit only the file: ${context.filePath}`,
+    `- Edit only the selected element at CSS locator: ${context.target.locator}`,
+    "- Do not modify any other element, page structure, slide, or file unless the user explicitly asks for a wider change.",
+    "- Preserve unrelated content and styles.",
+  ].join("\n");
+}
+```
+
+The store holds contexts by ID and LIFO undo checkpoints by `{ sessionId, filePath }`. It exposes `createContext`, `markRunning`, `complete`, `fail`, `latestUndoCheckpoint`, `popUndoCheckpoint`, and `resetSession`.
+
+- [ ] **Step 4: Verify GREEN and lifecycle behavior**
+
+```ts
+test("keeps completed checkpoints in LIFO order", () => {
+  const store = useDesignAiSelectionStore.getState();
+  store.complete("design-ai-1", { afterHtml: "<h1>One</h1>", afterUpdatedAt: 13 });
+  expect(store.latestUndoCheckpoint("ses_1", "design/ses_1/index.html")?.beforeHtml).toContain("Original");
+});
+```
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-selection.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the isolated model/store change**
+
+```powershell
+git add -- apps/app/src/react-app/domains/session/design/design-ai-selection.ts apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts apps/app/tests/design-ai-selection.test.ts
+git commit -m "Add Design AI selection context"
+```
+
+### Task 2: Add a stable selection locator and final AI toolbar action
+
+**Files:**
+
+- Modify: `apps/app/src/react-app/domains/session/design/design-html-runtime.ts`
+- Modify: `apps/app/src/react-app/domains/session/design/design-panel.tsx`
+- Modify: `apps/app/tests/design-html-runtime.test.ts`
+- Modify: `apps/app/tests/design-deck-navigation.test.ts`
+
+**Interfaces:**
+
+- Extends `DesignSelection` with `locator` and `source`.
+- Extends `DesignPanelProps` with `onAskAi(context: DesignAiSelectionContext): void`.
+
+- [ ] **Step 1: Write failing runtime and toolbar tests**
+
+```ts
+test("describes an editable element with a stable CSS locator", () => {
+  const preview = buildDesignPreviewDocument("<!doctype html><html><body><section><h1>Title</h1></section></body></html>", true);
+  expect(preview).toContain("const elementLocator = (element: HTMLElement)");
+  expect(preview).toContain("nth-of-type");
+  expect(preview).toContain("locator: elementLocator(element)");
+});
+
+test("places AI after every floating toolbar action", async () => {
+  const source = await Bun.file(panelUrl).text();
+  expect(source).toContain('aria-label="Ask AI about selected element"');
+  expect(source.lastIndexOf('aria-label="Ask AI about selected element"')).toBeGreaterThan(source.lastIndexOf('aria-label="Toggle advanced design settings"'));
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts`
+
+Expected: FAIL because the locator and AI toolbar action are absent.
+
+- [ ] **Step 3: Implement selection context creation**
+
+Add `elementLocator` in the editor bridge by walking from the element to `body` and composing `tag:nth-of-type(index)` segments. Include it in every `DesignSelection`; for images, source must prefer `data-ipw-preview-src` over a preview data URL.
+
+In `DesignPanel`, create the context only after `readLatestCanvasHtml()` captures the canvas. Use the active page path, `fileQuery.data.updatedAt`, selection metadata, and a generated ID. Append a `Sparkles` AI icon button after the advanced-settings action with `aria-label="Ask AI about selected element"` and call `onAskAi(context)`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts`
+
+Expected: PASS including protected roots, text-only div editing, toolbar delete, and PPT canvas checks.
+
+- [ ] **Step 5: Commit the toolbar entry point**
+
+```powershell
+git add -- apps/app/src/react-app/domains/session/design/design-html-runtime.ts apps/app/src/react-app/domains/session/design/design-panel.tsx apps/app/tests/design-html-runtime.test.ts apps/app/tests/design-deck-navigation.test.ts
+git commit -m "Add Design selection AI action"
+```
+
+### Task 3: Add an atomic purple Design chip to the existing composer
+
+**Files:**
+
+- Modify: `apps/app/src/app/types.ts`
+- Modify: `apps/app/src/react-app/domains/session/surface/composer/editor.tsx`
+- Modify: `apps/app/src/react-app/domains/session/surface/session-surface.tsx`
+- Modify: `apps/app/src/react-app/domains/session/chat/session-page.tsx`
+- Create: `apps/app/tests/design-ai-composer.test.ts`
+
+**Interfaces:**
+
+- Adds `ComposerPart` variant `{ type: "design-selection"; contextId: string; label: string }`.
+- `SessionPage` receives `onAskAi`, replaces a prior Design token in the current draft, and focuses the normal composer.
+
+- [ ] **Step 1: Write failing composer tests**
+
+```ts
+test("converts one Design token into a structured composer part", () => {
+  const parts = parseComposerParts("[[design-ai:design-ai-1]] make it blue", {
+    mentions: {},
+    pasteParts: [],
+    designSelectionLabel: () => "H1 路 Original",
+  });
+  expect(parts).toContainEqual({ type: "design-selection", contextId: "design-ai-1", label: "H1 路 Original" });
+  expect(parts).toContainEqual({ type: "text", text: " make it blue" });
+});
+
+test("renders a Design token as an atomic purple chip", async () => {
+  const source = await Bun.file(editorUrl).text();
+  expect(source).toContain("composer-design-selection");
+  expect(source).toContain('contentEditable = "false"');
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-composer.test.ts`
+
+Expected: FAIL because the part and Lexical node do not exist.
+
+- [ ] **Step 3: Implement chip rendering, parsing, and insertion**
+
+```ts
+export type ComposerPart =
+  | { type: "text"; text: string; synthetic?: boolean }
+  | { type: "design-selection"; contextId: string; label: string };
+
+function replaceDesignSelectionToken(draft: string, token: string) {
+  const withoutPrevious = draft.replace(/\[\[design-ai:[a-zA-Z0-9_-]+\]\]\s*/g, "").trimEnd();
+  return `${withoutPrevious}${withoutPrevious ? "\n" : ""}${token} `;
+}
+```
+
+Create a `ComposerDesignSelectionNode` with `data-composer-token="design-selection"`, purple rounded-pill styling, the stored selection label, and `contentEditable = "false"`. Serialize it to `[[design-ai:<id>]]`; Backspace removes it atomically. Extract and export `parseComposerParts(text, input)` from `session-surface.tsx`, then have `buildDraft` use it to split this token before normal `@`, paste, skill, and slash parsing, resolve its label from the Design AI store, and create the new `ComposerPart`.
+
+In `SessionPage`, pass `onAskAi` to `DesignPanel`; it uses the composer Zustand store to insert the token and emits `ipollowork:focusPrompt`.
+
+- [ ] **Step 4: Verify GREEN and mention compatibility**
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-composer.test.ts tests/mention-encoding.test.ts`
+
+Expected: PASS with unchanged agent/file/app mention encoding.
+
+- [ ] **Step 5: Commit composer integration**
+
+```powershell
+git add -- apps/app/src/app/types.ts apps/app/src/react-app/domains/session/surface/composer/editor.tsx apps/app/src/react-app/domains/session/surface/session-surface.tsx apps/app/src/react-app/domains/session/chat/session-page.tsx apps/app/tests/design-ai-composer.test.ts
+git commit -m "Add Design selection composer chip"
+```
+
+### Task 4: Scope the agent turn, refresh changed Design HTML, and persistently undo it
+
+**Files:**
+
+- Modify: `apps/app/src/react-app/shell/session-route.tsx`
+- Modify: `apps/app/src/react-app/domains/session/sync/runtime-sync.tsx`
+- Modify: `apps/app/src/react-app/domains/session/design/design-panel.tsx`
+- Modify: `apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts`
+- Create: `apps/app/tests/design-ai-session-route.test.ts`
+- Modify: `apps/app/tests/design-ai-selection.test.ts`
+
+**Interfaces:**
+
+- Consumes a `design-selection` part and context store record.
+- Completes a context only with `{ afterHtml, afterUpdatedAt }` when the agent actually changed the active file.
+- Uses the existing `session.status` / `session.idle` sync callbacks to detect that the normal agent turn has completed; `promptAsync` only enqueues the turn and must not trigger completion itself.
+
+- [ ] **Step 1: Write failing send, refresh, and undo tests**
+
+```ts
+test("expands the selected Design chip to a synthetic scoped agent instruction", async () => {
+  const parts = await draftToParts(draftWithDesignSelection, "C:/workspace");
+  expect(parts[0]).toMatchObject({ type: "text", synthetic: true });
+  expect(JSON.stringify(parts[0])).toContain("Do not modify any other element");
+});
+
+test("writes the AI pre-image with the post-agent revision during undo", async () => {
+  const source = await Bun.file(panelUrl).text();
+  expect(source).toContain("baseUpdatedAt: checkpoint.afterUpdatedAt");
+  expect(source).toContain("Could not undo the AI Design change because the file changed");
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts`
+
+Expected: FAIL because Design selection parts do not reach the prompt flow or persisted undo.
+
+- [ ] **Step 3: Implement preflight, completion, refresh, and undo**
+
+Export `draftToParts` and add an optional `designSelectionStore` dependency for its test. Turn a valid `design-selection` part into `{ type: "text", text: designAiSelectionInstruction(context), synthetic: true }`, preserving the user request as a separate normal text part.
+
+Immediately before `promptAsync`, read `context.filePath`; reject a stale revision; write `context.beforeHtml` with `baseUpdatedAt: current.updatedAt`; then mark the context running. `promptAsync` only submits the turn, so it must not reread or complete the context. Pass an `onSessionStatus` callback through `ReactSessionRuntime`; on the next `session.idle` for the running Design context, reread the file. If changed from `beforeHtml`, complete the context with the post-agent HTML/revision; otherwise mark the context completed-without-change and create no undo checkpoint.
+
+`DesignPanel` observes the completed context for its active session/file, reloads `afterHtml`, increments `previewRevision`, and retains the checkpoint. Its existing Undo first uses local canvas history; when it is empty it writes `checkpoint.beforeHtml` with `baseUpdatedAt: checkpoint.afterUpdatedAt`, reloads the result, then removes the checkpoint. On write conflict, retain the checkpoint and show `Could not undo the AI Design change because the file changed. Reload before trying again.`
+
+- [ ] **Step 4: Verify GREEN and Design regressions**
+
+Run:
+
+```powershell
+pnpm.cmd --filter @ipollowork/app exec bun test --isolate tests/design-ai-session-route.test.ts tests/design-ai-selection.test.ts tests/design-html-runtime.test.ts tests/design-deck-navigation.test.ts tests/design-preview-height.test.ts tests/presentation-canvas.test.ts
+pnpm.cmd --filter @ipollowork/app typecheck
+git diff --check
+```
+
+Expected: all tests pass, TypeScript exits 0, and `git diff --check` prints no errors.
+
+- [ ] **Step 5: Validate the real Electron flow and commit**
+
+1. Select a title and confirm the final floating-toolbar action is `Ask AI about selected element`.
+2. Click it and confirm the normal composer focuses with one purple title chip.
+3. Repeat for an image and confirm the chip label uses its original source filename instead of a preview data URL.
+4. Send a narrow request, wait for the agent, and confirm the active canvas file refreshes.
+5. Click Design Undo and confirm the original title/image source and workspace file return.
+6. Confirm protected slide roots do not expose AI.
+
+```powershell
+git add -- apps/app/src/app/types.ts apps/app/src/react-app/domains/session/design/design-ai-selection.ts apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts apps/app/src/react-app/domains/session/design/design-html-runtime.ts apps/app/src/react-app/domains/session/design/design-panel.tsx apps/app/src/react-app/domains/session/chat/session-page.tsx apps/app/src/react-app/domains/session/surface/composer/editor.tsx apps/app/src/react-app/domains/session/surface/session-surface.tsx apps/app/src/react-app/domains/session/sync/runtime-sync.tsx apps/app/src/react-app/shell/session-route.tsx apps/app/tests/design-ai-selection.test.ts apps/app/tests/design-ai-composer.test.ts apps/app/tests/design-ai-session-route.test.ts apps/app/tests/design-html-runtime.test.ts apps/app/tests/design-deck-navigation.test.ts apps/app/tests/design-preview-height.test.ts
+git commit -m "Add AI editing for selected Design elements"
+```
+
+

--- a/docs/superpowers/specs/2026-07-23-design-selection-ai-copilot-design.md
+++ b/docs/superpowers/specs/2026-07-23-design-selection-ai-copilot-design.md
@@ -1,0 +1,74 @@
+# Design Selection AI Copilot Design
+
+## Goal
+
+Let a user select one editable element in a Design/PPT canvas, invoke AI from the last control in the floating selection toolbar, and send a scoped request to the existing session conversation. The AI applies its edit directly to that selected element; the user can undo the resulting persisted edit.
+
+## User flow
+
+1. The user selects text, an image, or another editable element on a Design/PPT canvas.
+2. The existing white floating selection toolbar shows an AI button as its final action.
+3. Clicking the AI button creates one selection-context chip in the existing main conversation composer and focuses that composer. The chip uses the existing inline token behavior: it can be removed with Backspace as one unit.
+4. The chip label identifies the selected object without exposing raw HTML, for example `H1 · 用AI重构企业智能运营`, `Image · hero-banner.png`, or `Paragraph · 一站式企业AI决策平台…`.
+5. The user writes a request after the chip and sends it through the normal model/agent flow.
+6. The request carries an invisible, structured instruction identifying the active Design file and exactly one target element. The agent must change only that element unless the user explicitly asks for a wider change.
+7. The agent writes the Design file. When the agent turn completes, the canvas reloads the changed file and the normal chat transcript shows the result.
+8. The Design toolbar Undo action restores the file snapshot captured immediately before that AI turn, including for PPT decks.
+
+## Interaction boundaries
+
+- The AI action is available only when an element is selected and the editor is active.
+- The AI button is appended after the existing selection-toolbar actions, matching Office/Copilot-style contextual editing rather than adding a separate Design sidebar.
+- Slide/deck roots and runtime controls remain non-selectable and cannot become AI targets.
+- The existing normal conversation remains the only chat surface: model selection, streaming, stop, queued prompts, and transcript behavior are unchanged.
+- A direct AI edit is not applied until the normal agent turn completes. The canvas will not present an unverified local simulation.
+
+## Selection context
+
+The selection context is stored in a session-scoped frontend store and contains:
+
+- a generated context ID and display label;
+- workspace/session IDs and the active Design file path;
+- the exact pre-AI HTML snapshot and its file revision;
+- element kind, element locator, text or original image source, selected style fields, and frame bounds.
+
+The runtime provides a stable locator and user-facing summary for every editable selection. For image selections, the context uses the original workspace image source rather than a temporary preview data URL.
+
+The main composer renders the context as a dedicated purple Design chip. Its serialized token resolves to a synthetic agent instruction that tells the agent to read the active file, locate the exact selected element, preserve unrelated elements, and make the requested update only within the target's scope.
+
+## AI update and undo lifecycle
+
+Before the request reaches the agent, the send path writes the captured pre-AI HTML to the active Design file if it differs from disk, so the agent always operates on the selected canvas state. The same snapshot is retained as an AI undo checkpoint.
+
+When the agent turn returns, the Design panel reads the active file again. If its content changed, it updates the preview and adds the pre-AI checkpoint to the Design undo stack. Undo writes that checkpoint back to the workspace with the latest revision guard, reloads the iframe, and removes the checkpoint. If the agent did not alter the file, no undo checkpoint is added and the canvas remains unchanged.
+
+Existing in-canvas edits continue to use their existing local history first. After those local changes are undone, the AI checkpoint is available to restore the prior persisted file version.
+
+## Failure handling
+
+- No active selection: the AI toolbar action is unavailable.
+- A stale file revision before send: do not prompt the agent; report the write conflict and retain the chip for retry.
+- Agent completion without a file change: leave the canvas untouched and state that no Design change was detected.
+- Undo write conflict: do not overwrite the workspace; report the conflict and retain the checkpoint so the user can reload or retry deliberately.
+- Missing target after an agent response: reload the changed Design file rather than attempting a brittle partial client-side patch.
+
+## Files and responsibilities
+
+- `apps/app/src/react-app/domains/session/design/design-html-runtime.ts`: enrich editable selection messages with stable element context.
+- `apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts`: keep selection contexts and AI undo checkpoints session-scoped.
+- `apps/app/src/react-app/domains/session/design/design-panel.tsx`: render the contextual AI toolbar action, create a context chip, reload post-agent changes, and undo persisted AI changes.
+- `apps/app/src/react-app/domains/session/surface/composer/mention-encoding.ts` and `editor.tsx`: support a Design selection chip in the composer.
+- `apps/app/src/react-app/domains/session/surface/composer-state-store.ts` and `session-surface.tsx`: preserve the chip in a draft and convert it to a structured design-selection part.
+- `apps/app/src/app/types.ts` and `apps/app/src/react-app/shell/session-route.tsx`: deliver the structured scope instruction to the agent, snapshot the selected source state before prompting, and notify the Design panel when the turn finishes.
+
+## Verification
+
+Automated tests cover:
+
+- the AI action appears only for a selected editable element and is last in the floating toolbar;
+- the selection chip label and structured context survive a composer draft round trip;
+- text and image contexts include correct stable source data;
+- the outgoing agent instruction restricts the request to one element and its active file;
+- an agent-written change reloads the Design preview and creates a persisted undo checkpoint;
+- undo restores the exact pre-AI HTML and does not overwrite on revision conflict;
+- existing PPT selection, pan/zoom, toolbar deletion, and ordinary composer mentions continue to work.

--- a/docs/superpowers/specs/2026-07-23-internal-subtask-visibility-design.md
+++ b/docs/superpowers/specs/2026-07-23-internal-subtask-visibility-design.md
@@ -1,0 +1,54 @@
+# Internal Subtask Visibility Design
+
+## Goal
+
+Keep agent-created internal subtasks out of every user-facing task list while
+preserving the main task and user-created conversations.
+
+## Scope
+
+- Hide internal subtasks from the workspace sidebar.
+- Hide the same records from the command-palette session switcher and session
+  search, including the recent-session list.
+- Do not delete, archive, or otherwise mutate the underlying OpenCode sessions.
+- Do not hide user-created root tasks or user-created branches.
+
+## Classification
+
+The OpenCode session record is the source of truth. A session is an internal
+subtask only when both conditions hold:
+
+1. It has a non-empty `parentID`.
+2. Its `agent` is an internal delegated-agent value rather than the main
+   `orchestrator` agent.
+
+The frontend must carry the optional session `agent` field into the shared
+sidebar/session-list type. Classification must use this structured field,
+never the task title such as `(@executor subagent)`.
+
+This retains ordinary user conversations and explicit user branches, including
+their `parentID` relationship, because they do not carry an internal delegated
+agent identity.
+
+## Data Flow
+
+The workspace route already receives the complete list of OpenCode sessions.
+It will derive a user-visible list with one shared predicate before producing
+workspace session groups and palette/search session options. Internal subtasks
+remain in the raw list for runtime bookkeeping (activity/reload safety and
+direct-route handling), but never enter user-facing lists.
+
+## Error Handling
+
+Older or remote session payloads that omit `agent` remain visible. This avoids
+hiding any session when its origin cannot be established.
+
+## Verification
+
+Add focused tests covering:
+
+- an `executor` or `general` session with `parentID` is filtered out;
+- an `orchestrator` session with `parentID` stays visible;
+- a session with no `agent` stays visible;
+- sidebar tree, session switcher, and search all receive the same filtered
+  collection.


### PR DESCRIPTION
## Summary

This PR improves the Design/PPT editing workflow and fixes several export and selection issues.

- Fix export labels showing as `??` and keep export actions available when only one export job is running.
- Improve PPT canvas controls with Ctrl/⌘ + mouse-wheel zoom (50%–200%), a reset-to-fit action, and panning only after zooming in.
- Add toolbar-only deletion for selected elements; Delete and Backspace remain reserved for normal text editing.
- Prevent slide/deck roots and editor runtime controls from being selected, edited, deleted, or sent to AI.
- Support editing text-only `div` elements and apply their color changes to text instead of their background.
- Clear the current selection when users click blank canvas space or switch slides.
- Ensure the selection outline does not block clicks on text inside a selected card.

## AI-assisted element editing

A new AI action is added as the final button in the contextual floating toolbar, following the Office/Copilot-style interaction pattern.

- Users can select text, images, or other editable Design elements, then click **Ask AI**.
- The selected element appears as a chip in the existing chat composer, so AI editing stays in the same conversation rather than opening a separate panel.
- The AI receives the active Design file, a stable target locator, the selected element’s content/style context, and explicit instructions to modify only that element.
- Canvas changes are refreshed only after the normal AI turn finishes; the editor does not show an unverified optimistic update.
- A one-step undo restores the pre-AI version when the file has not been changed elsewhere.
- The flow handles retry, missing target, session switching, and external file-change conflicts safely.

## Why

The current Design editor had several friction points that made routine PPT editing less predictable: export labels were unreadable, presentation interaction did not match common slide tools, some text-like elements could not be edited, and selection state could remain active after changing context.

These updates make the editor behave more like a familiar presentation workspace: zooming is intentional, panning is available only when useful, deletion is visible and deliberate, and the canvas reliably clears stale selections.

For AI edits, the goal is to let users ask for a targeted change without handing the model unrestricted control of the entire page. By connecting the AI action to the current selection and attaching a precise file/element scope, users can request changes such as rewriting a headline, adjusting a card style, or updating an image while reducing the risk of unrelated changes elsewhere in the design.

## Scope

- Design export labels and export-menu state
- PPT canvas zoom, pan, selection, and deletion controls
- Text and element editing behavior
- Scoped AI editing and one-step undo for selected Design elements

## Out of scope

- Keyboard Delete/Backspace deletion of selected elements
- Changes to the underlying presentation export format

## Testing

### Ran

- `bun test --isolate` — 57 related tests passed
- `pnpm --filter @ipollowork/app typecheck`