### PR TITLE
Fix OpenCode Zen default selection

### DIFF
--- a/apps/app/src/react-app/infra/preferred-chat-model.ts
+++ b/apps/app/src/react-app/infra/preferred-chat-model.ts
@@ -6,9 +6,9 @@ export type SelectableChatModelSnapshot = Array<{
 }>;
 
 /**
- * The historical Big Pickle default can be advertised by OpenCode even when
- * no backend route is available, which surfaces as a delayed 401. Prefer a
- * user-connected provider for that implicit default and for stale selections.
+ * Preserve every available selection, including the built-in OpenCode Zen
+ * default. Only replace a stale selection that the provider list no longer
+ * exposes, preferring a user-connected provider for that recovery path.
  */
 export function resolvePreferredSelectableChatModel(input: {
   providers: SelectableChatModelSnapshot;
@@ -23,9 +23,7 @@ export function resolvePreferredSelectableChatModel(input: {
         provider.modelIDs.includes(input.current.modelID),
     ),
   );
-  const isLegacyImplicitDefault =
-    input.current?.providerID === "opencode" && input.current.modelID === "big-pickle";
-  if (currentAvailable && !isLegacyImplicitDefault) return input.current ?? null;
+  if (currentAvailable) return input.current ?? null;
 
   for (const provider of input.providers) {
     if (provider.providerID === "opencode" || provider.modelIDs.length === 0) continue;

--- a/apps/app/tests/preferred-chat-model.test.ts
+++ b/apps/app/tests/preferred-chat-model.test.ts
@@ -8,12 +8,22 @@ describe("resolvePreferredSelectableChatModel", () => {
     { providerID: "tokenstar", modelIDs: ["gpt-5.6-sol", "kimi-k2.7-code"] },
   ];
 
-  test("moves the implicit Big Pickle default to a connected user provider", () => {
+  test("keeps the available OpenCode Zen default", () => {
     expect(
       resolvePreferredSelectableChatModel({
         providers,
         defaults: { tokenstar: "kimi-k2.7-code" },
         current: { providerID: "opencode", modelID: "big-pickle" },
+      }),
+    ).toEqual({ providerID: "opencode", modelID: "big-pickle" });
+  });
+
+  test("recovers an unavailable model with a connected user provider", () => {
+    expect(
+      resolvePreferredSelectableChatModel({
+        providers,
+        defaults: { tokenstar: "kimi-k2.7-code" },
+        current: { providerID: "missing", modelID: "missing-model" },
       }),
     ).toEqual({ providerID: "tokenstar", modelID: "kimi-k2.7-code" });
   });


### PR DESCRIPTION
## What changed

- Preserve the built-in OpenCode Zen `Big Pickle` model whenever the provider list reports it as available.
- Keep the existing stale-model recovery behavior for models that are genuinely unavailable.
- Add regression coverage for both the OpenCode Zen default and the unavailable-model fallback.

## Root cause

The preferred-model reconciliation treated `opencode/big-pickle` as a legacy implicit default even when it was available. It then skipped the OpenCode provider and persisted the first connected third-party model, so selecting Big Pickle appeared to immediately revert to Kimi.

## User impact

OpenCode Zen remains the default path and an explicit Big Pickle selection now survives provider synchronization and a full app reload.

## Validation

- `pnpm exec bun test --isolate tests/preferred-chat-model.test.ts` — 4 passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `pnpm fraimz --flow app-smoke --cdp-url http://127.0.0.1:9823` — passed
- Real Electron flow — selected OpenCode Zen / Big Pickle, waited for synchronization, reloaded the app, and confirmed it remained selected
- Full `pnpm test` — 463 passed; 3 existing unrelated failures and 1 existing unrelated `import.meta.glob` loading error remain in Design/permission tests