### PR TITLE
Fix artifact cards across grouped assistant turns

### DIFF
--- a/apps/app/scripts/message-list.test.ts
+++ b/apps/app/scripts/message-list.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import type { UIMessage } from "ai";
 
-import { getLatestArtifactAssistantMessageId } from "../src/components/chat/message-list";
+import {
+  getAssistantGroupArtifactMessages,
+  getLatestArtifactAssistantMessageId,
+} from "../src/components/chat/message-list";
+import { getArtifactsFromMessages } from "../src/lib/artifacts";
 
 describe("getLatestArtifactAssistantMessageId", () => {
   it("keeps a template entry attached to the latest real assistant response after a synthetic error", () => {
@@ -19,5 +23,47 @@ describe("getLatestArtifactAssistantMessageId", () => {
     ];
 
     expect(getLatestArtifactAssistantMessageId(messages)).toBe("msg_answer");
+  });
+});
+
+describe("getAssistantGroupArtifactMessages", () => {
+  it("keeps documents and spreadsheets from earlier tool steps available to the final response cards", () => {
+    const messages: UIMessage[] = [
+      {
+        id: "msg_write",
+        role: "assistant",
+        parts: [{
+          type: "dynamic-tool",
+          toolName: "write",
+          toolCallId: "write_report",
+          state: "output-available",
+          input: { filePath: "reports/revenue.xlsx", content: "quarter,revenue" },
+          output: { filePath: "reports/revenue.xlsx" },
+        }, {
+          type: "dynamic-tool",
+          toolName: "write",
+          toolCallId: "write_summary",
+          state: "output-available",
+          input: { filePath: "reports/summary.docx", content: "Quarterly summary" },
+          output: { filePath: "reports/summary.docx" },
+        }],
+      },
+      {
+        id: "msg_done",
+        role: "assistant",
+        parts: [{ type: "text", text: "The spreadsheet is ready.", state: "done" }],
+      },
+    ];
+    const groupMessages = getAssistantGroupArtifactMessages(
+      messages.map((message, index) => ({ message, index })),
+    );
+
+    const artifacts = getArtifactsFromMessages(groupMessages, [], { includeTargetFallbacks: false });
+
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "reports/revenue.xlsx", type: "sheet" }),
+      expect.objectContaining({ path: "reports/summary.docx", type: "document" }),
+    ]));
   });
 });

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -257,6 +257,10 @@ export function getLatestArtifactAssistantMessageId(messages: UIMessage[]) {
   )?.id
 }
 
+export function getAssistantGroupArtifactMessages(items: UIMessageWithIndex[]) {
+  return items.map((item) => item.message)
+}
+
 function retryDelaySeconds(status: RetryStatus) {
   return Math.max(0, Math.round((status.next - Date.now()) / 1000))
 }
@@ -397,6 +401,7 @@ function QuoteFollowUpButton({ messages }: CopyMessageButtonProps) {
 
 type AssistantMessageProps = {
   message: UIMessage
+  artifactMessages?: UIMessage[]
   isLastMessage: boolean
   isStreaming: boolean
   isLastStep: boolean
@@ -495,7 +500,7 @@ function AssistantProcessSection(props: {
 }
 
 const AssistantMessage = React.memo(
-  ({ message, isStreaming, hideProcess = false, showLatestArtifactsTitle = false, templateEntryPath }: AssistantMessageProps) => {
+  ({ message, artifactMessages, isStreaming, hideProcess = false, showLatestArtifactsTitle = false, templateEntryPath }: AssistantMessageProps) => {
     const { showThinking, highlightQuery, sessionId } = useMessageList()
     const assistantRenderGroups = React.useMemo(
       () => getAssistantRenderGroups(message.parts, showThinking),
@@ -523,7 +528,7 @@ const AssistantMessage = React.memo(
             renderAssistantGroup(group, index, { highlightQuery })
           )}
           <ArtifactList
-            messages={[message]}
+            messages={artifactMessages ?? [message]}
             sessionId={sessionId}
             title={showLatestArtifactsTitle ? t("session.outputs.latest_turn") : undefined}
             supplementalFiles={templateEntryPath ? [templateEntryPath] : undefined}
@@ -727,6 +732,7 @@ UserMessage.displayName = "UserMessage"
 
 type MessageComponentProps = {
   message: UIMessage
+  artifactMessages?: UIMessage[]
   isLastMessage: boolean
   isStreaming: boolean
   isLastStep: boolean
@@ -736,7 +742,7 @@ type MessageComponentProps = {
 }
 
 const MessageComponent = React.memo(
-  ({ message, isLastMessage, isStreaming, isLastStep, hideProcess, showLatestArtifactsTitle, templateEntryPath }: MessageComponentProps) => {
+  ({ message, artifactMessages, isLastMessage, isStreaming, isLastStep, hideProcess, showLatestArtifactsTitle, templateEntryPath }: MessageComponentProps) => {
     if (isSessionErrorMessage(message)) {
       return <ErrorMessage error={getMessagesText([message]) || t("message.session_failed")} />
     }
@@ -754,6 +760,7 @@ const MessageComponent = React.memo(
       return (
         <AssistantMessage
           message={message}
+          artifactMessages={artifactMessages}
           isLastMessage={isLastMessage}
           isStreaming={isStreaming}
           isLastStep={isLastStep}
@@ -909,6 +916,10 @@ function MessageGroup({
   const lastRealItem = items.findLast((item) => !isSessionErrorMessage(item.message))
   const isLiveGroup = isStreaming && lastItem !== undefined && lastItem.index === messages.length - 1
   const stepsRef = React.useRef<HTMLDivElement>(null)
+  const artifactMessages = React.useMemo(
+    () => getAssistantGroupArtifactMessages(items),
+    [items],
+  )
 
   // Keep the capped step run pinned to the latest step while streaming.
   React.useEffect(() => {
@@ -986,6 +997,7 @@ function MessageGroup({
       {resultData ? (
         <MessageComponent
           message={resultData.item.message}
+          artifactMessages={artifactMessages}
           isLastMessage={resultData.item.index === messages.length - 1}
           isStreaming={resultData.item.index === messages.length - 1 && isStreaming}
           isLastStep


### PR DESCRIPTION
## Summary

- collect artifact messages from the complete grouped assistant turn
- keep the current final-response rendering, process disclosure, card styling, and output panel behavior unchanged
- add regression coverage for spreadsheet and document files created before the final assistant summary

## Root cause

The grouped-message redesign renders only the final text-bearing assistant message. The inline `ArtifactList` therefore received only that final message and could no longer see write-tool parts from earlier messages in the same assistant turn.

## User impact

Generated documents and spreadsheets once again appear as browsable/editable cards below the final response, including when the final response does not repeat the generated file paths.

## Validation

- `pnpm --filter @ipollowork/app exec bun test ./scripts/message-list.test.ts ./scripts/artifacts.test.ts` — 11 passed
- `pnpm --filter @ipollowork/app typecheck` — passed after temporarily applying the known main-branch fixes for the unrelated Design JSX/import/callback errors; those temporary changes are not part of this PR
- `pnpm --filter @ipollowork/types build && pnpm --filter @ipollowork/app build` — passed under the same temporary main-branch corrections
- `git diff --check` — passed

The broader App suite currently has unrelated failures on `main`; this PR adds and passes the focused regression coverage for the affected message/artifact path.