### PR TITLE
feat(i18n): 根据系统区域自动选择界面语言

### DIFF
--- a/apps/app/src/i18n/index.ts
+++ b/apps/app/src/i18n/index.ts
@@ -27,7 +27,15 @@ export const LANGUAGES: Language[] = ["en", "ja", "zh", "vi", "pt-BR", "th", "fr
  */
 export const LANGUAGE_OPTIONS = [
   { value: "en" as Language, label: "English", nativeName: "English" },
+  { value: "ja" as Language, label: "Japanese", nativeName: "日本語" },
   { value: "zh" as Language, label: "Chinese (Simplified)", nativeName: "简体中文" },
+  { value: "vi" as Language, label: "Vietnamese", nativeName: "Tiếng Việt" },
+  { value: "pt-BR" as Language, label: "Portuguese (BR)", nativeName: "Português (BR)" },
+  { value: "th" as Language, label: "Thai", nativeName: "ไทย" },
+  { value: "fr" as Language, label: "French", nativeName: "Français" },
+  { value: "ca" as Language, label: "Catalan", nativeName: "Català" },
+  { value: "es" as Language, label: "Spanish", nativeName: "Español" },
+  { value: "ru" as Language, label: "Russian", nativeName: "Русский" },
 ] as const;
 
 const PLURAL_SUFFIX_EMPTY_LANGUAGES = new Set<Language>(["ja", "zh", "th"]);
@@ -67,6 +75,41 @@ const TRANSLATIONS: Record<Language, Record<string, string>> = {
  */
 export const isLanguage = (value: unknown): value is Language => {
   return typeof value === "string" && LANGUAGES.includes(value as Language);
+};
+
+const REGION_LANGUAGE_ALIASES = new Map<string, Language>([
+  ["zh-cn", "zh"],
+  ["zh-sg", "zh"],
+  ["zh-hans", "zh"],
+  ["pt", "pt-BR"],
+]);
+
+/**
+ * Match browser BCP 47 language tags to the locales bundled with iPolloWork.
+ * Region-sensitive Chinese and Portuguese variants only match explicit aliases
+ * so users are not silently moved to a different writing system or dialect.
+ */
+export const languageFromLocale = (localeTag: string): Language | null => {
+  const normalized = localeTag.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const exact = LANGUAGES.find((language) => language.toLowerCase() === normalized);
+  if (exact) return exact;
+
+  const alias = REGION_LANGUAGE_ALIASES.get(normalized);
+  if (alias) return alias;
+
+  const baseLanguage = normalized.split("-")[0];
+  if (baseLanguage === "zh" || baseLanguage === "pt") return null;
+  return LANGUAGES.find((language) => language === baseLanguage) ?? null;
+};
+
+export const preferredLanguage = (localeTags: readonly string[]): Language => {
+  for (const localeTag of localeTags) {
+    const language = languageFromLocale(localeTag);
+    if (language) return language;
+  }
+  return "en";
 };
 
 let localeValue: Language = "en";
@@ -207,9 +250,12 @@ export const initLocale = (): Language => {
     console.warn("Failed to read language preference:", e);
   }
 
+  const detected = preferredLanguage(window.navigator.languages);
+  localeValue = detected;
+
   if (typeof document !== "undefined") {
-    document.documentElement.setAttribute("lang", "en");
+    document.documentElement.setAttribute("lang", detected);
   }
 
-  return "en";
+  return detected;
 };

--- a/apps/app/tests/i18n-browser-language.test.ts
+++ b/apps/app/tests/i18n-browser-language.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { languageFromLocale, preferredLanguage } from "../src/i18n";
+
+describe("browser language detection", () => {
+  test("matches supported languages with country and script tags", () => {
+    expect(languageFromLocale("en-SG")).toBe("en");
+    expect(languageFromLocale("ja-JP")).toBe("ja");
+    expect(languageFromLocale("zh-CN")).toBe("zh");
+    expect(languageFromLocale("zh-Hans")).toBe("zh");
+    expect(languageFromLocale("pt-BR")).toBe("pt-BR");
+  });
+
+  test("does not map unsupported regional variants to a different locale", () => {
+    expect(languageFromLocale("zh-TW")).toBeNull();
+    expect(languageFromLocale("pt-PT")).toBeNull();
+  });
+
+  test("uses the first supported browser preference and falls back to English", () => {
+    expect(preferredLanguage(["de-DE", "fr-CA", "en-US"])).toBe("fr");
+    expect(preferredLanguage(["de-DE", "ko-KR"])).toBe("en");
+  });
+});


### PR DESCRIPTION
## 说明

- 首次打开且没有保存语言偏好时，根据浏览器的 BCP 47 国家和地区语言标签选择已有界面语言。
- 支持 `zh-CN`、`zh-SG`、`zh-Hans`、`pt-BR` 以及其他已支持语言的地区标签。
- 不会把 `zh-TW` 或 `pt-PT` 静默映射到不同书写体系或地区变体。
- 用户已经手动保存的语言偏好仍然拥有最高优先级。

## 验证

- `bun test apps/app/tests/i18n-browser-language.test.ts`
- `pnpm --filter @ipollowork/app typecheck`
- `pnpm --filter @ipollowork/types build`
- `pnpm --filter @ipollowork/app build`

以上检查均已通过。

<!-- codex-publisher:a203e6c2-38be-4595-81d9-f8616abf6fe4 -->