### PR TITLE
Fix Design AI selection save race

### DIFF
--- a/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
+++ b/apps/app/src/react-app/domains/session/design/design-ai-selection-store.ts
@@ -9,11 +9,17 @@ type CompleteDesignAiSelection = {
   afterUpdatedAt: number | null;
 };
 
+type RebaseDesignAiSelection = {
+  beforeHtml: string;
+  baseUpdatedAt: number | null;
+};
+
 type DesignAiSelectionStore = {
   contexts: Record<string, DesignAiSelectionContext>;
   statuses: Record<string, DesignAiSelectionStatus>;
   undoCheckpoints: Record<string, Record<string, DesignAiUndoCheckpoint[]>>;
   createContext: (context: DesignAiSelectionContext) => void;
+  rebasePendingContext: (contextId: string, baseline: RebaseDesignAiSelection) => boolean;
   markRunning: (contextId: string) => void;
   claimCompletion: (contextId: string) => boolean;
   complete: (contextId: string, result: CompleteDesignAiSelection) => void;
@@ -61,6 +67,21 @@ export const useDesignAiSelectionStore = create<DesignAiSelectionStore>((set, ge
       statuses: { ...state.statuses, [context.id]: "pending" },
     };
   }),
+  rebasePendingContext: (contextId, baseline) => {
+    let rebased = false;
+    set((state) => {
+      const context = state.contexts[contextId];
+      if (!context || state.statuses[contextId] !== "pending") return state;
+      rebased = true;
+      return {
+        contexts: {
+          ...state.contexts,
+          [contextId]: copyContext({ ...context, ...baseline }),
+        },
+      };
+    });
+    return rebased;
+  },
   markRunning: (contextId) => set((state) => {
     if (!state.contexts[contextId] || state.statuses[contextId] !== "pending") return state;
     return { statuses: { ...state.statuses, [contextId]: "running" } };

--- a/apps/app/src/react-app/domains/session/design/design-ai-selection.ts
+++ b/apps/app/src/react-app/domains/session/design/design-ai-selection.ts
@@ -43,6 +43,7 @@ export function designAiSelectionInstruction(context: DesignAiSelectionContext) 
     `- Edit only the file: ${context.filePath}`,
     `- Edit only the selected element at CSS locator: ${context.target.locator}`,
     "- Do not modify any other element, page structure, slide, or file unless the user explicitly asks for a wider change.",
+    "- If the locator no longer resolves in the file, stop without changing the file and ask the user to select the element again.",
     "- Preserve unrelated content and styles.",
   ].join("\n");
 }

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -1341,10 +1341,29 @@ export function DesignPanel({
   };
 
   const askAiAboutSelection = async () => {
-    if (!selection || !workspaceId || !activePagePath || !fileQuery.data) return;
+    if (!selection || !workspaceId || !activePagePath || !fileQuery.data || saveMutation.isPending) return;
+    if (viewedVersionPath !== "current") {
+      toast.info("Switch to the Current design before asking AI about an element.");
+      return;
+    }
     const selected = selection;
-    const baseUpdatedAt = fileQuery.data.updatedAt;
-    const beforeHtml = await readLatestCanvasHtml();
+    let baseUpdatedAt = fileQuery.data.updatedAt;
+    let beforeHtml: string;
+    try {
+      beforeHtml = await readLatestCanvasHtml();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Could not read the current design.");
+      return;
+    }
+    if (pendingCanvasChange || beforeHtml !== savedSource) {
+      try {
+        const saved = await saveMutation.mutateAsync();
+        beforeHtml = saved.content;
+        baseUpdatedAt = saved.result.updatedAt ?? null;
+      } catch {
+        return;
+      }
+    }
     const summary = (selected.text || selected.alt || selected.source).replace(/\s+/g, " ").trim().slice(0, 80);
     onAskAi({
       id: `design-ai-${crypto.randomUUID()}`,
@@ -1974,7 +1993,7 @@ export function DesignPanel({
                           variant="ghost"
                           size="icon-xs"
                           onClick={() => void askAiAboutSelection()}
-                          disabled={!selection.canDelete}
+                          disabled={!selection.canDelete || saveMutation.isPending || viewedVersionPath !== "current"}
                           aria-label="Ask AI about selected element"
                         >
                           <Sparkles />

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -266,7 +266,7 @@ type DesignSelectionScope = {
 
 type DesignSelectionWorkspaceClient = {
   readWorkspaceFile: (workspaceId: string, path: string) => Promise<{ content: string; updatedAt?: number | null }>;
-  writeWorkspaceFile: (workspaceId: string, payload: { path: string; content: string; baseUpdatedAt?: number | null }) => Promise<unknown>;
+  writeWorkspaceFile: (workspaceId: string, payload: { path: string; content: string; baseUpdatedAt?: number | null }) => Promise<{ updatedAt?: number | null }>;
 };
 
 type DesignSelectionStore = Pick<typeof useDesignAiSelectionStore, "getState">;
@@ -310,14 +310,16 @@ export async function promptDesignSelectionContexts(input: {
   try {
     for (const context of input.contexts) {
       const current = await input.workspaceClient.readWorkspaceFile(context.workspaceId, context.filePath);
-      if ((current.updatedAt ?? null) !== context.baseUpdatedAt) {
-        throw new Error("The selected Design file changed before the AI update. Reload it and try again.");
-      }
-      await input.workspaceClient.writeWorkspaceFile(context.workspaceId, {
+      const prepared = await input.workspaceClient.writeWorkspaceFile(context.workspaceId, {
         path: context.filePath,
-        content: context.beforeHtml,
+        content: current.content,
         baseUpdatedAt: current.updatedAt ?? null,
       });
+      const rebased = designSelectionStore.getState().rebasePendingContext(context.id, {
+        beforeHtml: current.content,
+        baseUpdatedAt: prepared.updatedAt ?? current.updatedAt ?? null,
+      });
+      if (!rebased) throw new Error("The selected Design element is no longer ready for an AI update.");
       designSelectionStore.getState().markRunning(context.id);
     }
     const result = await input.prompt();

--- a/apps/app/tests/design-ai-selection.test.ts
+++ b/apps/app/tests/design-ai-selection.test.ts
@@ -47,6 +47,7 @@ describe("Design AI selections", () => {
     expect(instruction).toContain("design/ses_1/index.html");
     expect(instruction).toContain("body > h1:nth-of-type(1)");
     expect(instruction).toContain("Do not modify any other element");
+    expect(instruction).toContain("If the locator no longer resolves");
   });
 
   test("stores an immutable Design selection context", () => {
@@ -59,6 +60,40 @@ describe("Design AI selections", () => {
     mutableContext.target.styles.color = "red";
 
     expect(useDesignAiSelectionStore.getState().contexts["design-ai-1"]?.target.styles.color).toBe("black");
+  });
+
+  test("rebases only a pending Design selection context", () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(context);
+
+    expect(store.rebasePendingContext("design-ai-1", {
+      beforeHtml: "<h1>Latest</h1>",
+      baseUpdatedAt: 12,
+    })).toBe(true);
+    expect(useDesignAiSelectionStore.getState().contexts["design-ai-1"]).toMatchObject({
+      beforeHtml: "<h1>Latest</h1>",
+      baseUpdatedAt: 12,
+    });
+
+    store.markRunning("design-ai-1");
+    expect(store.rebasePendingContext("design-ai-1", {
+      beforeHtml: "<h1>Too late</h1>",
+      baseUpdatedAt: 13,
+    })).toBe(false);
+    expect(useDesignAiSelectionStore.getState().contexts["design-ai-1"]?.beforeHtml).toBe("<h1>Latest</h1>");
+  });
+
+  test("saves a dirty current Design before creating its AI selection context", async () => {
+    const source = await Bun.file(panelUrl).text();
+    const askAi = source.indexOf("const askAiAboutSelection = async () =>");
+    const saveDirty = source.indexOf("await saveMutation.mutateAsync()", askAi);
+    const createContext = source.indexOf("onAskAi({", askAi);
+
+    expect(askAi).toBeGreaterThan(-1);
+    expect(source.indexOf('viewedVersionPath !== "current"', askAi)).toBeGreaterThan(askAi);
+    expect(source.indexOf("pendingCanvasChange || beforeHtml !== savedSource", askAi)).toBeGreaterThan(askAi);
+    expect(saveDirty).toBeGreaterThan(askAi);
+    expect(createContext).toBeGreaterThan(saveDirty);
   });
 
   test("keeps completed checkpoints in LIFO order", () => {

--- a/apps/app/tests/design-ai-session-route.test.ts
+++ b/apps/app/tests/design-ai-session-route.test.ts
@@ -83,7 +83,8 @@ describe("Design AI session lifecycle", () => {
   test("preflights the Design snapshot before prompt submission and completes only on idle", async () => {
     const source = await Bun.file(routeUrl).text();
     const preflightRead = source.indexOf("readWorkspaceFile(context.workspaceId, context.filePath)");
-    const preflightWrite = source.indexOf("content: context.beforeHtml");
+    const preflightWrite = source.indexOf("content: current.content");
+    const rebase = source.indexOf("rebasePendingContext(context.id");
     const markRunning = source.indexOf("markRunning(context.id)");
     const prompt = source.indexOf("session.promptAsync({");
 
@@ -91,7 +92,8 @@ describe("Design AI session lifecycle", () => {
     expect(source).toContain("current.updatedAt ?? null");
     expect(source).toContain("baseUpdatedAt: current.updatedAt ?? null");
     expect(preflightWrite).toBeGreaterThan(preflightRead);
-    expect(markRunning).toBeGreaterThan(preflightRead);
+    expect(rebase).toBeGreaterThan(preflightWrite);
+    expect(markRunning).toBeGreaterThan(rebase);
     expect(prompt).toBeGreaterThan(markRunning);
     expect(source).toContain('update.status.type !== "idle"');
     expect(source).toContain("claimCompletion(context.id)");
@@ -99,6 +101,54 @@ describe("Design AI session lifecycle", () => {
     expect(source).toContain("afterUpdatedAt: after.updatedAt ?? null");
     expect(source).toContain("completeWithoutChange(context.id)");
     expect(source).toContain("onSessionStatus={handleSessionStatus}");
+  });
+
+  test("rebases a stale Design selection to the latest file before prompting", async () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    let writePayload: { content: string; baseUpdatedAt?: number | null } | undefined;
+
+    await sessionRoute.promptDesignSelectionContexts({
+      contexts: [lifecycleContext],
+      workspaceClient: {
+        readWorkspaceFile: async () => ({ content: "<h1>Latest</h1>", updatedAt: 12 }),
+        writeWorkspaceFile: async (_workspaceId, payload) => {
+          writePayload = payload;
+          return { updatedAt: 13 };
+        },
+      },
+      prompt: async () => ({ error: undefined }),
+      designSelectionStore: useDesignAiSelectionStore,
+    });
+
+    expect(writePayload).toMatchObject({ content: "<h1>Latest</h1>", baseUpdatedAt: 12 });
+    expect(useDesignAiSelectionStore.getState().contexts[lifecycleContext.id]).toMatchObject({
+      beforeHtml: "<h1>Latest</h1>",
+      baseUpdatedAt: 13,
+    });
+    expect(useDesignAiSelectionStore.getState().statuses[lifecycleContext.id]).toBe("running");
+  });
+
+  test("keeps a real concurrent write conflict from starting the AI prompt", async () => {
+    const store = useDesignAiSelectionStore.getState();
+    store.createContext(lifecycleContext);
+    let prompted = false;
+
+    await expect(sessionRoute.promptDesignSelectionContexts({
+      contexts: [lifecycleContext],
+      workspaceClient: {
+        readWorkspaceFile: async () => ({ content: "<h1>Latest</h1>", updatedAt: 12 }),
+        writeWorkspaceFile: async () => { throw new Error("File changed since it was loaded"); },
+      },
+      prompt: async () => {
+        prompted = true;
+        return { error: undefined };
+      },
+      designSelectionStore: useDesignAiSelectionStore,
+    })).rejects.toThrow("changed since");
+
+    expect(prompted).toBe(false);
+    expect(useDesignAiSelectionStore.getState().statuses[lifecycleContext.id]).toBe("failed");
   });
 
   test("rejects missing and foreign Design contexts before synthetic expansion", async () => {

--- a/apps/app/tests/design-deck-navigation.test.ts
+++ b/apps/app/tests/design-deck-navigation.test.ts
@@ -68,7 +68,7 @@ describe("Design deck navigation", () => {
     const source = await Bun.file(panelUrl).text();
     const labelIndex = source.lastIndexOf('aria-label="Ask AI about selected element"');
     const actionStart = source.lastIndexOf("<Button", labelIndex);
-    expect(source.slice(actionStart, labelIndex)).toContain("disabled={!selection.canDelete}");
+    expect(source.slice(actionStart, labelIndex)).toContain("disabled={!selection.canDelete || saveMutation.isPending || viewedVersionPath !== \"current\"}");
   });
 
   test("pans the overflowed presentation canvas without moving the slide", async () => {


### PR DESCRIPTION
## Summary

- persist unsaved changes from the current Design canvas before creating an AI selection context
- rebase pending AI selection baselines to the latest workspace file while preserving the atomic revision check
- keep completion detection and undo checkpoints aligned with the exact pre-agent HTML
- block AI selection from historical versions and instruct the agent to stop when the locator is stale
- add regression coverage for stale baselines, real concurrent conflicts, and save-before-selection behavior

## Validation

- pnpm --filter @ipollowork/app typecheck
- bun test apps/app/tests/design-ai-selection.test.ts apps/app/tests/design-ai-session-route.test.ts apps/app/tests/design-ai-composer.test.ts apps/app/tests/design-deck-navigation.test.ts (39 pass)
- pnpm --filter @ipollowork/app build
- development Electron client confirmed loaded from this checkout on ports 5173 and 9823

## Existing unrelated test failure

- the complete app test suite still has the main-branch composer queue assertion expecting onQueue while the current implementation uses onSteer; this PR does not touch that code or test