### PR TITLE
Fix expanded design property controls

### DIFF
--- a/apps/app/src/components/ui/popover.tsx
+++ b/apps/app/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ function PopoverContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
-        className="isolate z-50"
+        className="isolate z-[70] outline-none"
       >
         <PopoverPrimitive.Popup
           data-slot="popover-content"

--- a/apps/app/src/components/ui/select.tsx
+++ b/apps/app/src/components/ui/select.tsx
@@ -76,7 +76,7 @@ function SelectContent({
         align={align}
         alignOffset={alignOffset}
         alignItemWithTrigger={alignItemWithTrigger}
-        className="isolate z-50"
+        className="isolate z-[70]"
       >
         <SelectPrimitive.Popup
           data-slot="select-content"

--- a/apps/app/src/react-app/domains/session/design/design-panel-select.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel-select.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import * as React from "react";
+import { createPortal } from "react-dom";
 
 import { cn } from "@/lib/utils";
 import panelSelectChevron from "./assets/panel-select-chevron.svg";
@@ -33,7 +34,9 @@ export function DesignPanelSelect<T extends string>({
 }: DesignPanelSelectProps<T>) {
   const [open, setOpen] = React.useState(false);
   const [openAbove, setOpenAbove] = React.useState(false);
+  const [menuRect, setMenuRect] = React.useState<DOMRect | null>(null);
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const menuRef = React.useRef<HTMLDivElement>(null);
   const selected = options.find((option) => option.value === value) ?? options[0];
 
   const toggleOpen = () => {
@@ -41,6 +44,7 @@ export function DesignPanelSelect<T extends string>({
       const rect = rootRef.current.getBoundingClientRect();
       const menuHeight = options.length * 34 + 24;
       setOpenAbove(window.innerHeight - rect.bottom < menuHeight + 12 && rect.top > menuHeight + 12);
+      setMenuRect(rect);
     }
     setOpen((current) => !current);
   };
@@ -48,7 +52,8 @@ export function DesignPanelSelect<T extends string>({
   React.useEffect(() => {
     if (!open) return;
     const closeOnOutsidePointer = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target instanceof Node ? event.target : null)) setOpen(false);
+      const target = event.target instanceof Node ? event.target : null;
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) setOpen(false);
     };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false);
@@ -77,9 +82,16 @@ export function DesignPanelSelect<T extends string>({
         {showValue ? <span className={cn("min-w-0 flex-1 truncate text-[13px] text-[#24262b]", textClassName)}>{selected?.label ?? value}</span> : null}
         <img src={panelSelectChevron} alt="" width="16" height="16" className={cn("block size-4 shrink-0 transition-transform", open && "rotate-180")} />
       </button>
-      {open ? (
+      {open && menuRect ? createPortal(
         <div
-          className={cn("absolute left-0 z-50 w-full min-w-[120px] overflow-hidden rounded-xl border border-[#dedfe3] bg-white p-3 shadow-[0_8px_18px_rgba(37,41,49,0.11)]", openAbove ? "bottom-[calc(100%+12px)]" : "top-[calc(100%+12px)]", menuClassName)}
+          ref={menuRef}
+          className={cn("fixed z-[70] min-w-[120px] overflow-hidden rounded-xl border border-[#dedfe3] bg-white p-3 shadow-[0_8px_18px_rgba(37,41,49,0.11)]", menuClassName)}
+          style={{
+            left: menuRect.left,
+            top: openAbove ? undefined : menuRect.bottom + 12,
+            bottom: openAbove ? window.innerHeight - menuRect.top + 12 : undefined,
+            width: menuRect.width,
+          }}
           role="listbox"
           aria-label={ariaLabel}
         >
@@ -99,7 +111,8 @@ export function DesignPanelSelect<T extends string>({
               {option.label}
             </button>
           ))}
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </div>
   );

--- a/apps/app/tests/design-expanded-property-controls.test.ts
+++ b/apps/app/tests/design-expanded-property-controls.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const panelSelect = readFileSync(new URL("../src/react-app/domains/session/design/design-panel-select.tsx", import.meta.url), "utf8");
+const select = readFileSync(new URL("../src/components/ui/select.tsx", import.meta.url), "utf8");
+const popover = readFileSync(new URL("../src/components/ui/popover.tsx", import.meta.url), "utf8");
+
+test("Design property menus escape the expanded panel overflow and stacking context", () => {
+  expect(panelSelect).toContain("createPortal");
+  expect(panelSelect).toContain('className={cn("fixed z-[70]');
+  expect(select).toContain('className="isolate z-[70]"');
+  expect(popover).toContain('className="isolate z-[70] outline-none"');
+});


### PR DESCRIPTION
## Summary

- Fix PPT/Design property controls in expanded fullscreen mode.
- Allow font family, font size, font weight, color and other dropdowns to open and remain interactive.
- Render custom Design dropdowns through a document-level portal.
- Raise Select and Popover positioners above the fullscreen panel.

## Why

The expanded panel uses `z-index: 60`. Some property menus were either rendered inside an overflow container and clipped, or portalled with a `z-index: 50` positioner behind the panel.

## Scope

- Design property dropdown portal positioning.
- Select and Popover stacking order.
- Regression coverage for expanded property controls.

## Out of scope

- No changes to PPT export behavior or document content.
- No unrelated template-localization changes.

## Testing

- 28 relevant tests passed.
- TypeScript typecheck passed.
- `git diff --check` passed.

## Manual verification

1. Open a PPT/Design file and expand it to fullscreen.
2. Select a text element.
3. Confirm font family, size and weight menus open and accept selections.
4. Confirm color and other property popovers remain visible and interactive.
5. Confirm the property panel can still scroll normally.