### PR TITLE
docs: fix pronoun capitalization and list item case in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,9 @@ Keep changes focused, preserve the iPolloWork/OpenCode boundary, and include the
 
 ## Contribution terms
 
-By submitting a pull request or other contribution for inclusion in iPolloWork, You represent that You have the right to submit it and agree that:
+By submitting a pull request or other contribution for inclusion in iPolloWork, you represent that you have the right to submit it and agree that:
 
-1. the contribution may be distributed to users under the current iPolloWork Source Available License and any future version of that license; and
+1. The contribution may be distributed to users under the current iPolloWork Source Available License and any future version of that license; and
 2. You grant Different AI, Inc. a perpetual, worldwide, non-exclusive, irrevocable, royalty-free license to use, reproduce, modify, distribute, sublicense, and commercially license the contribution as part of iPolloWork and related products.
 
 Third-party code must keep its original copyright and license notice. Identify the source and license in the pull request. Do not submit code that cannot legally be included under these terms.


### PR DESCRIPTION
## Description
This PR fixes capitalization consistency in `CONTRIBUTING.md`.

## Details
1. Fixed mid-sentence capitalized `You` -> `you` under contribution terms.
2. Capitalized item 1 (`the contribution...` -> `The contribution...`) for consistency with item 2.