### PR TITLE
Fix Video Studio project routing

### DIFF
--- a/apps/app/tests/video-hyperframes-panel.test.ts
+++ b/apps/app/tests/video-hyperframes-panel.test.ts
@@ -174,6 +174,18 @@ describe("HyperFrames Video Studio", () => {
     expect(electronDevSource).toContain('runSync(bunCmd, ["run", "build:local-studio"]');
   });
 
+  test("opens the session project even when Electron inherits another working directory", () => {
+    const electronSource = readFileSync(
+      new URL("../../../apps/desktop/electron/main.mjs", import.meta.url),
+      "utf8",
+    );
+
+    expect(electronSource).toContain(
+      'spawnLocalHyperframes(["preview", projectPath, "--port", String(port), "--no-open"], projectPath)',
+    );
+    expect(electronSource).toContain("runningProjectName === expectedProjectName");
+  });
+
   test("prevents automatic browser activity from replacing Video Studio", () => {
     const sessionPageSource = readFileSync(
       new URL("../src/react-app/domains/session/chat/session-page.tsx", import.meta.url),

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -398,11 +398,13 @@ function createServerProbeRequest(port, onConfig) {
 async function waitForHyperframesServer(port, expectedProjectPath, timeoutMs = HYPERFRAMES_START_TIMEOUT_MS) {
   const startedAt = Date.now();
   const expectedProjectDir = path.resolve(expectedProjectPath);
+  const expectedProjectName = path.basename(expectedProjectDir);
   while (Date.now() - startedAt < timeoutMs) {
     const config = await readHyperframesServerConfig(port);
     if (config?.isHyperframes) {
       const runningProject = typeof config.projectDir === "string" ? path.resolve(config.projectDir) : "";
-      if (runningProject === expectedProjectDir) return config;
+      const runningProjectName = typeof config.projectName === "string" ? config.projectName : "";
+      if (runningProject === expectedProjectDir && runningProjectName === expectedProjectName) return config;
     }
     await new Promise((resolveDelay) => setTimeout(resolveDelay, 350));
   }
@@ -412,10 +414,17 @@ async function waitForHyperframesServer(port, expectedProjectPath, timeoutMs = H
 async function stopStaleHyperframesPort(port, expectedProjectPath) {
   const config = await readHyperframesServerConfig(port);
   if (!config?.pid) return;
-  const runningProject = typeof config.projectDir === "string" ? path.resolve(config.projectDir) : "";
+  const expectedProjectDir = path.resolve(expectedProjectPath);
+  const expectedProjectName = path.basename(expectedProjectDir);
+  const runningProjectDir = typeof config.projectDir === "string" ? path.resolve(config.projectDir) : "";
+  const runningProjectName = typeof config.projectName === "string" ? config.projectName : "";
   const runningVersion = typeof config.version === "string" ? config.version : "";
   const expectedVersion = localHyperframesVersion();
-  if (runningProject === path.resolve(expectedProjectPath) && runningVersion === expectedVersion) return;
+  if (
+    runningProjectDir === expectedProjectDir &&
+    runningProjectName === expectedProjectName &&
+    runningVersion === expectedVersion
+  ) return;
   try {
     if (process.platform === "win32") {
       execFileSync("taskkill", ["/pid", String(config.pid), "/T", "/F"], { stdio: "ignore" });
@@ -511,7 +520,7 @@ async function startHyperframesPreview(event, options = {}) {
   await runHyperframesInit(workspaceRoot, projectDirectory, projectPath);
   await stopStaleHyperframesPort(port, projectPath);
 
-  const child = spawnLocalHyperframes(["preview", "--port", String(port), "--no-open"], projectPath);
+  const child = spawnLocalHyperframes(["preview", projectPath, "--port", String(port), "--no-open"], projectPath);
   let output = "";
   return await new Promise((resolve, reject) => {
     let ready = false;


### PR DESCRIPTION
## Summary

- pass the session video directory explicitly to HyperFrames preview
- validate both the project directory and project ID before reporting Studio ready
- replace stale preview processes that use the right directory but the wrong project ID
- add a regression check for Electron processes that inherit a different working directory

## Root cause

In development, Electron starts from `apps/desktop` and passes only `cwd` to HyperFrames. HyperFrames derives an implicit project name from the inherited `PWD`, so the server registers the project as `desktop` while iPolloWork opens `#project/<session-id>`. The session project endpoints then return 404 and the right-side editor appears blank. Packaged launches can work because their inherited environment differs.

## Impact

Video Studio now routes to the active session project consistently in development and packaged environments. It also avoids reusing a server whose project ID does not match the requested session.

## Validation

- targeted Video Studio regression: 1 passed
- app TypeScript check: passed
- desktop test suite: 87 passed, 1 skipped
- app production build: passed
- full desktop build: passed
- runtime probe with deliberately incorrect inherited `PWD`: `projectName` matched the session ID; project, preview, and index endpoints returned HTTP 200
- `git diff --check`: passed

## Existing baseline issues

- the full Video Studio source-assertion file has two unrelated stale assertions on current `main`
- `typecheck:electron` currently fails in `electron-after-pack.cjs:108` because an existing helper call supplies one argument instead of two
