### PR TITLE
fix: preserve model configuration fallback

### DIFF
--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -305,7 +305,11 @@ export function ModelSelect({
           }}
           onConfigureModels={() => {
             onOpenChange(false);
-            onConfigureModels?.();
+            if (onConfigureModels) {
+              onConfigureModels();
+              return;
+            }
+            window.dispatchEvent(new CustomEvent(openModelPickerEvent));
           }}
         />
       </PopoverContent>


### PR DESCRIPTION
## What changed

We found a small regression in the model picker refactor that landed with the combined model and reasoning menu. When a `ModelSelect` caller does not provide its optional `onConfigureModels` handler, the wrapper still supplies an empty callback to `ModelListContent`. That prevents the shared list from dispatching our normal `openModelPickerEvent`, so **Configure models** can silently do nothing.

This keeps the popover close behavior and explicitly dispatches the existing fallback event when there is no custom handler.

## How we checked it

- Compared `eva` with `main`; the branch adds one commit and changes only `apps/app/src/components/model-select.tsx`.
- Verified the updated `eva` source retains the custom callback path and restores the default event path.
- The local checkout was unavailable to this automation run, so we could not run the Bun test suite here.

## Reproduction

1. Render `ModelSelect` without `onConfigureModels`.
2. Open the picker and choose **Configure models**.
3. Before this fix, the popover closes but no model configuration UI opens.
4. With this fix, the existing `openModelPickerEvent` is dispatched.