### PR TITLE
Confirm provider disconnects and improve dark Chinese settings text

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -241,6 +241,14 @@
   --new-conversation-composer-surface: #343434;
 }
 
+html[lang="zh"][data-theme="dark"] [data-settings-content] {
+  font-weight: 450;
+}
+
+html[lang="zh"][data-theme="dark"] [data-settings-content] .font-normal {
+  font-weight: 450;
+}
+
 html,
 body {
   height: 100%;

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1458,6 +1458,8 @@ export default {
   "providers.auth_failed": "Authentication failed",
   "providers.connect_failed": "Failed to connect provider",
   "providers.disabled_in_config_suffix": "and disabled it in OpenCode config.",
+  "providers.disconnect_confirm_message": "This removes the saved provider authentication from this workspace. You can reconnect at any time.",
+  "providers.disconnect_confirm_title": "Disconnect {provider}?",
   "providers.disconnect_failed": "Failed to disconnect provider",
   "providers.disconnected_prefix": "Disconnected",
   "providers.load_failed": "Failed to load providers",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -1208,6 +1208,8 @@ export default {
   "providers.auth_failed": "认证失败",
   "providers.connect_failed": "连接提供商失败",
   "providers.disabled_in_config_suffix": "并已在OpenCode配置中禁用。",
+  "providers.disconnect_confirm_message": "将移除此工作区中保存的供应商认证信息。你之后仍可重新连接。",
+  "providers.disconnect_confirm_title": "断开{provider}？",
   "providers.disconnect_failed": "断开提供商失败",
   "providers.disconnected_prefix": "已断开",
   "providers.load_failed": "加载提供商失败",

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -1,10 +1,12 @@
 /** @jsxImportSource react */
 import { Button } from "@/components/ui/button";
-import type { ReactNode } from "react";
+import { toast } from "@/components/ui/sonner";
+import { useState, type ReactNode } from "react";
 import { ArrowRight, CheckCircle2, KeyRound, X } from "lucide-react";
 
 import { t } from "@/i18n";
 import { ProviderIcon } from "../../../design-system/provider-icon";
+import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { SettingsNotice, SettingsStatusBadge } from "../settings-section";
 import {
   LayoutSection,
@@ -37,7 +39,7 @@ export type AiSettingsViewProps = {
   providerDisconnectStatus: string | null;
   providerDisconnectError: string | null;
   onOpenProviderAuth: () => void | Promise<void>;
-  onDisconnectProvider: (providerId: string) => void | Promise<void>;
+  onDisconnectProvider: (providerId: string) => void | Promise<string | void>;
   canDisconnectProvider: (source?: ConnectedProvider["source"]) => boolean;
   /** Set of local provider IDs that were imported from cloud. */
   cloudProviderIds?: Set<string>;
@@ -64,8 +66,29 @@ function providerStatusTone(label: string): "ready" | "warning" | "neutral" {
 }
 
 export function AiSettingsView(props: AiSettingsViewProps) {
+  const [disconnectTarget, setDisconnectTarget] = useState<ConnectedProvider | null>(null);
+  const [localDisconnectingProviderId, setLocalDisconnectingProviderId] = useState<string | null>(null);
+  const disconnectingProviderId = localDisconnectingProviderId ?? props.disconnectingProviderId;
+
+  const confirmDisconnect = async () => {
+    const target = disconnectTarget;
+    if (!target || disconnectingProviderId !== null) return;
+
+    setDisconnectTarget(null);
+    setLocalDisconnectingProviderId(target.id);
+    try {
+      const message = await props.onDisconnectProvider(target.id);
+      toast.success(message?.trim() || `${t("providers.disconnected_prefix")} ${target.name}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : t("providers.disconnect_failed"));
+    } finally {
+      setLocalDisconnectingProviderId(null);
+    }
+  };
+
   return (
-    <LayoutStack>
+    <>
+      <LayoutStack>
       {/* ---- Providers ---- */}
       <LayoutSection>
         <LayoutSectionHeader>
@@ -169,15 +192,15 @@ export function AiSettingsView(props: AiSettingsViewProps) {
                 {!props.cloudProviderIds?.has(provider.id) ? (
                   <Button
                     variant="destructive"
-                    onClick={() => void props.onDisconnectProvider(provider.id)}
+                    onClick={() => setDisconnectTarget(provider)}
                     disabled={
                       props.busy ||
                       props.providerAuthBusy ||
-                      props.disconnectingProviderId !== null ||
+                      disconnectingProviderId !== null ||
                       !props.canDisconnectProvider(provider.source)
                     }
                   >
-                    {props.disconnectingProviderId === provider.id
+                    {disconnectingProviderId === provider.id
                       ? t("settings.disconnecting")
                       : props.canDisconnectProvider(provider.source)
                         ? t("settings.disconnect")
@@ -231,6 +254,17 @@ export function AiSettingsView(props: AiSettingsViewProps) {
 
       {props.cloudProvidersView}
 
-    </LayoutStack>
+      </LayoutStack>
+      <ConfirmModal
+        open={disconnectTarget !== null}
+        title={t("providers.disconnect_confirm_title", { provider: disconnectTarget?.name ?? "" })}
+        message={t("providers.disconnect_confirm_message")}
+        confirmLabel={t("settings.disconnect")}
+        cancelLabel={t("common.cancel")}
+        variant="danger"
+        onConfirm={() => void confirmDisconnect()}
+        onCancel={() => setDisconnectTarget(null)}
+      />
+    </>
   );
 }

--- a/apps/app/src/react-app/domains/settings/shell/panel.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/panel.tsx
@@ -10,7 +10,7 @@ type SettingsContentProps = {
 };
 
 export function SettingsContent(props: SettingsContentProps) {
-  return <div className="min-w-0 min-h-0 flex-1 overflow-y-auto flex flex-col gap-6 p-4 md:gap-8 md:p-6 lg:p-8 items-center">{props.children}</div>;
+  return <div data-settings-content className="min-w-0 min-h-0 flex-1 overflow-y-auto flex flex-col gap-6 p-4 md:gap-8 md:p-6 lg:p-8 items-center">{props.children}</div>;
 }
 
 type SettingsPanelProps = {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1624,9 +1624,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             providerDisconnectStatus={configActionStatus}
             providerDisconnectError={null}
             onOpenProviderAuth={handleOpenProviderAuth}
-            onDisconnectProvider={async (providerId) => {
-              await providerAuthStore.disconnectProvider(providerId);
-            }}
+            onDisconnectProvider={(providerId) => providerAuthStore.disconnectProvider(providerId)}
             canDisconnectProvider={(source) => source !== "env"}
             cloudProviderIds={new Set(
               Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).map((p) => p.providerId)

--- a/apps/app/tests/provider-disconnect-confirmation.test.ts
+++ b/apps/app/tests/provider-disconnect-confirmation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const aiView = readFileSync(
+  join(import.meta.dir, "../src/react-app/domains/settings/pages/ai-view.tsx"),
+  "utf8",
+);
+const settingsRoute = readFileSync(
+  join(import.meta.dir, "../src/react-app/shell/settings-route.tsx"),
+  "utf8",
+);
+
+describe("provider disconnect confirmation", () => {
+  test("asks for confirmation before disconnecting a provider", () => {
+    expect(aiView).toContain("setDisconnectTarget(provider)");
+    expect(aiView).toContain("<ConfirmModal");
+    expect(aiView).toContain('title={t("providers.disconnect_confirm_title"');
+    expect(aiView).toContain('variant="danger"');
+  });
+
+  test("shows immediate progress and reports the background result", () => {
+    expect(aiView).toContain("setLocalDisconnectingProviderId(target.id)");
+    expect(aiView).toContain('t("settings.disconnecting")');
+    expect(aiView).toContain("toast.success");
+    expect(aiView).toContain("toast.error");
+    expect(settingsRoute).toContain(
+      "onDisconnectProvider={(providerId) => providerAuthStore.disconnectProvider(providerId)}",
+    );
+  });
+});

--- a/apps/app/tests/settings-dark-chinese-weight.test.ts
+++ b/apps/app/tests/settings-dark-chinese-weight.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const css = readFileSync(join(import.meta.dir, "../src/app/index.css"), "utf8");
+const panel = readFileSync(
+  join(import.meta.dir, "../src/react-app/domains/settings/shell/panel.tsx"),
+  "utf8",
+);
+
+describe("settings dark Chinese typography", () => {
+  test("raises only the default Chinese settings weight in dark mode", () => {
+    expect(panel).toContain("data-settings-content");
+    expect(css).toContain('html[lang="zh"][data-theme="dark"] [data-settings-content]');
+    expect(css).toContain("font-weight: 450;");
+  });
+
+  test("keeps the adjustment scoped away from English and light mode", () => {
+    expect(css).not.toContain('html[lang="en"][data-theme="dark"] [data-settings-content]');
+    expect(css).not.toContain('html[lang="zh"][data-theme="light"] [data-settings-content]');
+  });
+});


### PR DESCRIPTION
## Summary

- add a destructive confirmation dialog before disconnecting a local AI provider
- show an immediate `Disconnecting...` state and prevent duplicate disconnect requests
- surface disconnect success and failure through notifications
- preserve the provider store's returned status message instead of discarding it in the settings route
- strengthen default Chinese text from weight 400 to 450 across all Settings subpages in dark mode
- keep the typography adjustment scoped to Chinese dark mode so English, light mode, and existing 500/600 headings are unchanged

## Why

Provider disconnect buttons previously started a destructive action immediately and offered no visible progress or completion feedback. Chinese body text in dark Settings pages also rendered noticeably lighter than the surrounding hierarchy on macOS, reducing readability.

## Validation

- `pnpm --dir apps/app typecheck` — passed
- `cd apps/app && bun test ./tests/provider-disconnect-confirmation.test.ts ./tests/chinese-locale-coverage.test.ts` — 3 passed, 0 failed
- `cd apps/app && bun test ./tests/settings-dark-chinese-weight.test.ts ./tests/dark-theme-regressions.test.ts` — 4 passed, 0 failed
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed with no errors; existing cross-domain warnings remain

## Manual verification

1. Open Settings → AI Providers with OpenCode Zen or OpenAI connected.
2. Click **Disconnect** and verify a confirmation dialog appears immediately.
3. Cancel and verify the dialog closes without changing the provider connection.
4. Confirm a disconnect and verify the row immediately shows **Disconnecting...**, duplicate actions are disabled, and completion is reported through a notification.
5. Switch the app to Chinese and use the dark system appearance.
6. Open several Settings subpages and verify body copy is more legible while headings retain their stronger hierarchy.

## Runtime evidence

- The development client displayed the confirmation for OpenCode Zen with the expected cancel and destructive actions; cancel closed it without disconnecting the provider.
- In a real rendered Settings page, the dark Chinese content container and description computed to weight `450`, while the page heading remained `600`.

No screen recording is attached. The steps above reproduce the validated flows in the development client.

## Scope

The separate local right-panel stability work is not included in this PR.
