### PR TITLE
Refine dark theme, appearance options, and dialog behavior

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -237,6 +237,10 @@
   --dls-card-shadow: 0 14px 36px rgba(0, 0, 0, 0.24);
 }
 
+[data-theme="dark"] .new-conversation-composer {
+  --new-conversation-composer-surface: #343434;
+}
+
 html,
 body {
   height: 100%;

--- a/apps/app/src/components/chat/new-conversation-starter.tsx
+++ b/apps/app/src/components/chat/new-conversation-starter.tsx
@@ -1132,7 +1132,7 @@ export function NewConversationStarter({
         </div>
 
         <div
-          className="mt-8 grid h-[46px] w-full max-w-[394px] grid-cols-4 items-center gap-1.5 rounded-[12px] bg-[#F5F5F5] p-1 dark:bg-[#343434]"
+          className="mt-8 grid h-[46px] w-full max-w-[394px] grid-cols-4 items-center gap-1.5 rounded-[12px] bg-[#F5F5F5] p-1 dark:bg-[#333]"
           role="tablist"
           aria-label={t("new_conversation.mode_label")}
         >
@@ -1147,8 +1147,8 @@ export function NewConversationStarter({
               className={cn(
                 "inline-flex h-[38px] min-w-0 items-center justify-center gap-1.5 rounded-[8px] px-1.5 font-sans text-[12px] font-medium leading-normal transition-[background-color,color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 selected
-                  ? "bg-white text-black"
-                  : "text-[#999] hover:bg-white/70 hover:text-black dark:hover:bg-white/10 dark:hover:text-white",
+                  ? "bg-white text-black dark:bg-black dark:text-[#ccc]"
+                  : "text-[#999] hover:bg-white/70 hover:text-black dark:hover:bg-black/50 dark:hover:text-[#ccc] dark:active:bg-black dark:active:text-[#ccc]",
               )}
               onClick={() => selectMode(id)}
               onMouseEnter={() => setHoveredMode(id)}
@@ -1161,8 +1161,7 @@ export function NewConversationStarter({
                 className={cn(
                   "shrink-0 object-contain",
                   id === "video" ? "h-[14px] w-[18px]" : "size-4",
-                  (selected || hoveredMode === id) && "brightness-0",
-                  !selected && hoveredMode === id && "dark:invert",
+                  (selected || hoveredMode === id) && "brightness-0 dark:invert dark:opacity-80",
                 )}
               />
               <span className="min-w-0 truncate">{t(label)}</span>

--- a/apps/app/src/components/chat/new-conversation-starter.tsx
+++ b/apps/app/src/components/chat/new-conversation-starter.tsx
@@ -1116,19 +1116,23 @@ export function NewConversationStarter({
         src={publicAssetUrl("new-conversation-bg.png")}
         alt=""
         aria-hidden
-        className="pointer-events-none absolute left-[calc(50%-280px)] -top-[18px] h-[243px] w-[243px] max-w-none"
+        className="pointer-events-none absolute left-[calc(50%-280px)] -top-[18px] h-[243px] w-[243px] max-w-none dark:opacity-20"
       />
       <div className="relative">
         <div className="max-w-4xl">
-          <img src={publicAssetUrl("ipollo-work-wordmark.svg")} alt="iPollo Work" className="h-[25px] w-[144px]" />
-          <h1 className="mt-3 font-sans text-[48px] font-semibold leading-none tracking-[-1.92px] text-black">
+          <img
+            src={publicAssetUrl("ipollo-work-wordmark.svg")}
+            alt="iPollo Work"
+            className="h-[25px] w-[144px] dark:invert dark:opacity-80"
+          />
+          <h1 className="mt-3 font-sans text-[48px] font-semibold leading-none tracking-[-1.92px] text-black dark:text-white">
             {t("new_conversation.title")}
           </h1>
-          <p className="mt-8 font-sans text-[16px] font-light leading-normal tracking-[-0.8px] text-[#666]">{t("new_conversation.subtitle")}</p>
+          <p className="mt-8 font-sans text-[16px] font-light leading-normal tracking-[-0.64px] text-[#666] dark:text-[#ccc]">{t("new_conversation.subtitle")}</p>
         </div>
 
         <div
-          className="mt-8 grid h-[46px] w-full max-w-[394px] grid-cols-4 items-center gap-1.5 rounded-[12px] bg-[#F5F5F5] p-1"
+          className="mt-8 grid h-[46px] w-full max-w-[394px] grid-cols-4 items-center gap-1.5 rounded-[12px] bg-[#F5F5F5] p-1 dark:bg-[#343434]"
           role="tablist"
           aria-label={t("new_conversation.mode_label")}
         >
@@ -1144,7 +1148,7 @@ export function NewConversationStarter({
                 "inline-flex h-[38px] min-w-0 items-center justify-center gap-1.5 rounded-[8px] px-1.5 font-sans text-[12px] font-medium leading-normal transition-[background-color,color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 selected
                   ? "bg-white text-black"
-                  : "text-[#999] hover:bg-white/70 hover:text-black",
+                  : "text-[#999] hover:bg-white/70 hover:text-black dark:hover:bg-white/10 dark:hover:text-white",
               )}
               onClick={() => selectMode(id)}
               onMouseEnter={() => setHoveredMode(id)}
@@ -1154,7 +1158,12 @@ export function NewConversationStarter({
                 src={iconSrc}
                 alt=""
                 aria-hidden
-                className={cn("shrink-0 object-contain", id === "video" ? "h-[14px] w-[18px]" : "size-4", (selected || hoveredMode === id) && "brightness-0")}
+                className={cn(
+                  "shrink-0 object-contain",
+                  id === "video" ? "h-[14px] w-[18px]" : "size-4",
+                  (selected || hoveredMode === id) && "brightness-0",
+                  !selected && hoveredMode === id && "dark:invert",
+                )}
               />
               <span className="min-w-0 truncate">{t(label)}</span>
             </button>
@@ -1174,8 +1183,8 @@ export function NewConversationStarter({
               className={cn(
                 "inline-flex h-[24px] min-w-[50px] items-center justify-center rounded-[18px] border px-2 text-[12px] font-medium transition-[background-color,border-color,color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 selectedTemplateAction || selectedCapabilityAction
-                  ? "border-[#CCC] bg-[#F5F5F5] text-[#999]"
-                  : "border-[#CBCBCB] bg-white text-[#999] hover:border-[#CCC] hover:bg-[#F5F5F5]",
+                  ? "border-[#CCC] bg-[#F5F5F5] text-[#999] dark:border-[#666] dark:bg-[#343434] dark:text-[#ccc]"
+                  : "border-[#CBCBCB] bg-white text-[#999] hover:border-[#CCC] hover:bg-[#F5F5F5] dark:border-[#666] dark:bg-transparent dark:hover:border-[#999] dark:hover:bg-[#343434] dark:hover:text-[#ccc]",
               )}
               onClick={() => {
                 if (templateCategory) {
@@ -1203,7 +1212,9 @@ export function NewConversationStarter({
               type="button"
               className={cn(
                 "inline-flex size-[24px] items-center justify-center rounded-full border text-muted-foreground transition-[background-color,border-color,color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                shortcutEditorOpen ? "border-[#CCC] bg-[#F5F5F5] text-foreground" : "border-[#CBCBCB] bg-white hover:border-[#CCC] hover:bg-[#F5F5F5] hover:text-foreground",
+                shortcutEditorOpen
+                  ? "border-[#CCC] bg-[#F5F5F5] text-foreground dark:border-[#666] dark:bg-[#343434]"
+                  : "border-[#CBCBCB] bg-white hover:border-[#CCC] hover:bg-[#F5F5F5] hover:text-foreground dark:border-[#666] dark:bg-transparent dark:hover:border-[#999] dark:hover:bg-[#343434]",
               )}
               aria-label={t("new_conversation.shortcuts.add")}
               aria-expanded={shortcutEditorOpen}

--- a/apps/app/src/i18n/index.ts
+++ b/apps/app/src/i18n/index.ts
@@ -27,15 +27,7 @@ export const LANGUAGES: Language[] = ["en", "ja", "zh", "vi", "pt-BR", "th", "fr
  */
 export const LANGUAGE_OPTIONS = [
   { value: "en" as Language, label: "English", nativeName: "English" },
-  { value: "ja" as Language, label: "Japanese", nativeName: "日本語" },
   { value: "zh" as Language, label: "Chinese (Simplified)", nativeName: "简体中文" },
-  { value: "vi" as Language, label: "Vietnamese", nativeName: "Tiếng Việt" },
-  { value: "pt-BR" as Language, label: "Portuguese (BR)", nativeName: "Português (BR)" },
-  { value: "th" as Language, label: "Thai", nativeName: "ไทย" },
-  { value: "fr" as Language, label: "French", nativeName: "Français" },
-  { value: "ca" as Language, label: "Catalan", nativeName: "Català" },
-  { value: "es" as Language, label: "Spanish", nativeName: "Español" },
-  { value: "ru" as Language, label: "Russian", nativeName: "Русский" },
 ] as const;
 
 const PLURAL_SUFFIX_EMPTY_LANGUAGES = new Set<Language>(["ja", "zh", "th"]);

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -112,7 +112,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
             {connecting ? (
               <Loader2 size={18} className="animate-spin text-dls-secondary" />
             ) : resolvedIconSrc ? (
-              <div className="flex size-6 items-center justify-center rounded-md bg-white">
+              <div className="flex size-6 items-center justify-center rounded-md bg-card">
                 <img src={resolvedIconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
               </div>
             ) : (

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -247,7 +247,7 @@ export function ExtensionDetailModal({
                 )}
               >
                 {resolvedIconSrc ? (
-                  <div className="flex size-8 items-center justify-center rounded-md bg-white">
+                  <div className="flex size-8 items-center justify-center rounded-md bg-card">
                     <img src={resolvedIconSrc} alt="" width={20} height={20} loading="lazy" style={{ display: "block" }} />
                   </div>
                 ) : (

--- a/apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/add-mcp-modal.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import { TextInput } from "../../../design-system/text-input";
 import type { McpDirectoryInfo } from "@/app/constants";
 import { t } from "@/i18n";
@@ -19,7 +20,7 @@ import { t } from "@/i18n";
 export type AddMcpModalProps = {
   open: boolean;
   onClose: () => void;
-  onAdd: (entry: McpDirectoryInfo) => void;
+  onAdd: (entry: McpDirectoryInfo) => void | Promise<unknown>;
   busy: boolean;
   isRemoteWorkspace: boolean;
 };
@@ -63,7 +64,6 @@ export function AddMcpModal(props: AddMcpModalProps) {
   };
 
   const handleClose = () => {
-    if (state.submitting) return;
     reset();
     props.onClose();
   };
@@ -113,6 +113,9 @@ export function AddMcpModal(props: AddMcpModalProps) {
             ...(oauthConfig ? { oauthConfig } : {}),
           }),
         );
+        toast.success(t("mcp.connected"));
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : t("mcp.connect_failed"));
       } finally {
         dispatch({ submitting: false });
       }
@@ -133,6 +136,9 @@ export function AddMcpModal(props: AddMcpModalProps) {
             oauth: false,
           }),
         );
+        toast.success(t("mcp.connected"));
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : t("mcp.connect_failed"));
       } finally {
         dispatch({ submitting: false });
       }

--- a/apps/app/src/react-app/domains/connections/modals/claude-plugin-import-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/modals/claude-plugin-import-modal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useReducer } from "react";
+import { useReducer, useRef } from "react";
 import { Download, Loader2, Search } from "lucide-react";
 
 import {
@@ -12,6 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import { t } from "@/i18n";
 import { TextInput } from "../../../design-system/text-input";
 import type { iPolloWorkClaudePluginPreview } from "../../../../app/lib/ipollowork-server";
@@ -68,9 +69,10 @@ const COMPONENT_LABEL_KEYS: Record<string, string> = {
 
 export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const operationRef = useRef(0);
 
   const handleClose = () => {
-    if (state.previewing || state.installing) return;
+    operationRef.current += 1;
     dispatch("reset");
     props.onClose();
   };
@@ -81,11 +83,14 @@ export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
       dispatch({ error: t("claude_plugin.invalid_url") });
       return;
     }
+    const operation = ++operationRef.current;
     dispatch({ previewing: true, error: null, preview: null, previewedUrl: null });
     try {
       const preview = await props.onPreview(url);
+      if (operationRef.current !== operation) return;
       dispatch({ kind: "preview-success", url, preview });
     } catch (error) {
+      if (operationRef.current !== operation) return;
       dispatch({
         previewing: false,
         error: error instanceof Error ? error.message : t("claude_plugin.load_preview_failed"),
@@ -97,18 +102,31 @@ export function ClaudePluginImportModal(props: ClaudePluginImportModalProps) {
     // Install exactly what was previewed — never a URL edited after preview.
     const url = state.previewedUrl;
     if (!url || state.installing) return;
+    const operation = ++operationRef.current;
     dispatch({ installing: true, error: null });
     try {
       const result = await props.onInstall(url);
       if (!result.ok) {
+        if (operationRef.current !== operation) {
+          toast.error(result.message);
+          return;
+        }
         dispatch({ installing: false, error: result.message });
         return;
       }
+      toast.success(result.message);
     } catch (error) {
+      const message = error instanceof Error ? error.message : t("claude_plugin.install_failed");
+      toast.error(message);
+      if (operationRef.current !== operation) return;
       dispatch({
         installing: false,
-        error: error instanceof Error ? error.message : t("claude_plugin.install_failed"),
+        error: message,
       });
+      return;
+    }
+    if (operationRef.current !== operation) {
+      props.onInstalled?.();
       return;
     }
     dispatch("reset");

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2011,7 +2011,7 @@ export function SessionPage(props: SessionPageProps) {
                       <img
                         src={publicAssetUrl(sidePanelOpen ? "sidebar-right-open.svg" : "sidebar-right-closed.svg")}
                         alt=""
-                        className="h-3 w-4 shrink-0"
+                        className="h-3 w-4 shrink-0 dark:invert"
                       />
                     </Button>
                   }
@@ -2020,9 +2020,9 @@ export function SessionPage(props: SessionPageProps) {
               </Tooltip>
             ) : null}
             <ResizablePanel minSize={rightPanelExpanded ? "0px" : `${mainWorkspaceMinWidth}px`} className="min-w-0">
-              <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-[#EAEAEA] [border-right-width:0.5px]">
+              <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border [border-right-width:0.5px]">
           <header className={cn(
-            "relative z-10 h-10 shrink-0 items-center justify-between border-b border-[#EAEAEA] px-4 [border-bottom-width:0.5px] md:px-6 mac:titlebar-drag mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar",
+            "relative z-10 h-10 shrink-0 items-center justify-between border-b border-border px-4 [border-bottom-width:0.5px] md:px-6 mac:titlebar-drag mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar",
             mainHeaderHidden ? "hidden" : "flex",
             sidebarVisuallyCollapsed && shellConfig.sidebar ? "!pl-16 mac:!pl-32" : "",
           )}>
@@ -2037,7 +2037,7 @@ export function SessionPage(props: SessionPageProps) {
                 onClick={openLeftSidebar}
                 style={{ WebkitAppRegion: "no-drag", pointerEvents: "auto" } as CSSProperties}
               >
-                <img src={publicAssetUrl("sidebar-left-expand.svg")} alt="" className="h-3 w-4 shrink-0" />
+                <img src={publicAssetUrl("sidebar-left-expand.svg")} alt="" className="h-3 w-4 shrink-0 dark:invert" />
               </Button>
             ) : null}
             <div className="flex min-w-0 items-center gap-1">
@@ -2139,7 +2139,7 @@ export function SessionPage(props: SessionPageProps) {
                       <img
                         src={publicAssetUrl(sidePanelOpen ? "sidebar-right-open.svg" : "sidebar-right-closed.svg")}
                         alt=""
-                        className="h-3 w-4 shrink-0"
+                        className="h-3 w-4 shrink-0 dark:invert"
                       />
                     </Button>
                   }
@@ -2404,7 +2404,7 @@ export function SessionPage(props: SessionPageProps) {
                   className="min-h-0 overflow-hidden lg:flex lg:flex-col"
                 >
                   {effectiveSidePanelView === "launcher" ? (
-                    <div className="flex h-full flex-col bg-background px-6 pt-16 text-[#6B7280] min-[960px]:px-10 min-[960px]:pt-[44vh]">
+                    <div className="flex h-full flex-col bg-background px-6 pt-16 text-muted-foreground min-[960px]:px-10 min-[960px]:pt-[44vh]">
                       <div className="w-full max-w-[240px] space-y-5">
                         {sidePanelLauncherItems.map((item) => {
                           return (
@@ -2412,8 +2412,8 @@ export function SessionPage(props: SessionPageProps) {
                               key={item.id}
                               type="button"
                               className={cn(
-                                "flex h-9 w-full items-center gap-3 rounded-xl px-2 text-left text-[14px] font-normal tracking-[-0.56px] text-[#8A8A8A] transition-colors hover:bg-[#F5F5F5] hover:text-[#242424] disabled:cursor-not-allowed disabled:opacity-40",
-                                item.active && "bg-[#F5F5F5] text-[#242424]",
+                                "flex h-9 w-full items-center gap-3 rounded-xl px-2 text-left text-[14px] font-normal tracking-[-0.56px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40",
+                                item.active && "bg-muted text-foreground",
                               )}
                               onClick={item.onClick}
                               disabled={item.disabled}

--- a/apps/app/src/react-app/domains/session/design/design-color-field.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-color-field.tsx
@@ -30,7 +30,7 @@ export function DesignColorField({ value, onChange, label = "Color", mixed = fal
   };
 
   return (
-    <div className={cn("flex h-[34px] items-center gap-2 rounded-lg bg-[#f5f6f9] px-2 pr-4", className)}>
+    <div className={cn("flex h-[34px] items-center gap-2 rounded-lg bg-muted px-2 pr-4", className)}>
       <label className="relative size-5 shrink-0 cursor-pointer overflow-hidden rounded-[4px]" style={mixed ? { background: "linear-gradient(135deg, #d1d5db 50%, #f9fafb 50%)" } : { backgroundColor: hex }}>
         <span className="sr-only">Choose {label.toLowerCase()}</span>
         <input
@@ -51,7 +51,7 @@ export function DesignColorField({ value, onChange, label = "Color", mixed = fal
         ariaLabel="Color format"
         className="h-7 w-[62px] shrink-0 rounded-lg"
         menuClassName="w-[92px]"
-        textClassName="text-[10px] uppercase text-[#858a94]"
+        textClassName="text-[10px] uppercase text-muted-foreground"
       />
       <Input
         className="h-7 min-w-0 flex-1 border-0 bg-transparent px-0 text-right text-[13px] uppercase shadow-none focus-visible:ring-0"

--- a/apps/app/src/react-app/domains/session/design/design-image-fit-select.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-image-fit-select.tsx
@@ -17,7 +17,7 @@ export function DesignImageFitSelect({ value, onChange, className, ariaLabel = "
       options={IMAGE_FIT_OPTIONS}
       onChange={onChange}
       ariaLabel={ariaLabel}
-      className={className ?? "h-[34px] w-full rounded-lg bg-[#f5f6f9]"}
+      className={className ?? "h-[34px] w-full rounded-lg bg-muted"}
     />
   );
 }

--- a/apps/app/src/react-app/domains/session/design/design-panel-select.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel-select.tsx
@@ -79,13 +79,13 @@ export function DesignPanelSelect<T extends string>({
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        {showValue ? <span className={cn("min-w-0 flex-1 truncate text-[13px] text-[#24262b]", textClassName)}>{selected?.label ?? value}</span> : null}
+        {showValue ? <span className={cn("min-w-0 flex-1 truncate text-[13px] text-foreground", textClassName)}>{selected?.label ?? value}</span> : null}
         <img src={panelSelectChevron} alt="" width="16" height="16" className={cn("block size-4 shrink-0 transition-transform", open && "rotate-180")} />
       </button>
       {open && menuRect ? createPortal(
         <div
           ref={menuRef}
-          className={cn("fixed z-[70] min-w-[120px] overflow-hidden rounded-xl border border-[#dedfe3] bg-white p-3 shadow-[0_8px_18px_rgba(37,41,49,0.11)]", menuClassName)}
+          className={cn("fixed z-[70] min-w-[120px] overflow-hidden rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-[0_8px_18px_rgba(37,41,49,0.11)]", menuClassName)}
           style={{
             left: menuRect.left,
             top: openAbove ? undefined : menuRect.bottom + 12,
@@ -102,7 +102,7 @@ export function DesignPanelSelect<T extends string>({
               role="option"
               aria-selected={option.value === value}
               disabled={option.disabled}
-              className={cn("flex h-[34px] w-full items-center rounded-lg px-2.5 text-left text-[12px] text-black transition-colors hover:bg-[#f4f5f7] focus-visible:bg-[#f4f5f7] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40", option.value === value && "bg-[#f4f5f7]")}
+              className={cn("flex h-[34px] w-full items-center rounded-lg px-2.5 text-left text-[12px] text-foreground transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-40", option.value === value && "bg-muted")}
               onClick={() => {
                 onChange(option.value);
                 setOpen(false);

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -137,8 +137,8 @@ const PDF_SLIDE_HEIGHT = 900;
 const PDF_PAGE_WIDTH_MM = 297;
 const PDF_PAGE_HEIGHT_MM = 167.0625;
 const LOCAL_IMAGE_ACCEPT = "image/*";
-const DESIGN_ACTION_BUTTON_CLASS = "size-8 rounded-lg border-0 bg-transparent text-[#202228] shadow-none hover:bg-[#F3F4F6] hover:text-[#202228] [&_svg]:!size-[18px]";
-const FLOATING_TOOLBAR_BUTTON_CLASS = "grid size-6 shrink-0 place-items-center rounded transition-colors hover:bg-[#F3F4F6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40";
+const DESIGN_ACTION_BUTTON_CLASS = "size-8 rounded-lg border-0 bg-transparent text-foreground shadow-none hover:bg-muted hover:text-foreground [&_svg]:!size-[18px]";
+const FLOATING_TOOLBAR_BUTTON_CLASS = "grid size-6 shrink-0 place-items-center rounded transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-40";
 
 function isDesignRuntimeMessage(value: unknown): value is DesignRuntimeMessage {
   if (!value || typeof value !== "object") return false;
@@ -1952,7 +1952,7 @@ export function DesignPanel({
       ) : (
         <>
           <div className={cn(
-            "flex min-w-0 shrink-0 flex-wrap items-center border-b border-[#EAEAEA] px-3 py-2 [border-bottom-width:0.5px]",
+            "flex min-w-0 shrink-0 flex-wrap items-center border-b border-border px-3 py-2 [border-bottom-width:0.5px]",
             compactToolbar ? "gap-1" : "gap-2",
           )}>
             {hasSiteVersioning ? (
@@ -1960,7 +1960,7 @@ export function DesignPanel({
                 <p className="min-w-0 truncate text-sm font-medium">{fileName(activePagePath)}</p>
                 {versionTargets.length > 0 ? (
                   <Select value={viewedVersionPath} onValueChange={(value) => { if (value) void viewVersion(value); }}>
-                    <SelectTrigger size="sm" className="w-14 shrink-0 rounded-lg border-0 bg-transparent px-2 shadow-none hover:bg-[#F3F4F6] focus-visible:ring-0" aria-label="Design version"><SelectValue>{viewedVersionLabel}</SelectValue></SelectTrigger>
+                    <SelectTrigger size="sm" className="w-14 shrink-0 rounded-lg border-0 bg-transparent px-2 shadow-none hover:bg-muted focus-visible:ring-0" aria-label="Design version"><SelectValue>{viewedVersionLabel}</SelectValue></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="current">{currentVersionLabel}</SelectItem>
                       {versionTargets.map((version, index) => <SelectItem key={version.path} value={version.path}>V{versionTargets.length - index}</SelectItem>)}
@@ -1985,14 +1985,14 @@ export function DesignPanel({
               Edit
             </Label>
             {deck ? (
-              <div className="order-2 flex h-8 min-w-0 items-center rounded-lg border border-[#D8DADF] bg-transparent p-0.5 shadow-none" data-testid="design-deck-navigation">
-                <Button variant="ghost" size="icon-sm" className="size-7 rounded-md text-[#202228] hover:bg-[#F3F4F6]" onClick={() => navigateDeck("previous")} disabled={deck.index <= 0} aria-label="Previous slide" title="Previous slide">
+              <div className="order-2 flex h-8 min-w-0 items-center rounded-lg border border-border bg-transparent p-0.5 shadow-none" data-testid="design-deck-navigation">
+                <Button variant="ghost" size="icon-sm" className="size-7 rounded-md text-foreground hover:bg-muted" onClick={() => navigateDeck("previous")} disabled={deck.index <= 0} aria-label="Previous slide" title="Previous slide">
                   <ChevronLeft className="size-4" />
                 </Button>
-                <span className="min-w-0 max-w-40 truncate px-1.5 text-[11px] font-medium tabular-nums text-[#5F636B]" aria-live="polite">
+                <span className="min-w-0 max-w-40 truncate px-1.5 text-[11px] font-medium tabular-nums text-muted-foreground" aria-live="polite">
                   {deck.index + 1} / {deck.total}
                 </span>
-                <Button variant="ghost" size="icon-sm" className="size-7 rounded-md text-[#202228] hover:bg-[#F3F4F6]" onClick={() => navigateDeck("next")} disabled={deck.index >= deck.total - 1} aria-label="Next slide" title="Next slide">
+                <Button variant="ghost" size="icon-sm" className="size-7 rounded-md text-foreground hover:bg-muted" onClick={() => navigateDeck("next")} disabled={deck.index >= deck.total - 1} aria-label="Next slide" title="Next slide">
                   <ChevronRight className="size-4" />
                 </Button>
               </div>
@@ -2027,7 +2027,7 @@ export function DesignPanel({
               {editing ? <Button
                 variant="ghost"
                 size="icon-sm"
-                className={cn(DESIGN_ACTION_BUTTON_CLASS, elementPropertiesOpen && "bg-[#F3F4F6]")}
+                className={cn(DESIGN_ACTION_BUTTON_CLASS, elementPropertiesOpen && "bg-muted")}
                 onClick={toggleElementProperties}
                 aria-label="Toggle design properties"
                 title="Design properties"
@@ -2183,7 +2183,7 @@ export function DesignPanel({
                 {editing && selection && selectionSummary ? (
                   <div
                     ref={floatingToolbarRef}
-                    className="absolute z-20 flex w-max items-center gap-[17px] rounded-lg border border-[#EBEBEB] bg-white px-4 py-2 shadow-[0_4px_4.2px_rgba(0,0,0,0.09)]"
+                    className="absolute z-20 flex w-max items-center gap-[17px] rounded-lg border border-border bg-popover px-4 py-2 text-popover-foreground shadow-[0_4px_4.2px_rgba(0,0,0,0.09)]"
                     style={floatingStyle}
                     role="toolbar"
                     aria-label="Design floating toolbar"
@@ -2194,7 +2194,7 @@ export function DesignPanel({
                   >
                     <button
                       type="button"
-                      className="grid size-6 shrink-0 touch-none cursor-grab place-items-center rounded transition-colors hover:bg-[#F3F4F6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+                      className="grid size-6 shrink-0 touch-none cursor-grab place-items-center rounded transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
                       onPointerDown={startFloatingDrag}
                       onPointerMove={moveFloatingToolbar}
                       onPointerUp={stopFloatingDrag}
@@ -2280,7 +2280,7 @@ export function DesignPanel({
                           <>
                             <button
                               type="button"
-                              className="flex h-6 shrink-0 items-center rounded px-1 transition-colors hover:bg-[#F3F4F6] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                              className="flex h-6 shrink-0 items-center rounded px-1 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                               onClick={() => beginQuickEdit("text")}
                               aria-label="Edit selected text"
                             >
@@ -2288,7 +2288,7 @@ export function DesignPanel({
                             </button>
                             <button
                               type="button"
-                              className="h-6 shrink-0 rounded px-1 text-base font-normal leading-6 text-[#858A94] transition-colors hover:bg-[#F3F4F6] hover:text-[#202228] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                              className="h-6 shrink-0 rounded px-1 text-base font-normal leading-6 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                               onClick={() => beginQuickEdit("fontSize")}
                               aria-label="Change selected font size"
                             >

--- a/apps/app/src/react-app/domains/session/design/design-properties-inspector.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-properties-inspector.tsx
@@ -144,7 +144,7 @@ function ElementPropertiesContent({
 
   return <>
 
-      <div className={cn("flex h-[52px] items-center px-4", !linkOpen && "border-b border-[#e8e9ec]")}>
+      <div className={cn("flex h-[52px] items-center px-4", !linkOpen && "border-b border-border")}>
         <span className="min-w-0 flex-1 truncate text-[14px] font-medium">{isMultiSelection ? `${selectionCount} elements · Batch selection` : selection.canEditText ? "Text layer" : `${selection.tag.charAt(0).toUpperCase()}${selection.tag.slice(1).toLowerCase()} layer`}</span>
         {!isMultiSelection ? <>
           <InspectorIconButton
@@ -163,7 +163,7 @@ function ElementPropertiesContent({
 
       {linkOpen && !isMultiSelection ? (
         <form
-          className="flex gap-2 border-b border-[#e8e9ec] px-4 pb-3"
+          className="flex gap-2 border-b border-border px-4 pb-3"
           onSubmit={(event) => {
             event.preventDefault();
             const href = linkDraft.trim();
@@ -177,7 +177,7 @@ function ElementPropertiesContent({
             value={linkDraft}
             placeholder="https://example.com or /page"
             aria-label="Layer link"
-            className="h-9 min-w-0 flex-1 rounded-lg border-[#dedfe3] px-2.5 text-[12px] shadow-none"
+            className="h-9 min-w-0 flex-1 rounded-lg border-border px-2.5 text-[12px] shadow-none"
             onChange={(event) => setLinkDraft(event.currentTarget.value)}
             onKeyDown={(event) => {
               if (event.key === "Escape") {
@@ -186,7 +186,7 @@ function ElementPropertiesContent({
               }
             }}
           />
-          <Button type="submit" size="sm" className="h-9 shrink-0 rounded-lg bg-black px-3 text-white hover:bg-black/85 active:bg-black">保存</Button>
+          <Button type="submit" size="sm" className="h-9 shrink-0 rounded-lg px-3">保存</Button>
         </form>
       ) : null}
 
@@ -195,7 +195,7 @@ function ElementPropertiesContent({
         <InspectorSection title="Text">
           <Input
             aria-label="Design text"
-            className="h-11 rounded-lg border-[#77a0ff] bg-white px-3 text-[13px] shadow-none focus-visible:ring-1 focus-visible:ring-[#77a0ff]"
+            className="h-11 rounded-lg border-ring bg-background px-3 text-[13px] shadow-none focus-visible:ring-1 focus-visible:ring-ring"
             value={selection.text}
             placeholder="预览文本可编辑内容框..."
             onFocus={() => onApplyField("text", selection.text, true)}
@@ -338,7 +338,7 @@ function ElementPropertiesContent({
           value={selection.html}
           aria-label="Selected element HTML code"
           spellCheck={false}
-          className="h-[220px] w-full resize-none overflow-auto rounded-[9px] border border-[#99b8f2] bg-white px-4 py-2 text-[14px] leading-5 text-[#24262b] outline-none selection:bg-[#dce8ff]"
+          className="h-[220px] w-full resize-none overflow-auto rounded-[9px] border border-ring bg-background px-4 py-2 text-[14px] leading-5 text-foreground outline-none selection:bg-accent"
           placeholder="HTML Code..."
         />
       </InspectorSection>
@@ -364,13 +364,13 @@ export function DesignSystemInspectorShell({ onClose, children }: Pick<DesignPro
 
 function InspectorShell({ activeTab, onActiveTabChange, onClose, children, designSystemOnly = false }: Pick<DesignPropertiesInspectorProps, "activeTab" | "onActiveTabChange" | "onClose" | "children"> & { designSystemOnly?: boolean }) {
   return (
-    <aside className="flex h-full w-[310px] shrink-0 flex-col overflow-hidden border-l border-[#ebebeb] bg-white text-[#202228]" aria-label="Design inspector">
-      <header className="sticky left-0 top-0 z-20 flex h-[58px] w-full shrink-0 items-center border-b border-[#ebebeb] bg-white !px-4">
+    <aside className="flex h-full w-[310px] shrink-0 flex-col overflow-hidden border-l border-border bg-background text-foreground" aria-label="Design inspector">
+      <header className="sticky left-0 top-0 z-20 flex h-[58px] w-full shrink-0 items-center border-b border-border bg-background !px-4">
         <div className="flex w-[240px] shrink-0 gap-1">
-          {!designSystemOnly ? <button type="button" onClick={() => onActiveTabChange("element")} className={cn("h-[35px] w-[118px] shrink-0 whitespace-nowrap rounded-lg px-2 text-[12px] font-semibold leading-none text-[#24262b] transition-colors", activeTab === "element" ? "bg-[#f5f6f9]" : "hover:bg-[#f5f6f9]")} aria-pressed={activeTab === "element"}>Element</button> : null}
-          <button type="button" onClick={() => onActiveTabChange("design-system")} className={cn("h-[35px] w-[118px] shrink-0 whitespace-nowrap rounded-lg px-1 text-[12px] font-semibold leading-none text-[#24262b] transition-colors", activeTab === "design-system" ? "bg-[#f5f6f9]" : "hover:bg-[#f5f6f9]")} aria-pressed={activeTab === "design-system"}>Design System</button>
+          {!designSystemOnly ? <button type="button" onClick={() => onActiveTabChange("element")} className={cn("h-[35px] w-[118px] shrink-0 whitespace-nowrap rounded-lg px-2 text-[12px] font-semibold leading-none text-foreground transition-colors", activeTab === "element" ? "bg-muted" : "hover:bg-muted")} aria-pressed={activeTab === "element"}>Element</button> : null}
+          <button type="button" onClick={() => onActiveTabChange("design-system")} className={cn("h-[35px] w-[118px] shrink-0 whitespace-nowrap rounded-lg px-1 text-[12px] font-semibold leading-none text-foreground transition-colors", activeTab === "design-system" ? "bg-muted" : "hover:bg-muted")} aria-pressed={activeTab === "design-system"}>Design System</button>
         </div>
-        <button type="button" className="absolute right-4 grid size-8 place-items-center rounded-lg text-[#5f636b] transition-colors hover:bg-[#f3f4f6] hover:text-[#202228]" onClick={onClose} aria-label="Close design properties">
+        <button type="button" className="absolute right-4 grid size-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground" onClick={onClose} aria-label="Close design properties">
           <X className="size-4" strokeWidth={1.7} />
         </button>
       </header>
@@ -394,7 +394,7 @@ function fillTypeFor(selection: DesignSelection): FillType {
 }
 
 function FillSummary({ swatchClassName, label }: { swatchClassName: string; label: string }) {
-  return <div className="mt-3 flex h-[34px] items-center justify-between rounded-lg bg-[#f5f6f9] px-2 pr-4"><span className="flex items-center gap-2 text-[13px] text-[#24262b]"><span className={cn("size-5 rounded-[4px]", swatchClassName)} />{label}</span><ChevronDown className="size-4 text-[#858a94]" /></div>;
+  return <div className="mt-3 flex h-[34px] items-center justify-between rounded-lg bg-muted px-2 pr-4"><span className="flex items-center gap-2 text-[13px] text-foreground"><span className={cn("size-5 rounded-[4px]", swatchClassName)} />{label}</span><ChevronDown className="size-4 text-muted-foreground" /></div>;
 }
 
 function ImageFillPicker({ selection, onApplyFields, onChooseImage }: { selection: DesignSelection; onApplyFields: (fields: Partial<Record<DesignStyleField, string>>) => void; onChooseImage: () => void }) {
@@ -452,7 +452,7 @@ function ShadowIntensityControl({ value, shadow, onChange }: { value: number; sh
 
   return (
     <div className="grid grid-cols-2 gap-3">
-      <label className="flex h-9 items-center rounded-lg bg-[#f4f5f8] px-2.5">
+      <label className="flex h-9 items-center rounded-lg bg-muted px-2.5">
         <span className="sr-only">Shadow intensity</span>
         <input
           type="range"
@@ -461,8 +461,8 @@ function ShadowIntensityControl({ value, shadow, onChange }: { value: number; sh
           step={1}
           value={value}
           aria-label="Shadow intensity"
-          className="h-3.5 w-full cursor-pointer appearance-none rounded-full bg-transparent [&::-webkit-slider-thumb]:size-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-[2px] [&::-webkit-slider-thumb]:border-black [&::-webkit-slider-thumb]:bg-white"
-          style={{ background: `linear-gradient(to right, #000 0%, #000 ${value}%, #e3e5ea ${value}%, #e3e5ea 100%)` }}
+          className="h-3.5 w-full cursor-pointer appearance-none rounded-full bg-transparent [&::-webkit-slider-thumb]:size-3.5 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-[2px] [&::-webkit-slider-thumb]:border-foreground [&::-webkit-slider-thumb]:bg-background"
+          style={{ background: `linear-gradient(to right, var(--foreground) 0%, var(--foreground) ${value}%, var(--border) ${value}%, var(--border) 100%)` }}
           onPointerDown={beginInteraction}
           onPointerUp={endInteraction}
           onPointerCancel={endInteraction}
@@ -482,33 +482,33 @@ function ShadowIntensityControl({ value, shadow, onChange }: { value: number; sh
 
 function InspectorSection({ title, children, last = false }: { title: string; children: React.ReactNode; last?: boolean }) {
   return (
-    <section className={cn("px-4 py-3.5", !last && "border-b border-[#e8e9ec]")}>
-      <h3 className="mb-3 text-[14px] font-medium text-black">{title}</h3>
+    <section className={cn("px-4 py-3.5", !last && "border-b border-border")}>
+      <h3 className="mb-3 text-[14px] font-medium text-foreground">{title}</h3>
       {children}
     </section>
   );
 }
 
 function FieldCaption({ className, children }: { className?: string; children: React.ReactNode }) {
-  return <p className={cn("mb-1 text-[10px] text-[#969ba5]", className)}>{children}</p>;
+  return <p className={cn("mb-1 text-[10px] text-muted-foreground", className)}>{children}</p>;
 }
 
 function PropertyField({ label, value, suffix, onChange, disabled = false, mixed = false }: { label: string; value: string; suffix?: string; onChange: (value: string, remember?: boolean) => void; disabled?: boolean; mixed?: boolean }) {
   return (
-    <label className="flex h-9 min-w-0 items-center gap-2 rounded-lg bg-[#f4f5f8] px-2.5">
-      <span className="shrink-0 text-[10px] text-[#969ba5]">{label}</span>
-      <input className="min-w-0 flex-1 bg-transparent text-right text-[12px] outline-none placeholder:text-[#6b7280] disabled:cursor-default" value={mixed ? "" : value} placeholder={mixed ? "Mixed" : undefined} disabled={disabled} onFocus={() => onChange(value, true)} onChange={(event) => onChange(event.currentTarget.value, false)} aria-label={`Design ${label.toLowerCase()} value`} />
-      {suffix && !mixed ? <span className="text-[10px] text-[#969ba5]">{suffix}</span> : null}
+    <label className="flex h-9 min-w-0 items-center gap-2 rounded-lg bg-muted px-2.5">
+      <span className="shrink-0 text-[10px] text-muted-foreground">{label}</span>
+      <input className="min-w-0 flex-1 bg-transparent text-right text-[12px] outline-none placeholder:text-muted-foreground disabled:cursor-default" value={mixed ? "" : value} placeholder={mixed ? "Mixed" : undefined} disabled={disabled} onFocus={() => onChange(value, true)} onChange={(event) => onChange(event.currentTarget.value, false)} aria-label={`Design ${label.toLowerCase()} value`} />
+      {suffix && !mixed ? <span className="text-[10px] text-muted-foreground">{suffix}</span> : null}
     </label>
   );
 }
 
 function DragNumberField({ label, value, suffix = "", onChange, mixed = false }: { label: string; value: string; suffix?: string; onChange: (value: number, remember?: boolean) => void; mixed?: boolean }) {
   return (
-    <label className="flex h-9 min-w-0 items-center gap-2 rounded-lg bg-[#f4f5f8] px-2.5">
-      <span className="shrink-0 text-[10px] text-[#969ba5]">{label}</span>
+    <label className="flex h-9 min-w-0 items-center gap-2 rounded-lg bg-muted px-2.5">
+      <span className="shrink-0 text-[10px] text-muted-foreground">{label}</span>
       <DragNumberInput label={label} value={String(numericValue(value, 0))} mixed={mixed} onChange={onChange} />
-      {suffix && !mixed ? <span className="text-[10px] text-[#969ba5]">{suffix}</span> : null}
+      {suffix && !mixed ? <span className="text-[10px] text-muted-foreground">{suffix}</span> : null}
     </label>
   );
 }
@@ -575,8 +575,8 @@ function FontPresetField({ label, value, presets, onChange, mixed = false }: { l
   const options = presets.map((preset) => typeof preset === "string" ? { value: preset, label: preset } : preset);
 
   return (
-    <div className="flex h-9 min-w-0 items-center gap-2 rounded-lg bg-[#f4f5f8] px-2.5">
-      <span className="shrink-0 text-[10px] text-[#969ba5]">{label}</span>
+    <div className="flex h-9 min-w-0 items-center gap-2 rounded-lg bg-muted px-2.5">
+      <span className="shrink-0 text-[10px] text-muted-foreground">{label}</span>
       {label === "Size" ? (
         <DragNumberInput label={label} value={value} mixed={mixed} onChange={(nextValue, remember) => onChange(String(nextValue), remember)} />
       ) : (
@@ -603,7 +603,7 @@ function BorderStyleField({ value, onChange }: { value: string; onChange: (value
       options={BORDER_STYLE_OPTIONS}
       onChange={onChange}
       ariaLabel="Design border style"
-      className="h-9 min-w-0 rounded-lg bg-[#f4f5f8]"
+      className="h-9 min-w-0 rounded-lg bg-muted"
     />
   );
 }
@@ -659,24 +659,24 @@ function FontFamilyPicker({ value, onChange, mixed = false }: { value: string; o
     <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger
         type="button"
-        className="flex h-9 w-full min-w-0 items-center rounded-lg bg-[#f4f5f8] px-2.5 text-[#202228] hover:bg-[#e9ebef]"
+        className="flex h-9 w-full min-w-0 items-center rounded-lg bg-muted px-2.5 text-foreground hover:bg-accent"
         aria-label="Design font family"
       >
         <span className="min-w-0 flex-1 truncate text-left text-[12px]" style={mixed ? undefined : { fontFamily: currentFamily }}>{mixed ? "Mixed" : currentFamily}</span>
         <img src={panelSelectChevron} alt="" className={cn("size-4 shrink-0 transition-transform", open && "rotate-180")} />
       </PopoverTrigger>
-      <PopoverContent align="start" sideOffset={12} initialFocus={false} className="w-[276px] gap-2 rounded-xl border-[#dedfe3] bg-white p-3 shadow-[0_8px_18px_rgba(37,41,49,0.11)] before:hidden">
+      <PopoverContent align="start" sideOffset={12} initialFocus={false} className="w-[276px] gap-2 rounded-xl border-border bg-popover p-3 text-popover-foreground shadow-[0_8px_18px_rgba(37,41,49,0.11)] before:hidden">
         <Input
           autoFocus
           value={query}
           onChange={(event) => setQuery(event.currentTarget.value)}
           placeholder="Search fonts"
           aria-label="Search fonts"
-          className="h-[34px] rounded-lg border-0 bg-[#f4f5f7] px-2.5 text-[12px] shadow-none"
+          className="h-[34px] rounded-lg border-0 bg-muted px-2.5 text-[12px] shadow-none"
         />
         <div className="max-h-64 overflow-y-auto" role="listbox" aria-label="Font families">
-          {loading ? <p className="px-2.5 py-2 text-[12px] text-[#858a94]">Loading fonts…</p> : null}
-          {!loading && visibleFamilies.length === 0 ? <p className="px-2.5 py-2 text-[12px] text-[#858a94]">No matching fonts</p> : null}
+          {loading ? <p className="px-2.5 py-2 text-[12px] text-muted-foreground">Loading fonts…</p> : null}
+          {!loading && visibleFamilies.length === 0 ? <p className="px-2.5 py-2 text-[12px] text-muted-foreground">No matching fonts</p> : null}
           {visibleFamilies.map((family) => {
             const selected = family.toLocaleLowerCase() === currentFamily.toLocaleLowerCase();
             return (
@@ -689,7 +689,7 @@ function FontFamilyPicker({ value, onChange, mixed = false }: { value: string; o
                   onChange(family);
                   setOpen(false);
                 }}
-                className={cn("flex w-full items-center rounded-md px-2.5 py-2 text-left text-[13px] hover:bg-[#f4f5f8]", selected && "bg-[#edf2ff]")}
+                className={cn("flex w-full items-center rounded-md px-2.5 py-2 text-left text-[13px] hover:bg-muted", selected && "bg-accent")}
                 style={{ fontFamily: family }}
               >
                 <span className="min-w-0 flex-1 truncate">{family}</span>
@@ -704,19 +704,19 @@ function FontFamilyPicker({ value, onChange, mixed = false }: { value: string; o
 }
 
 function ColorField({ label = "Color", value, onChange, mixed = false }: { label?: string; value: string; onChange: (value: string, remember?: boolean) => void; mixed?: boolean }) {
-  return <DesignColorField label={label} mixed={mixed} value={value} onChange={onChange} className="mt-2 h-9 bg-[#f4f5f8] px-2.5" />;
+  return <DesignColorField label={label} mixed={mixed} value={value} onChange={onChange} className="mt-2 h-9 bg-muted px-2.5" />;
 }
 
 function PropertyButton({ active = false, disabled = false, onClick, children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement> & { active?: boolean }) {
   return (
-    <button type="button" className={cn("grid h-9 min-w-0 place-items-center rounded-lg bg-[#f4f5f8] text-[#858a94] transition-colors [&_svg]:size-4", active && "bg-black text-white", !disabled && "hover:bg-[#e9ebef] hover:text-black", active && !disabled && "hover:bg-black hover:text-white")} disabled={disabled} onClick={onClick} {...props}>
+    <button type="button" className={cn("grid h-9 min-w-0 place-items-center rounded-lg bg-muted text-muted-foreground transition-colors [&_svg]:size-4", active && "bg-foreground text-background", !disabled && "hover:bg-accent hover:text-foreground", active && !disabled && "hover:bg-foreground hover:text-background")} disabled={disabled} onClick={onClick} {...props}>
       {children}
     </button>
   );
 }
 
 function MixedValueHint({ mixed }: { mixed?: boolean }) {
-  return mixed ? <span className="text-[10px] font-medium text-[#6b7280]">Mixed</span> : null;
+  return mixed ? <span className="text-[10px] font-medium text-muted-foreground">Mixed</span> : null;
 }
 
 function BatchPropertyButton({ mixed, label, children }: { mixed: boolean; label: string; children: React.ReactNode }) {
@@ -730,8 +730,8 @@ function BatchPropertyButton({ mixed, label, children }: { mixed: boolean; label
 
 function inspectorIconButtonClass(active = false) {
   return cn(
-    "grid h-9 w-[34px] shrink-0 place-items-center rounded-lg p-0 text-[#858a94] transition-colors hover:bg-[#f4f5f8] hover:text-[#202228] active:bg-black active:text-white disabled:pointer-events-none disabled:opacity-55 [&_svg]:!size-4",
-    active && "bg-black text-white hover:bg-black hover:text-white",
+    "grid h-9 w-[34px] shrink-0 place-items-center rounded-lg p-0 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground active:bg-foreground active:text-background disabled:pointer-events-none disabled:opacity-55 [&_svg]:!size-4",
+    active && "bg-foreground text-background hover:bg-foreground hover:text-background",
   );
 }
 

--- a/apps/app/src/react-app/domains/session/design/design-system-drawer.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-system-drawer.tsx
@@ -559,28 +559,28 @@ function EmbeddedDesignSystemControls({
   };
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto bg-white text-[#24262b]">
+    <div className="min-h-0 flex-1 overflow-y-auto bg-background text-foreground">
       <div className="space-y-0">
         <PanelSection title="Style preset">
-          <button type="button" className="flex h-16 w-full items-center gap-3 rounded-[9px] border border-[#ebebeb] p-2 text-left hover:border-[#cfd3da]" onClick={() => setPresetOpen((open) => !open)} aria-expanded={presetOpen}>
+          <button type="button" className="flex h-16 w-full items-center gap-3 rounded-[9px] border border-border p-2 text-left hover:border-ring" onClick={() => setPresetOpen((open) => !open)} aria-expanded={presetOpen}>
             <ThemeThumbnail colors={colorValues} />
-            <span className="min-w-0 flex-1"><span className="block truncate text-[13px] font-semibold">{selectedTheme?.name ?? "Custom"}</span><span className="mt-1 block truncate text-[11px] text-[#858a94]">{selectedTheme?.description ?? "Your current style preset"}</span></span>
-            {presetOpen ? <img src={designSystemChevronUpIcon} alt="" className="size-4 shrink-0" /> : <ChevronDown className="size-4 shrink-0 text-[#858a94]" />}
+            <span className="min-w-0 flex-1"><span className="block truncate text-[13px] font-semibold">{selectedTheme?.name ?? "Custom"}</span><span className="mt-1 block truncate text-[11px] text-muted-foreground">{selectedTheme?.description ?? "Your current style preset"}</span></span>
+            {presetOpen ? <img src={designSystemChevronUpIcon} alt="" className="size-4 shrink-0" /> : <ChevronDown className="size-4 shrink-0 text-muted-foreground" />}
           </button>
-          {presetOpen ? <div className="mt-3 h-[474px] rounded-xl border border-[#dedfe3] p-3 shadow-[0_8px_18px_rgba(37,41,49,0.11)]">
-            <div className="relative"><img src={designSystemSearchIcon} alt="" className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2" /><Input value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Search presets..." className="h-[34px] rounded-lg border-0 bg-[#f4f5f7] pl-[34px] text-[12px] shadow-none" /></div>
-            <div className="mt-[9px] flex gap-[5px] overflow-x-auto pb-1">{categories.map((item) => <button key={item} type="button" className={cn("h-[27px] shrink-0 rounded-[7px] px-2 text-[11px] transition-colors", category === item ? "bg-[#202124] text-white" : "bg-[#f4f5f7] text-[#70757e] hover:bg-[#ebebeb]")} onClick={() => setCategory(item)}>{item}</button>)}</div>
+          {presetOpen ? <div className="mt-3 h-[474px] rounded-xl border border-border p-3 shadow-[0_8px_18px_rgba(37,41,49,0.11)]">
+            <div className="relative"><img src={designSystemSearchIcon} alt="" className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2" /><Input value={query} onChange={(event) => setQuery(event.currentTarget.value)} placeholder="Search presets..." className="h-[34px] rounded-lg border-0 bg-muted pl-[34px] text-[12px] shadow-none" /></div>
+            <div className="mt-[9px] flex gap-[5px] overflow-x-auto pb-1">{categories.map((item) => <button key={item} type="button" className={cn("h-[27px] shrink-0 rounded-[7px] px-2 text-[11px] transition-colors", category === item ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:bg-accent")} onClick={() => setCategory(item)}>{item}</button>)}</div>
             <div className="mt-[9px] max-h-[340px] space-y-[5px] overflow-y-auto">{themes.map((theme) => {
               const active = theme.id === currentThemeId;
-              return <button key={theme.id} type="button" className={cn("flex h-16 w-full items-center gap-2.5 rounded-[9px] border p-2 text-left transition-colors", active ? "border-[#9cbdf0] bg-[#f4f8ff]" : "border-transparent bg-white hover:bg-[#f5f6f9]")} onClick={() => { onApplyTheme(theme); setPresetOpen(false); }}>
-                <ThemeThumbnail colors={themeColors(theme)} /><span className="min-w-0 flex-1"><span className="block truncate text-[12px] font-semibold">{theme.name}</span><span className="block truncate text-[10px] text-[#858a94]">{theme.category}</span></span>{active ? <Check className="size-4 text-[#2f6de1]" /> : null}
+              return <button key={theme.id} type="button" className={cn("flex h-16 w-full items-center gap-2.5 rounded-[9px] border p-2 text-left transition-colors", active ? "border-ring bg-accent" : "border-transparent bg-background hover:bg-muted")} onClick={() => { onApplyTheme(theme); setPresetOpen(false); }}>
+                <ThemeThumbnail colors={themeColors(theme)} /><span className="min-w-0 flex-1"><span className="block truncate text-[12px] font-semibold">{theme.name}</span><span className="block truncate text-[10px] text-muted-foreground">{theme.category}</span></span>{active ? <Check className="size-4 text-primary" /> : null}
               </button>;
             })}</div>
           </div> : null}
         </PanelSection>
 
         <PanelSection title="Theme Colors">
-          <div className="flex items-center gap-[11px]">{THEME_COLOR_TOKEN_NAMES.map((name, index) => <ColorSwatch key={name} label={["Primary", "Secondary", "Background"][index] ?? name} value={colorValues[index] ?? DEFAULTS[name]} onChange={(value) => onTokenChange(name, value)} />)}<button type="button" onClick={onResetColors} className="grid size-[25px] place-items-center rounded-[7px] border border-[#dee0e5] bg-[#f0f2f5]" aria-label="Reset theme colors"><img src={designSystemRefreshIcon} alt="" className="size-4" /></button></div>
+          <div className="flex items-center gap-[11px]">{THEME_COLOR_TOKEN_NAMES.map((name, index) => <ColorSwatch key={name} label={["Primary", "Secondary", "Background"][index] ?? name} value={colorValues[index] ?? DEFAULTS[name]} onChange={(value) => onTokenChange(name, value)} />)}<button type="button" onClick={onResetColors} className="grid size-[25px] place-items-center rounded-[7px] border border-border bg-muted" aria-label="Reset theme colors"><img src={designSystemRefreshIcon} alt="" className="size-4" /></button></div>
         </PanelSection>
 
         <BackgroundSection mode={backgroundMode} values={values} colors={colorValues} onSelectMode={applyBackgroundMode} onTokenChange={onTokenChange} onChooseMedia={onChooseBackgroundImage} />
@@ -595,7 +595,7 @@ function EmbeddedDesignSystemControls({
         <PanelSection title="Shadow"><TokenSelect value={cardShadow ?? "none"} ariaLabel="Shadow" options={shadowOptions(cardShadow)} onChange={(value) => onTokenChange("--ipw-card-shadow", value)} /></PanelSection>
         <PanelSection title="Motion"><TokenSelect value={motion} ariaLabel="Motion" options={MOTION_OPTIONS} onChange={setMotion} /></PanelSection>
       </div>
-      <div className="flex items-center justify-end border-t border-[#ebebeb] px-4 py-2"><Button variant="ghost" size="xs" onClick={onReset}><RotateCcw /> Reset</Button></div>
+      <div className="flex items-center justify-end border-t border-border px-4 py-2"><Button variant="ghost" size="xs" onClick={onReset}><RotateCcw /> Reset</Button></div>
     </div>
   );
 }
@@ -617,10 +617,10 @@ function withPresetOption(options: Array<{ label: string; value: string }>, valu
 function fontOptions(value: string, label: string) { return withPresetOption(FONT_OPTIONS, value, label); }
 function shadowOptions(value: string | undefined) { return withPresetOption(SHADOW_OPTIONS, value, "Preset shadow"); }
 
-function PanelSection({ title, children }: { title: string; children: React.ReactNode }) { return <section className="border-b border-[#ebebeb] px-4 pb-6 pt-2"><h3 className="mb-3 text-[14px] font-semibold leading-5">{title}</h3>{children}</section>; }
-function SegmentButton({ active, children, onClick }: { active: boolean; children: React.ReactNode; onClick: () => void }) { return <button type="button" className={cn("h-[34px] rounded-lg px-1 text-[14px] font-normal transition-colors", active ? "bg-black text-white" : "bg-[#f5f6f9] text-[#858a94] hover:bg-[#ebebeb]")} onClick={onClick} aria-pressed={active}>{children}</button>; }
-function TokenSelect({ value, ariaLabel, options, onChange }: { value: string; ariaLabel: string; options: Array<{ label: string; value: string }>; onChange: (value: string) => void }) { const option = options.find((item) => item.value === value) ?? options[0]; if (!option) return null; return <DesignPanelSelect value={option.value} options={options} onChange={onChange} ariaLabel={ariaLabel} className="h-[34px] w-full rounded-lg bg-[#f5f6f9]" />; }
-function LabeledTokenSelect({ label, ...props }: { label: string; value: string; ariaLabel: string; options: Array<{ label: string; value: string }>; onChange: (value: string) => void }) { return <label className="block"><span className="mb-1 block text-[10px] text-[#858a94]">{label}</span><TokenSelect {...props} /></label>; }
+function PanelSection({ title, children }: { title: string; children: React.ReactNode }) { return <section className="border-b border-border px-4 pb-6 pt-2"><h3 className="mb-3 text-[14px] font-semibold leading-5">{title}</h3>{children}</section>; }
+function SegmentButton({ active, children, onClick }: { active: boolean; children: React.ReactNode; onClick: () => void }) { return <button type="button" className={cn("h-[34px] rounded-lg px-1 text-[14px] font-normal transition-colors", active ? "bg-foreground text-background" : "bg-muted text-muted-foreground hover:bg-accent")} onClick={onClick} aria-pressed={active}>{children}</button>; }
+function TokenSelect({ value, ariaLabel, options, onChange }: { value: string; ariaLabel: string; options: Array<{ label: string; value: string }>; onChange: (value: string) => void }) { const option = options.find((item) => item.value === value) ?? options[0]; if (!option) return null; return <DesignPanelSelect value={option.value} options={options} onChange={onChange} ariaLabel={ariaLabel} className="h-[34px] w-full rounded-lg bg-muted" />; }
+function LabeledTokenSelect({ label, ...props }: { label: string; value: string; ariaLabel: string; options: Array<{ label: string; value: string }>; onChange: (value: string) => void }) { return <label className="block"><span className="mb-1 block text-[10px] text-muted-foreground">{label}</span><TokenSelect {...props} /></label>; }
 function ColorSwatch({ label, value, onChange }: { label: string; value: string; onChange: (value: string) => void }) { return <label className="group relative grid size-[25px] cursor-pointer place-items-center rounded-[7px] border border-black/10" title={label} style={{ backgroundColor: normalizeHex(value, "#ffffff") }}><input type="color" className="absolute inset-0 cursor-pointer opacity-0" value={normalizeHex(value, "#ffffff")} onChange={(event) => onChange(event.currentTarget.value)} aria-label={`${label} color`} /></label>; }
 function BackgroundSection({ mode, values, colors, onSelectMode, onTokenChange, onChooseMedia }: { mode: BackgroundMode; values: DesignTokenValues; colors: string[]; onSelectMode: (mode: BackgroundMode) => void; onTokenChange: (name: string, value: string) => void; onChooseMedia?: () => void }) {
   const controls: Array<{ mode: BackgroundMode; label: string; icon: string }> = [{ mode: "none", label: "No background", icon: backgroundNoneIcon }, { mode: "solid", label: "Solid color", icon: backgroundSolidDefaultIcon }, { mode: "gradient", label: "Gradient", icon: backgroundGradientIcon }, { mode: "image", label: "Image", icon: backgroundImageIcon }];
@@ -628,9 +628,9 @@ function BackgroundSection({ mode, values, colors, onSelectMode, onTokenChange, 
   const imageMode = backgroundImageFitMode(values["--ipw-bg-size"]);
 
   return <PanelSection title="Background">
-    <div className="flex gap-1">{controls.map(({ mode: itemMode, label, icon }) => <button key={itemMode} type="button" className={cn("grid h-[34px] flex-1 place-items-center rounded-lg transition-colors", mode === itemMode ? "bg-black" : "bg-[#f5f6f9] hover:bg-[#ebebeb]")} onClick={() => onSelectMode(itemMode)} aria-label={label} aria-pressed={mode === itemMode}>{itemMode === "solid" ? <img src={mode === "solid" ? backgroundSolidActiveIcon : icon} alt="" className="h-[34px] w-[68px] max-w-none" /> : <img src={icon} alt="" className={cn("size-4", mode === itemMode && "brightness-0 invert")} />}</button>)}</div>
+    <div className="flex gap-1">{controls.map(({ mode: itemMode, label, icon }) => <button key={itemMode} type="button" className={cn("grid h-[34px] flex-1 place-items-center rounded-lg transition-colors", mode === itemMode ? "bg-foreground" : "bg-muted hover:bg-accent")} onClick={() => onSelectMode(itemMode)} aria-label={label} aria-pressed={mode === itemMode}>{itemMode === "solid" ? <img src={mode === "solid" ? backgroundSolidActiveIcon : icon} alt="" className="h-[34px] w-[68px] max-w-none" /> : <img src={icon} alt="" className={cn("size-4", mode === itemMode && "brightness-0 invert")} />}</button>)}</div>
     {mode === "solid" ? <DesignColorField value={solidColor} onChange={(value) => onTokenChange("--ipw-color-bg", value)} className="mt-3" /> : null}
-    {mode === "gradient" ? <button type="button" className="mt-3 flex h-[34px] w-full items-center justify-between rounded-lg bg-[#f5f6f9] px-2 pr-4 text-left"><span className="flex items-center gap-2"><span className="size-5 rounded-[4px] bg-gradient-to-b from-[#2e6bdb] to-[#76e3e9]" /><span className="text-[13px]">Gradient</span></span><ChevronDown className="size-4 text-[#858a94]" /></button> : null}
+    {mode === "gradient" ? <button type="button" className="mt-3 flex h-[34px] w-full items-center justify-between rounded-lg bg-muted px-2 pr-4 text-left"><span className="flex items-center gap-2"><span className="size-5 rounded-[4px] bg-gradient-to-b from-[#2e6bdb] to-[#76e3e9]" /><span className="text-[13px]">Gradient</span></span><ChevronDown className="size-4 text-muted-foreground" /></button> : null}
     {mode === "image" ? <div className="mt-3 space-y-3">
       <DesignImageFitSelect value={imageMode} onChange={(value) => { onTokenChange("--ipw-bg-size", backgroundSizeFor(value)); onTokenChange("--ipw-bg-position", "50% 50%"); }} ariaLabel="Background image fit mode" />
       <div className="group relative flex h-[100px] w-full items-center justify-center overflow-hidden rounded-lg bg-[linear-gradient(45deg,#929292_25%,#9f9f9f_25%,#9f9f9f_50%,#929292_50%,#929292_75%,#9f9f9f_75%)] bg-[length:24px_24px]" style={backgroundImageStyle(values["--ipw-bg-image"], values["--ipw-bg-size"], values["--ipw-bg-position"])}>

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -350,7 +350,7 @@ function BrowserPanelContent({
 
   return (
     <>
-      <div className="flex h-10 shrink-0 items-center gap-1 border-b border-[#EAEAEA] bg-background px-2 [border-bottom-width:0.5px] mac:titlebar-drag mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background px-2 [border-bottom-width:0.5px] mac:titlebar-drag mac:bg-background/80 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
         {isAvailable ? (
           <>
             <Tooltip>
@@ -647,7 +647,7 @@ export function SidePanel({
                 <DropdownMenuContent
                   align="end"
                   positionerClassName={expanded ? "z-[70]" : undefined}
-                  className="w-[296px] rounded-[18px] border border-[#E5E5E5] bg-white p-3 text-[#242424] shadow-[0_8px_24px_rgba(0,0,0,0.10)] before:hidden"
+                  className="w-[296px] rounded-[18px] border border-border bg-popover p-3 text-popover-foreground shadow-[0_8px_24px_rgba(0,0,0,0.10)] before:hidden"
                 >
                   {launcherItems.map((item) => {
                     return (
@@ -656,13 +656,13 @@ export function SidePanel({
                         disabled={item.disabled}
                         onClick={item.onClick}
                         className={[
-                          "h-9 rounded-xl px-2 text-[14px] font-normal tracking-[-0.56px] text-[#8A8A8A] focus:bg-transparent focus:text-[#8A8A8A] hover:bg-[#F5F5F5] hover:text-[#242424] active:bg-[#EBEBEB] active:text-[#242424] data-highlighted:bg-transparent data-highlighted:text-[#8A8A8A] data-disabled:opacity-40",
+                          "h-9 rounded-xl px-2 text-[14px] font-normal tracking-[-0.56px] text-muted-foreground focus:bg-muted focus:text-foreground hover:bg-muted hover:text-foreground active:bg-accent active:text-foreground data-highlighted:bg-muted data-highlighted:text-foreground data-disabled:opacity-40",
                         ].join(" ")}
                       >
                         <img src={item.iconSrc} alt="" className="size-4 shrink-0" />
                         <span className="flex-1">{item.label}</span>
                         {item.shortcut ? (
-                          <span className="text-[12px] tracking-[-0.24px] text-[#8A8A8A]">{item.shortcut}</span>
+                          <span className="text-[12px] tracking-[-0.24px] text-muted-foreground">{item.shortcut}</span>
                         ) : null}
                       </DropdownMenuItem>
                     );
@@ -670,7 +670,7 @@ export function SidePanel({
                   {launcherItems.length === 0 && isBrowserAvailable ? (
                     <DropdownMenuItem
                       onClick={() => createTab()}
-                      className="h-11 rounded-xl px-2 text-[20px] font-normal tracking-[-0.8px] text-[#242424] focus:bg-[#F5F5F5] focus:text-[#242424]"
+                      className="h-11 rounded-xl px-2 text-[20px] font-normal tracking-[-0.8px] text-foreground focus:bg-muted focus:text-foreground"
                     >
                       <Globe className="size-6 stroke-[1.8] text-[#666666]" />
                       <span className="min-w-0 flex-1 truncate">{t("side_panel.launcher.browser")}</span>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -521,7 +521,7 @@ export type AppSidebarProps = {
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
 };
 
-const primarySidebarActionClassName = "h-8 gap-1 rounded-[8px] px-1 py-0 text-sm font-normal leading-4 text-black transition-colors hover:bg-black/5 hover:text-black active:bg-black/10 active:text-black data-active:bg-black/5 data-active:text-black focus-visible:ring-1 dark:text-black dark:hover:bg-black/5 dark:hover:text-black dark:active:bg-black/10 dark:data-active:bg-black/5 dark:data-active:text-black";
+const primarySidebarActionClassName = "h-8 gap-1 rounded-[8px] px-1 py-0 text-sm font-normal leading-4 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground focus-visible:ring-1";
 
 function useSessionTree(
   sessions: WorkspaceSessionGroup["sessions"],
@@ -635,7 +635,7 @@ export function AppSidebar(props: AppSidebarProps) {
           <div className="flex w-full justify-end px-3">
             <SidebarTrigger
               className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent mac:hover:bg-black/5 mac:active:bg-black/5 dark:mac:hover:bg-white/10 dark:mac:active:bg-white/10"
-              icon={<img src={publicAssetUrl("sidebar-left-expand.svg")} alt="" className="h-3 w-4 shrink-0" />}
+              icon={<img src={publicAssetUrl("sidebar-left-expand.svg")} alt="" className="h-3 w-4 shrink-0 dark:invert" />}
               aria-label={t("sidebar.collapse")}
               title={t("sidebar.collapse")}
             />
@@ -660,7 +660,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 aria-keyshortcuts={isMacPlatform() ? "Meta+Shift+F" : "Control+Shift+F"}
                 className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg text-sidebar-foreground transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent mac:hover:bg-black/5 mac:active:bg-black/5 dark:mac:hover:bg-white/10 dark:mac:active:bg-white/10"
               >
-                <img src={publicAssetUrl("sidebar-icon/search.svg")} alt="" className="size-6" />
+                <img src={publicAssetUrl("sidebar-icon/search.svg")} alt="" className="size-6 dark:invert" />
               </button>
             ) : null}
           </div>
@@ -674,7 +674,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 onClick={() => props.onCreateTaskInWorkspace(props.selectedWorkspaceId, "work")}
               >
                 <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
-                  <img src={publicAssetUrl("sidebar-icon/figma-square-pen.svg")} alt="" className="size-[11px]" />
+                  <img src={publicAssetUrl("sidebar-icon/figma-square-pen.svg")} alt="" className="size-[11px] dark:invert" />
                 </span>
                 <span className="flex-1 truncate">{t("session.new_task")}</span>
               </SidebarMenuButton>
@@ -686,7 +686,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 className={primarySidebarActionClass}
               >
                 <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
-                  <img src={publicAssetUrl("sidebar-icon/figma-layout-panel-top.svg")} alt="" className="size-[11px]" />
+                  <img src={publicAssetUrl("sidebar-icon/figma-layout-panel-top.svg")} alt="" className="size-[11px] dark:invert" />
                 </span>
                 <span className="flex-1 truncate">{t("template_market.title")}</span>
               </SidebarMenuButton>
@@ -698,7 +698,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 className={primarySidebarActionClass}
               >
                 <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
-                  <img src={publicAssetUrl("sidebar-icon/figma-plug.svg")} alt="" className="h-[13px] w-2" />
+                  <img src={publicAssetUrl("sidebar-icon/figma-plug.svg")} alt="" className="h-[13px] w-2 dark:invert" />
                 </span>
                 <span className="flex-1 truncate">{t("settings.tab_extensions")}</span>
               </SidebarMenuButton>
@@ -1034,16 +1034,16 @@ function SessionGroupSeparator({ label, expanded, onToggle, onAdd, addDisabled, 
   onTitlePointerDown?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   return (
-    <div className="group/session-group-row flex h-8 w-full items-center justify-between rounded-[8px] px-1 transition-colors hover:bg-black/5 active:bg-black/10 focus-within:ring-1 focus-within:ring-sidebar-ring">
+    <div className="group/session-group-row flex h-8 w-full items-center justify-between rounded-[8px] px-1 transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent focus-within:ring-1 focus-within:ring-sidebar-ring">
       <button
         type="button"
         onClick={onToggle}
         onPointerDown={onTitlePointerDown}
-        className="flex h-8 min-w-0 flex-1 cursor-grab touch-none items-center gap-1 rounded-[8px] text-left text-sm font-medium leading-4 text-black outline-hidden active:cursor-grabbing"
+        className="flex h-8 min-w-0 flex-1 cursor-grab touch-none items-center gap-1 rounded-[8px] text-left text-sm font-medium leading-4 text-sidebar-foreground outline-hidden active:cursor-grabbing"
         aria-expanded={expanded}
       >
         <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
-          <img src={publicAssetUrl("sidebar-icon/figma-folder-closed.svg")} alt="" className="h-[10px] w-3" />
+          <img src={publicAssetUrl("sidebar-icon/figma-folder-closed.svg")} alt="" className="h-[10px] w-3 dark:invert" />
         </span>
         <span className="truncate">{label}</span>
       </button>

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1184,9 +1184,9 @@ export function ReactSessionComposer(props: ComposerProps) {
       <div className="max-w-[800px] mx-auto">
         {/* Main composer panel */}
         <div
-          className={`relative overflow-visible rounded-[18px] border border-transparent bg-dls-surface shadow-[0_4px_12.9px_rgba(80,130,222,0.20)] transition-all ${panelRoundedClass}`}
+          className={`relative overflow-visible rounded-[18px] border border-transparent bg-dls-surface shadow-[0_4px_12.9px_rgba(80,130,222,0.20)] transition-all ${props.layout === "inline" ? "new-conversation-composer dark:bg-[#343434] dark:shadow-[0_4px_9.5px_rgba(113,156,234,0.53)]" : ""} ${panelRoundedClass}`}
           style={{
-            backgroundImage: "linear-gradient(var(--dls-surface), var(--dls-surface)), linear-gradient(90deg, #7FCDFF 0%, #FFE67D 100%)",
+            backgroundImage: `linear-gradient(${props.layout === "inline" ? "var(--new-conversation-composer-surface, var(--dls-surface))" : "var(--dls-surface)"}, ${props.layout === "inline" ? "var(--new-conversation-composer-surface, var(--dls-surface))" : "var(--dls-surface)"}), linear-gradient(90deg, #7FCDFF 0%, #FFE67D 100%)`,
             backgroundOrigin: "border-box",
             backgroundClip: "padding-box, border-box",
           }}
@@ -1549,7 +1549,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                                     className="flex w-full items-start gap-3 rounded-[16px] px-3 py-2.5 text-left text-gray-11 transition-colors hover:bg-gray-2/70"
                                     onClick={() => applyExtensionSelection(entry)}
                                   >
-                                    <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg border border-dls-border bg-white shadow-sm">
+                                    <div className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-lg border border-dls-border bg-card shadow-sm">
                                       {extensionIcon(entry, 16)}
                                     </div>
                                     <div className="min-w-0 flex-1">
@@ -1742,8 +1742,10 @@ export function ReactSessionComposer(props: ComposerProps) {
                     disabled={props.disabled || !canSend}
                     className={`inline-flex h-8 max-h-8 w-8 items-center justify-center rounded-full transition-colors ${
                       !canSend || props.disabled
-                        ? "bg-gray-4 text-gray-10"
-                        : "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
+                        ? `bg-gray-4 text-gray-10 ${props.layout === "inline" ? "dark:bg-white/15 dark:text-[#999]" : ""}`
+                        : props.layout === "inline"
+                          ? "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)] dark:bg-white dark:text-black dark:hover:bg-white/90"
+                          : "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
                     }`}
                     title={t("composer.run_task")}
                   >

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1622,7 +1622,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       ) : null}
 
       {isEmptyConversation ? (
-        <div className="flex min-h-0 flex-1 justify-center overflow-y-auto px-5">
+        <div className="flex min-h-0 flex-1 justify-center overflow-y-auto bg-background px-5 dark:bg-[#131313]">
           <div className="flex min-h-full w-full max-w-[800px] flex-col justify-center pb-12 pt-8">
             <NewConversationStarter
               selectedMode={newConversationMode}

--- a/apps/app/src/react-app/domains/session/video/video-panel.tsx
+++ b/apps/app/src/react-app/domains/session/video/video-panel.tsx
@@ -564,7 +564,7 @@ export function VideoPanel({ sessionId, workspaceRoot, client, workspaceId, isRe
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background" data-testid="video-panel" data-expanded={expanded ? "true" : "false"}>
-      <header className="flex h-11 shrink-0 items-center gap-2 border-b border-[#EAEAEA] px-3 [border-bottom-width:0.5px] mac:titlebar-drag">
+      <header className="flex h-11 shrink-0 items-center gap-2 border-b border-border px-3 [border-bottom-width:0.5px] mac:titlebar-drag">
         <Film className="size-4 text-primary" />
         <div className="flex min-w-0 flex-1 items-center">
           <p className="truncate text-sm font-medium">{t("video.title")}</p>
@@ -608,7 +608,7 @@ export function VideoPanel({ sessionId, workspaceRoot, client, workspaceId, isRe
             />
             <DropdownMenuContent
               align="end"
-              className="w-[296px] rounded-[18px] border border-[#E5E5E5] bg-white p-3 text-[#242424] shadow-[0_8px_24px_rgba(0,0,0,0.10)] before:hidden"
+              className="w-[296px] rounded-[18px] border border-border bg-popover p-3 text-popover-foreground shadow-[0_8px_24px_rgba(0,0,0,0.10)] before:hidden"
             >
               {launcherItems.map((item) => (
                 <DropdownMenuItem
@@ -616,14 +616,14 @@ export function VideoPanel({ sessionId, workspaceRoot, client, workspaceId, isRe
                   disabled={item.disabled}
                   onClick={item.onClick}
                   className={cn(
-                    "h-9 rounded-xl px-2 text-[14px] font-normal tracking-[-0.56px] text-[#242424] focus:bg-[#F5F5F5] focus:text-[#242424] data-disabled:opacity-40",
-                    item.active && "bg-[#F5F5F5]",
+                    "h-9 rounded-xl px-2 text-[14px] font-normal tracking-[-0.56px] text-foreground focus:bg-muted focus:text-foreground data-disabled:opacity-40",
+                    item.active && "bg-muted",
                   )}
                 >
                   <img src={item.iconSrc} alt="" className="size-4 shrink-0" />
                   <span className="flex-1">{item.label}</span>
                   {item.shortcut ? (
-                    <span className="text-[12px] tracking-[-0.24px] text-[#8A8A8A]">{item.shortcut}</span>
+                    <span className="text-[12px] tracking-[-0.24px] text-muted-foreground">{item.shortcut}</span>
                   ) : null}
                 </DropdownMenuItem>
               ))}

--- a/apps/app/src/react-app/domains/settings/authorization-form-dialog.tsx
+++ b/apps/app/src/react-app/domains/settings/authorization-form-dialog.tsx
@@ -95,7 +95,7 @@ export function AuthorizationFormDialog(props: AuthorizationFormDialogProps) {
         </FieldGroup>
         {props.error ? <p role="alert" className="rounded-xl border border-red-6 bg-red-2 px-3 py-2 text-xs leading-5 text-red-11">{props.error}</p> : null}
         <DialogFooter>
-          <DialogClose render={<Button size="sm" variant="outline" disabled={props.saving} />}>
+          <DialogClose render={<Button size="sm" variant="outline" />}>
             {props.cancelLabel}
           </DialogClose>
           <Button size="sm" onClick={props.onSubmit} disabled={props.saving}>

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -213,7 +213,7 @@ function ConnectRowIcon(props: { iconSlug?: string; iconSrc?: string; name: stri
   return (
     <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-dls-border bg-dls-hover">
       {src ? (
-        <div className="flex size-6 items-center justify-center rounded-md bg-white">
+        <div className="flex size-6 items-center justify-center rounded-md bg-card">
           <img src={src} alt="" width={16} height={16} loading="lazy" className="block" onError={() => setFailed(true)} />
         </div>
       ) : (

--- a/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-variable-provider.tsx
@@ -165,6 +165,9 @@ export function EnvironmentVariableProvider({ children, client, runtimeKey, onAp
         queryKey: environmentUserEnvQueryKey(runtimeKey),
       });
     },
+    onError: (error) => {
+      toast.error(error.message);
+    },
   });
 
   const { mutate: removeAsync, isPending: isRemoving, reset: resetRemove, error: removeError } = useMutation({

--- a/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/environment-view.tsx
@@ -443,13 +443,13 @@ function EnvironmentEditorModal(props: EnvironmentEditorModalProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && !isModifying) {
+      if (event.key === "Escape") {
         props.onClose();
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isModifying, props.onClose]);
+  }, [props.onClose]);
 
   const submitEditor = () => {
     if (isModifying) {
@@ -463,7 +463,7 @@ function EnvironmentEditorModal(props: EnvironmentEditorModalProps) {
     <Dialog
       open
       onOpenChange={(open) => {
-        if (!open && !isModifying) {
+        if (!open) {
           props.onClose();
         }
       }}
@@ -488,10 +488,7 @@ function EnvironmentEditorModal(props: EnvironmentEditorModalProps) {
         />
 
         <DialogFooter>
-          <DialogClose
-            disabled={isModifying}
-            render={<Button variant="outline" size="sm" disabled={isModifying} />}
-          >
+          <DialogClose render={<Button variant="outline" size="sm" />}>
             {t("settings.environment.cancel")}
           </DialogClose>
           <Button size="sm" onClick={submitEditor} disabled={isModifying}>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -108,7 +108,7 @@ export type McpViewProps = {
   selectedMcp: string | null;
   setSelectedMcp: (name: string | null) => void;
   quickConnect: McpDirectoryInfo[];
-  connectMcp: (entry: McpDirectoryInfo) => void;
+  connectMcp: (entry: McpDirectoryInfo) => void | Promise<unknown>;
   authorizeMcp: (entry: McpServerEntry) => void;
   logoutMcpAuth: (name: string) => Promise<void> | void;
   removeMcp: (name: string) => void;

--- a/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
@@ -1265,7 +1265,7 @@ export function SkillsView(props: SkillsViewProps) {
           if (!open) closeCustomRepoModal();
         }}
       >
-        <DialogContent showCloseButton={false} className="w-full max-w-lg overflow-hidden sm:max-w-lg">
+        <DialogContent className="w-full max-w-lg overflow-hidden sm:max-w-lg">
             <DialogHeader>
               <DialogTitle>{t("skills.add_custom_repo")}</DialogTitle>
               <DialogDescription>{t("skills.github_repo_hint")}</DialogDescription>
@@ -1312,10 +1312,7 @@ export function SkillsView(props: SkillsViewProps) {
               {customRepoError ? <div className="rounded-xl border border-red-7/20 bg-red-1/40 px-4 py-3 text-xs text-red-12">{customRepoError}</div> : null}
             </div>
             <DialogFooter>
-              <DialogClose
-                disabled={props.busy}
-                render={<Button variant="outline" disabled={props.busy} />}
-              >
+              <DialogClose render={<Button variant="outline" />}>
                 {t("common.cancel")}
               </DialogClose>
               <Button variant="secondary" onClick={saveCustomRepo} disabled={props.busy}>

--- a/apps/app/src/react-app/domains/settings/plugin-package-import-modal.tsx
+++ b/apps/app/src/react-app/domains/settings/plugin-package-import-modal.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef, useState } from "react";
 import { Archive, Bot, FileText, Loader2, Package, ShieldCheck, Upload } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import {
   Dialog,
   DialogClose,
@@ -33,6 +34,7 @@ type PluginPackageImportModalProps = {
 
 export function PluginPackageImportModal(props: PluginPackageImportModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const operationRef = useRef(0);
   const [upload, setUpload] = useState<iPolloWorkPluginPackageUpload | null>(null);
   const [preview, setPreview] = useState<iPolloWorkPluginPackagePreview | null>(null);
   const [busy, setBusy] = useState<"preview" | "install" | null>(null);
@@ -54,41 +56,49 @@ export function PluginPackageImportModal(props: PluginPackageImportModalProps) {
   };
 
   const close = () => {
-    if (busy) return;
+    operationRef.current += 1;
     reset();
     props.onClose();
   };
 
   const previewFile = async (file: File) => {
+    const operation = ++operationRef.current;
     setBusy("preview");
     setError(null);
     setPreview(null);
     try {
       const nextUpload = await readPluginPackageArchive(file);
       const response = await props.client.validatePluginPackageUpload(props.workspaceId, nextUpload);
+      if (operationRef.current !== operation) return;
       setUpload(nextUpload);
       setPreview(response.preview);
     } catch (cause) {
+      if (operationRef.current !== operation) return;
       setUpload(null);
       setError(formatPluginPlatformError(cause, t("plugin_platform.import_error")));
     } finally {
-      setBusy(null);
+      if (operationRef.current === operation) setBusy(null);
     }
   };
 
   const install = async () => {
     if (!upload || !preview) return;
+    const operation = ++operationRef.current;
     setBusy("install");
     setError(null);
     try {
       const response = await props.client.importPluginPackage(props.workspaceId, upload);
       await props.onInstalled(response.result.pluginId);
+      toast.success(t("plugin_platform.status.installed"));
+      if (operationRef.current !== operation) return;
       reset();
       props.onClose();
     } catch (cause) {
-      setError(formatPluginPlatformError(cause, t("plugin_platform.import_error")));
+      const message = formatPluginPlatformError(cause, t("plugin_platform.import_error"));
+      toast.error(message);
+      if (operationRef.current === operation) setError(message);
     } finally {
-      setBusy(null);
+      if (operationRef.current === operation) setBusy(null);
     }
   };
 
@@ -172,7 +182,7 @@ export function PluginPackageImportModal(props: PluginPackageImportModalProps) {
         </div>
 
         <DialogFooter className="shrink-0">
-          <DialogClose render={<Button variant="outline" disabled={busy !== null} />} disabled={busy !== null}>
+          <DialogClose render={<Button variant="outline" />}>
             {t("common.cancel")}
           </DialogClose>
           <Button disabled={!preview || busy !== null} onClick={() => void install()}>

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1755,7 +1755,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 enablementContext={enablementContext}
                 builtInExtensionsDisabled={builtInExtensionsDisabled}
                 connectMcp={(entry) => {
-                  void connectionsStore.connectMcp(entry);
+                  return connectionsStore.connectMcp(entry);
                 }}
                 configSlotForEntry={extensionController.configSlotForEntry}
                 isExtensionConnected={extensionController.isConnected}

--- a/apps/app/tests/dark-theme-regressions.test.ts
+++ b/apps/app/tests/dark-theme-regressions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const readAppSource = (path: string) => readFileSync(
+  new URL(`../src/react-app/domains/session/${path}`, import.meta.url),
+  "utf8",
+);
+
+describe("dark theme regressions", () => {
+  test("keeps sidebar actions and folder rows on semantic theme colors", () => {
+    const source = readAppSource("sidebar/app-sidebar.tsx");
+
+    expect(source).toContain("text-sidebar-foreground");
+    expect(source).toContain("hover:bg-sidebar-accent");
+    expect(source).not.toContain("dark:text-black");
+    expect(source).not.toContain('leading-4 text-black outline-hidden');
+  });
+
+  test("keeps design inspector chrome on semantic theme surfaces", () => {
+    const source = readAppSource("design/design-properties-inspector.tsx");
+
+    expect(source).toContain('border-l border-border bg-background text-foreground');
+    expect(source).toContain('border-border bg-popover');
+    expect(source).not.toContain('aria-label="Design inspector">\n      <header className="sticky left-0 top-0 z-20 flex h-[58px] w-full shrink-0 items-center border-b border-[#ebebeb] bg-white');
+  });
+});

--- a/apps/app/tests/dialog-close-regressions.test.ts
+++ b/apps/app/tests/dialog-close-regressions.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const sourceRoot = join(import.meta.dir, "../src/react-app");
+
+function source(path: string) {
+  return readFileSync(join(sourceRoot, path), "utf8");
+}
+
+describe("ordinary dialog close behavior", () => {
+  test("keeps close controls available while background work continues", () => {
+    const addMcp = source("domains/connections/modals/add-mcp-modal.tsx");
+    const claudeImport = source("domains/connections/modals/claude-plugin-import-modal.tsx");
+    const pluginImport = source("domains/settings/plugin-package-import-modal.tsx");
+    const environment = source("domains/settings/pages/environment-view.tsx");
+    const authorization = source("domains/settings/authorization-form-dialog.tsx");
+
+    expect(addMcp).not.toContain("if (state.submitting) return;\n    reset();");
+    expect(claudeImport).not.toContain("if (state.previewing || state.installing) return;");
+    expect(pluginImport).not.toContain("if (busy) return;\n    reset();");
+    expect(pluginImport).toContain('DialogClose render={<Button variant="outline" />}');
+    expect(environment).toContain('if (event.key === "Escape")');
+    expect(environment).toContain('DialogClose render={<Button variant="outline" size="sm" />}');
+    expect(authorization).toContain('DialogClose render={<Button size="sm" variant="outline" />}');
+  });
+
+  test("does not hide the close button on the custom skill repository dialog", () => {
+    const skills = source("domains/settings/pages/skills-view.tsx");
+
+    expect(skills).not.toContain("showCloseButton={false}");
+    expect(skills).toContain('<DialogClose render={<Button variant="outline" />}>');
+  });
+
+  test("keeps forced permission approval separate from ordinary dialogs", () => {
+    const permission = source("domains/session/chat/permission-approval-modal.tsx");
+
+    expect(permission).toContain("<AlertDialogContent");
+    expect(permission).not.toContain("<DialogContent");
+  });
+});

--- a/apps/app/tests/new-conversation-animation-catalog.test.ts
+++ b/apps/app/tests/new-conversation-animation-catalog.test.ts
@@ -87,7 +87,9 @@ describe("new conversation animation catalog", () => {
     expect(surface).toContain('dark:bg-[#131313]');
     expect(starter).toContain('new-conversation-bg.png');
     expect(starter).toContain('max-w-none dark:opacity-20');
-    expect(starter).toContain('dark:bg-[#343434]');
+    expect(starter).toContain('dark:bg-[#333]');
+    expect(starter).toContain('dark:bg-black dark:text-[#ccc]');
+    expect(starter).toContain('brightness-0 dark:invert dark:opacity-80');
     expect(starter).toContain('dark:text-[#ccc]');
     expect(starter).toContain('dark:invert dark:opacity-80');
     expect(composer).toContain("new-conversation-composer");

--- a/apps/app/tests/new-conversation-animation-catalog.test.ts
+++ b/apps/app/tests/new-conversation-animation-catalog.test.ts
@@ -6,6 +6,8 @@ const root = resolve(import.meta.dir, "..");
 const starter = readFileSync(resolve(root, "src/components/chat/new-conversation-starter.tsx"), "utf8");
 const surface = readFileSync(resolve(root, "src/react-app/domains/session/surface/session-surface.tsx"), "utf8");
 const sessionPage = readFileSync(resolve(root, "src/react-app/domains/session/chat/session-page.tsx"), "utf8");
+const composer = readFileSync(resolve(root, "src/react-app/domains/session/surface/composer/composer.tsx"), "utf8");
+const styles = readFileSync(resolve(root, "src/app/index.css"), "utf8");
 
 describe("new conversation animation catalog", () => {
   test("shows the video template picker without the GSAP animation catalog", () => {
@@ -79,5 +81,17 @@ describe("new conversation animation catalog", () => {
     expect(sessionPage).toContain("setTemplateSessionData({ ...result, hasBrief });");
     expect(sessionPage).toContain("setTemplateSessionData({ sessionId: props.selectedSessionId, ...result, hasBrief: false });");
     expect(sessionPage).toContain("const designTemplateEntryPath = currentTemplateSessionData?.manifest.surface === \"design\"");
+  });
+
+  test("matches the Figma dark palette without changing the light theme", () => {
+    expect(surface).toContain('dark:bg-[#131313]');
+    expect(starter).toContain('new-conversation-bg.png');
+    expect(starter).toContain('max-w-none dark:opacity-20');
+    expect(starter).toContain('dark:bg-[#343434]');
+    expect(starter).toContain('dark:text-[#ccc]');
+    expect(starter).toContain('dark:invert dark:opacity-80');
+    expect(composer).toContain("new-conversation-composer");
+    expect(styles).toContain("--new-conversation-composer-surface: #343434");
+    expect(composer).toContain("dark:bg-white dark:text-black");
   });
 });

--- a/apps/desktop/electron/desktop-auth-window.mjs
+++ b/apps/desktop/electron/desktop-auth-window.mjs
@@ -4,6 +4,56 @@
 // workspace renderer.
 
 export const DESKTOP_AUTH_SESSION_PARTITION = "persist:ipollowork-auth";
+const DESKTOP_AUTH_CLOSE_URL = "ipollowork-auth-window://close";
+const DESKTOP_AUTH_CLOSE_CONTROL_ID = "ipollowork-desktop-auth-close";
+
+function desktopAuthCloseControlScript() {
+  return `(() => {
+    const id = ${JSON.stringify(DESKTOP_AUTH_CLOSE_CONTROL_ID)};
+    if (document.getElementById(id)) return;
+
+    const button = document.createElement("button");
+    button.id = id;
+    button.type = "button";
+    button.setAttribute("aria-label", "Close sign-in window");
+    button.title = "Close";
+    button.innerHTML = '<svg viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+    button.style.cssText = [
+      "all: initial !important",
+      "position: fixed !important",
+      "top: 16px !important",
+      "right: 16px !important",
+      "z-index: 2147483647 !important",
+      "display: grid !important",
+      "width: 36px !important",
+      "height: 36px !important",
+      "place-items: center !important",
+      "box-sizing: border-box !important",
+      "border: 1px solid rgba(143, 151, 166, 0.35) !important",
+      "border-radius: 9999px !important",
+      "background: rgba(24, 31, 46, 0.72) !important",
+      "color: rgba(255, 255, 255, 0.88) !important",
+      "box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18) !important",
+      "backdrop-filter: blur(12px) !important",
+      "cursor: pointer !important",
+      "font-family: -apple-system, BlinkMacSystemFont, sans-serif !important",
+    ].join(";");
+    const icon = button.querySelector("svg");
+    icon.style.cssText = "width: 18px !important; height: 18px !important; fill: none !important; stroke: currentColor !important; stroke-width: 1.8 !important; stroke-linecap: round !important";
+    button.addEventListener("mouseenter", () => {
+      button.style.setProperty("background", "rgba(45, 54, 72, 0.92)", "important");
+      button.style.setProperty("color", "#ffffff", "important");
+    });
+    button.addEventListener("mouseleave", () => {
+      button.style.setProperty("background", "rgba(24, 31, 46, 0.72)", "important");
+      button.style.setProperty("color", "rgba(255, 255, 255, 0.88)", "important");
+    });
+    button.addEventListener("click", () => {
+      window.location.href = ${JSON.stringify(DESKTOP_AUTH_CLOSE_URL)};
+    });
+    document.documentElement.append(button);
+  })()`;
+}
 
 function isDenAuthCallbackUrl(value) {
   try {
@@ -32,6 +82,9 @@ export function classifyDesktopAuthNavigation(value) {
   if (!url) return { kind: "block" };
   if (url === "about:blank") return { kind: "allow", url };
   if (url.startsWith("data:text/html;charset=utf-8,")) return { kind: "allow", url };
+  if (url === DESKTOP_AUTH_CLOSE_URL || url === `${DESKTOP_AUTH_CLOSE_URL}/`) {
+    return { kind: "cancel" };
+  }
   if (isDenAuthCallbackUrl(url)) return { kind: "complete", url };
 
   try {
@@ -45,28 +98,30 @@ export function classifyDesktopAuthNavigation(value) {
   }
 }
 
-function runNavigationAction(event, targetUrl, { onComplete, openExternal }) {
+function runNavigationAction(event, targetUrl, { onComplete, onCancel, openExternal }) {
   const decision = classifyDesktopAuthNavigation(targetUrl);
   if (decision.kind === "allow") return decision;
 
   event?.preventDefault?.();
   if (decision.kind === "complete") {
     onComplete?.(decision.url);
+  } else if (decision.kind === "cancel") {
+    onCancel?.();
   } else if (decision.kind === "external") {
     void openExternal?.(decision.url);
   }
   return decision;
 }
 
-function installDesktopAuthNavigation(window, { onComplete, openExternal }) {
+function installDesktopAuthNavigation(window, { onComplete, onCancel, openExternal }) {
   const inspectNavigation = (event, targetUrl) => {
-    runNavigationAction(event, targetUrl, { onComplete, openExternal });
+    runNavigationAction(event, targetUrl, { onComplete, onCancel, openExternal });
   };
 
   window.webContents.on("will-navigate", inspectNavigation);
   window.webContents.on("will-redirect", inspectNavigation);
   window.webContents.setWindowOpenHandler(({ url }) => {
-    const decision = runNavigationAction(null, url, { onComplete, openExternal });
+    const decision = runNavigationAction(null, url, { onComplete, onCancel, openExternal });
     if (decision.kind === "allow") {
       // Providers that use window.open stay in this isolated client window.
       // This avoids an application switch while keeping the page top-level
@@ -74,6 +129,13 @@ function installDesktopAuthNavigation(window, { onComplete, openExternal }) {
       void window.loadURL(decision.url).catch(() => undefined);
     }
     return { action: "deny" };
+  });
+}
+
+function installDesktopAuthCloseControl(window) {
+  window.webContents.on("dom-ready", () => {
+    if (window.isDestroyed()) return;
+    void window.webContents.executeJavaScript(desktopAuthCloseControlScript(), true).catch(() => undefined);
   });
 }
 
@@ -156,7 +218,14 @@ export function createDesktopAuthWindow({
   });
 
   window.setMenuBarVisibility?.(false);
-  installDesktopAuthNavigation(window, { onComplete, openExternal });
+  installDesktopAuthNavigation(window, {
+    onComplete,
+    onCancel: () => {
+      if (!window.isDestroyed()) window.close();
+    },
+    openExternal,
+  });
+  installDesktopAuthCloseControl(window);
   window.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedUrl, isMainFrame) => {
     if (!isMainFrame || window.isDestroyed()) return;
     if (errorCode === -3) return;

--- a/apps/desktop/electron/desktop-auth-window.test.mjs
+++ b/apps/desktop/electron/desktop-auth-window.test.mjs
@@ -30,6 +30,17 @@ test("captures only Den desktop callbacks for the app handoff", () => {
   );
 });
 
+test("captures the isolated auth window close control without opening it externally", () => {
+  assert.deepEqual(
+    classifyDesktopAuthNavigation("ipollowork-auth-window://close"),
+    { kind: "cancel" },
+  );
+  assert.deepEqual(
+    classifyDesktopAuthNavigation("ipollowork-auth-window://close/"),
+    { kind: "cancel" },
+  );
+});
+
 test("does not navigate an auth window to arbitrary local protocols", () => {
   assert.deepEqual(
     classifyDesktopAuthNavigation("file:///tmp/untrusted.html"),


### PR DESCRIPTION
## Summary

- refine the new-conversation dark theme, including reduced background-art opacity and semantic dark surfaces
- align the Work, Create, Design, and Video tabs with the Figma dark palette
- improve dark-theme consistency across the sidebar, composer, Design inspector, Design System, and Video surfaces
- limit the Appearance language selector to English and Simplified Chinese
- keep ordinary dialogs dismissible while previews, imports, saves, and connection work continue in the background
- report background completion or failure through notifications instead of trapping users in busy dialogs
- add an app-owned close control to the isolated desktop sign-in and registration window
- retain forced-decision behavior for permission approval and required startup flows

## Why

Several ordinary dialogs disabled or hid their close controls while work was in progress. The isolated Electron authentication window also depended on the remote page to provide an exit, leaving macOS users without a visible way to close registration. This change makes dismissal behavior consistent without interrupting background work.

## Validation

- `pnpm --dir apps/app typecheck` — passed
- `cd apps/app && bun test ./tests/dark-theme-regressions.test.ts ./tests/dialog-close-regressions.test.ts` — 5 passed, 0 failed
- `node --test apps/desktop/electron/desktop-auth-window.test.mjs` — 5 passed, 0 failed
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed with no errors; existing cross-domain warnings remain
- development Electron client launched successfully

## Manual verification

1. Open Settings → Appearance and verify only English and Simplified Chinese are shown.
2. Use the system dark appearance and verify the new-conversation background, mode tabs, sidebar, composer, Design inspector, Design System, and Video surfaces.
3. Start a normal import, connection, save, or preview operation and verify the dialog can still be closed.
4. Verify the background result is reported through a notification.
5. Open iPolloWork account registration from Settings → Connect.
6. Verify the isolated registration window shows a 36 × 36 close control, positioned 16 px from the top-right corner.
7. Close the registration window and verify the main client remains open and usable.

## Scope notes

- Permission approval and required startup flows remain intentionally non-dismissible until the user makes the required decision.
- The separate local right-panel stability work is not included in this PR update.

## Evidence

The real development client flow was exercised through Electron and the registration window close behavior was verified. No screen recording is attached; the steps above reproduce the validated flow.
