### PR TITLE
Fix PPT template launch routing

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -509,6 +509,7 @@ export function SessionPage(props: SessionPageProps) {
     getArtifactsFromMessages(conversationMessages, accessibleTargets, { includeTargetFallbacks: true })
       .find(isVideoHtmlArtifact) ?? null
   ), [accessibleTargets, conversationMessages]);
+  const autoOpenedDesignTemplateRef = useRef<string | null>(null);
   const autoOpenedVideoOutputRef = useRef<string | null>(null);
   const templateBriefDismissed = Boolean(
     props.selectedSessionId && dismissedTemplateBriefSessionIds.has(props.selectedSessionId),
@@ -870,6 +871,14 @@ export function SessionPage(props: SessionPageProps) {
     }
     setCurrentSidePanel("panel");
   }, [designTemplateEntryPath, openTab, props.selectedSessionId, selectTab, sessionPanelState.tabs, setCurrentSidePanel]);
+
+  useEffect(() => {
+    if (!props.selectedSessionId || !designTemplateEntryPath) return;
+    const templateKey = `${props.selectedSessionId}:${designTemplateEntryPath}`;
+    if (autoOpenedDesignTemplateRef.current === templateKey) return;
+    autoOpenedDesignTemplateRef.current = templateKey;
+    openDesignTab(designTemplateEntryPath);
+  }, [designTemplateEntryPath, openDesignTab, props.selectedSessionId]);
 
   const toggleCurrentSidePanel = useCallback((panel: SidePanelItem) => {
     setMainWorkspaceView(null);

--- a/apps/app/tests/new-conversation-animation-catalog.test.ts
+++ b/apps/app/tests/new-conversation-animation-catalog.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 const root = resolve(import.meta.dir, "..");
 const starter = readFileSync(resolve(root, "src/components/chat/new-conversation-starter.tsx"), "utf8");
 const surface = readFileSync(resolve(root, "src/react-app/domains/session/surface/session-surface.tsx"), "utf8");
+const sessionPage = readFileSync(resolve(root, "src/react-app/domains/session/chat/session-page.tsx"), "utf8");
 
 describe("new conversation animation catalog", () => {
   test("shows the video template picker and GSAP animation catalog", () => {
@@ -64,5 +65,11 @@ describe("new conversation animation catalog", () => {
     expect(surface).toContain("onMaterializeTemplate?: (templateId: string, surface: \"design\" | \"video\") => void | Promise<void>");
     expect(surface).toContain("onUseTemplate={props.onMaterializeTemplate ? (templateId, surface) => void props.onMaterializeTemplate?.(templateId, surface) : props.onCreateSession ?");
     expect(surface).toContain("props.onCreateSession?.(surface === \"video\" ? \"video\" : \"design\", templateId)");
+  });
+
+  test("opens a materialized design template in the Design panel", () => {
+    expect(sessionPage).toContain("const autoOpenedDesignTemplateRef = useRef<string | null>(null)");
+    expect(sessionPage).toContain("const templateKey = `${props.selectedSessionId}:${designTemplateEntryPath}`");
+    expect(sessionPage).toContain("openDesignTab(designTemplateEntryPath)");
   });
 });

--- a/apps/server/src/templates.e2e.test.ts
+++ b/apps/server/src/templates.e2e.test.ts
@@ -32,14 +32,14 @@ describe("template API", () => {
     const capabilities = await fetch(`${base}/capabilities`, { headers }).then((response) => response.json());
     expect(capabilities.templates).toEqual({ read: true, install: true, import: true, uninstall: true });
     const catalog = await fetch(`${base}/workspace/ws/templates`, { headers }).then((response) => response.json());
-    expect(catalog.items).toHaveLength(70);
+    expect(catalog.items).toHaveLength(73);
     expect(catalog.items.some((item: { manifest: { id: string } }) => item.manifest.id === "ipollowork.saas-landing")).toBe(true);
     for (const templateId of [
       "ipollowork.pptx-compatible-brief",
       "ipollowork.pptx-compatible-pitch",
       "ipollowork.pptx-compatible-report",
     ]) {
-      expect(catalog.items.some((item: { manifest: { id: string } }) => item.manifest.id === templateId)).toBe(false);
+      expect(catalog.items.some((item: { manifest: { id: string } }) => item.manifest.id === templateId)).toBe(true);
     }
 
     const invalidPackage = await fetch(`${base}/workspace/ws/templates/import`, {

--- a/apps/server/src/templates.test.ts
+++ b/apps/server/src/templates.test.ts
@@ -640,10 +640,10 @@ describe("template installations", () => {
     process.env.IPOLLOWORK_RUNTIME_DB = join(root, "runtime.sqlite");
     const serverConfig = config(root);
     const first = await listTemplates(serverConfig, "alpha");
-    expect(first.filter((item) => item.installed)).toHaveLength(70);
+    expect(first.filter((item) => item.installed)).toHaveLength(73);
     expect(first.some((item) => item.manifest.id === "ipollowork.saas-landing")).toBe(true);
     for (const templateId of pptxCompatibleTemplateIds) {
-      expect(first.some((item) => item.manifest.id === templateId)).toBe(false);
+      expect(first.some((item) => item.manifest.id === templateId)).toBe(true);
       expect(existsSync(join(bundledTemplatesRoot, templateId, "manifest.json"))).toBe(true);
     }
     expect(new Set(first.map((item) => item.manifest.category)).size).toBe(9);

--- a/apps/server/src/templates.ts
+++ b/apps/server/src/templates.ts
@@ -511,13 +511,6 @@ async function installDirectory(input: {
   });
 }
 
-const HIDDEN_BUNDLED_TEMPLATE_IDS = new Set([
-  "ipollowork.pptx-compatible-brief",
-  "ipollowork.pptx-compatible-pitch",
-  "ipollowork.pptx-compatible-report",
-]);
-
-
 export async function listTemplates(config: ServerConfig, workspaceId: string, scope: TemplateLibraryScope = "personal"): Promise<TemplateCatalogItem[]> {
   const db = await templateDb(config);
   const libraryId = templateLibraryId(scope);
@@ -536,8 +529,7 @@ export async function listTemplates(config: ServerConfig, workspaceId: string, s
     const parsed = templateManifestV1Schema.safeParse(JSON.parse(row.manifestJson));
     if (parsed.success) items.push({ manifest: parsed.data, sourceType: row.sourceType, installed: true, installedVersion: row.version, updateAvailable: false, verified: row.sourceType === "market" });
   }
-  const visibleItems = items.filter((item) => !HIDDEN_BUNDLED_TEMPLATE_IDS.has(item.manifest.id));
-  return sortTemplatesForCatalog(visibleItems.map((item) => item.manifest)).map((manifest) => visibleItems.find((item) => item.manifest === manifest)!);
+  return sortTemplatesForCatalog(items.map((item) => item.manifest)).map((manifest) => items.find((item) => item.manifest === manifest)!);
 }
 
 export async function installBundledTemplate(config: ServerConfig, workspaceId: string, templateId: string, scope: TemplateLibraryScope = "personal") {


### PR DESCRIPTION
## What changed

- Restore Executive Brief, Investor Pitch, and Quarterly Report to the template catalog.
- Automatically open a materialized Design/PPT template entry in the Design panel instead of leaving the user on an empty chat page or sending them to a browser.

## Root cause

The three packaged PPT-compatible templates were explicitly filtered out of the catalog. After a catalog template was materialized, the session route loaded but did not automatically open its generated entry file in the Design workspace.

## Scope

This PR fixes the shared product behavior for new checkouts. It intentionally does not migrate or reconcile any developer's historical local runtime databases; that environment-specific cleanup will be handled separately.

## Validation

- `pnpm --filter @ipollowork/app exec bun test tests/new-conversation-animation-catalog.test.ts` (8 passed)
- `pnpm --filter ./apps/server exec bun test src/templates.test.ts src/templates.e2e.test.ts` (33 passed)
- `pnpm --filter @ipollowork/app typecheck`
- `pnpm --filter ipollowork-server typecheck`
- `pnpm --filter ipollowork-server build`
- `pnpm --filter @ipollowork/app build`
- `pnpm --filter ipollowork-server test` (388 passed, 6 skipped, 0 failed)
- Real browser flow: Templates → Executive Brief → Use created a new session and opened `entry.html` in the Design preview with no page errors.

The full app suite currently reports 464 passing tests and 3 unrelated pre-existing failures in `design-preview-height.test.ts`, `permission-approval-modal.test.ts`, and `design-ai-session-route.test.ts` (`import.meta.glob` is unsupported by Bun in that test).

## Replay steps

1. Open a new task.
2. Open Templates and choose Executive Brief.
3. Select Use.
4. Confirm the new session shows Define this deck, the `entry.html` Design tab, and the Design preview.
