### PR TITLE
Add MiniMax provider preset

### DIFF
--- a/apps/app/src/app/defaults/models.ts
+++ b/apps/app/src/app/defaults/models.ts
@@ -18,6 +18,8 @@ export const RECOMMENDED_MODEL_PATTERNS: string[] = [
   "gpt-5.5",
   "kimi-k2.6",
   "glm-5.2",
+  "minimax-m3",
+  "minimax-m2.7",
 ];
 
 /**

--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -417,6 +417,29 @@ export const BUILT_IN_IPOLLOWORK_EXTENSION_MANIFESTS: iPolloWorkExtensionManifes
   },
   {
     schemaVersion: 1,
+    id: "minimax",
+    name: "MiniMax",
+    description: "Configure MiniMax models through regional OpenAI-compatible or Anthropic endpoints.",
+    source: { format: "ipollowork-builtin", origin: "builtin", trusted: true },
+    composer: { prompt: "Use MiniMax to " },
+    setup: {
+      instructions: "Save a MiniMax API key, choose a regional endpoint, and add both current MiniMax models to OpenCode.",
+      primaryCta: "Configure MiniMax",
+    },
+    resources: [
+      { type: "provider", id: "minimax", label: "MiniMax", providerId: "minimax", required: true },
+    ],
+    contributions: [
+      { type: "settings-panel", ref: "ipollowork.minimax.settings", location: "settings-detail" },
+      { type: "composer-prompt", prompt: "Use MiniMax to ", location: "composer" },
+    ],
+    enablement: [
+      { type: "provider-connected", ref: "minimax", label: "MiniMax provider" },
+    ],
+    lifecycle: { reload: ["config"], detection: ["provider:minimax"] },
+  },
+  {
+    schemaVersion: 1,
     id: "ollama",
     name: "Ollama",
     description: "Local model provider at http://localhost:11434.",

--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -42,6 +42,7 @@ export const FRIENDLY_PROVIDER_LABELS: Record<string, string> = {
   mistral: "Mistral",
   groq: "Groq",
   openrouter: "OpenRouter",
+  minimax: "MiniMax",
   tokenstar: "TokenStar",
   together: "Together AI",
   fireworks: "Fireworks",
@@ -111,6 +112,10 @@ export const FRIENDLY_MODEL_LABELS: [pattern: string, label: string][] = [
   // OpenCode
   ["big-pickle", "Big Pickle"],
   ["kimi-k3", "Kimi K3"],
+
+  // MiniMax
+  ["minimax-m3", "MiniMax-M3"],
+  ["minimax-m2.7", "MiniMax-M2.7"],
 ];
 
 /**

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { McpDirectoryInfo } from "../../../app/constants";
 import { extensionContribution } from "../../../app/extensions";
 import type { iPolloWorkServerClient } from "../../../app/lib/ipollowork-server";
+import type { LocalProviderInstallInput } from "./openai-image-extension";
 
 /**
  * Context bag that the settings route passes to extension config factories.
@@ -41,14 +42,7 @@ export type ExtensionConfigContext = {
     busy: boolean;
     status: string | null;
     error: string | null;
-    onInstall: (input: {
-      providerId: string;
-      name: string;
-      baseURL: string;
-      modelId: string;
-      modelName: string;
-      setDefault: boolean;
-    }) => void | Promise<void>;
+    onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
   };
 };
 

--- a/apps/app/src/react-app/domains/settings/minimax-config.tsx
+++ b/apps/app/src/react-app/domains/settings/minimax-config.tsx
@@ -1,0 +1,221 @@
+/** @jsxImportSource react */
+import { useMemo, useState } from "react";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
+import type { LocalProviderInstallInput } from "./openai-image-extension";
+import {
+  buildMiniMaxProviderConfig,
+  getMiniMaxEndpoint,
+  MINIMAX_ENDPOINTS,
+  MINIMAX_PROVIDER,
+  type MiniMaxEndpointId,
+} from "./minimax-provider";
+
+const minimaxConfigFactory = (ctx: ExtensionConfigContext) => (
+  <MiniMaxConfig
+    busy={ctx.localProvider.busy}
+    status={ctx.localProvider.status}
+    error={ctx.localProvider.error}
+    onInstall={ctx.localProvider.onInstall}
+  />
+);
+
+registerExtensionConfig("ipollowork.minimax.settings", minimaxConfigFactory);
+registerExtensionConfig("minimax", minimaxConfigFactory);
+
+type MiniMaxConfigProps = {
+  busy: boolean;
+  status: string | null;
+  error: string | null;
+  onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
+};
+
+function isMiniMaxEndpointId(value: string): value is MiniMaxEndpointId {
+  return MINIMAX_ENDPOINTS.some((endpoint) => endpoint.id === value);
+}
+
+function formatContextWindow(value: number) {
+  return value.toLocaleString("en-US");
+}
+
+export function MiniMaxConfig(props: MiniMaxConfigProps) {
+  const [apiKey, setApiKey] = useState("");
+  const [endpointId, setEndpointId] = useState<MiniMaxEndpointId>("global-openai");
+  const [defaultModelId, setDefaultModelId] = useState(MINIMAX_PROVIDER.models[0].id);
+  const [setDefault, setSetDefault] = useState(true);
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const endpoint = useMemo(() => getMiniMaxEndpoint(endpointId), [endpointId]);
+  const selectedModel = MINIMAX_PROVIDER.models.find((model) => model.id === defaultModelId) ?? MINIMAX_PROVIDER.models[0];
+
+  const handleInstall = () => {
+    const trimmedApiKey = apiKey.trim();
+    if (!trimmedApiKey) {
+      setLocalError("MiniMax API key is required.");
+      return;
+    }
+
+    const provider = buildMiniMaxProviderConfig(endpointId);
+    setLocalError(null);
+    void props.onInstall({
+      providerId: MINIMAX_PROVIDER.providerId,
+      name: MINIMAX_PROVIDER.name,
+      api: provider.api,
+      npm: provider.npm,
+      apiKey: trimmedApiKey,
+      modelId: selectedModel.id,
+      modelName: selectedModel.id,
+      models: provider.models,
+      setDefault,
+    });
+  };
+
+  const error = localError ?? props.error;
+
+  return (
+    <Card variant="outline" size="sm">
+      <CardHeader>
+        <CardTitle>Configure MiniMax</CardTitle>
+        <CardDescription>
+          Add both current MiniMax models to OpenCode through a regional endpoint.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error ? (
+          <Alert variant="destructive">
+            <XCircle />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+        {props.status ? (
+          <Alert>
+            <CheckCircle2 />
+            <AlertDescription>{props.status}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="space-y-2">
+          <label htmlFor="minimax-api-key" className="text-sm font-medium">MiniMax API key</label>
+          <Input
+            id="minimax-api-key"
+            type="password"
+            value={apiKey}
+            onChange={(event) => {
+              setApiKey(event.currentTarget.value);
+              setLocalError(null);
+            }}
+            autoComplete="off"
+            autoCapitalize="off"
+            spellCheck={false}
+            placeholder="Enter your MiniMax API key"
+            disabled={props.busy}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="minimax-endpoint" className="text-sm font-medium">Endpoint</label>
+          <Select
+            value={endpointId}
+            items={MINIMAX_ENDPOINTS.map((candidate) => ({ value: candidate.id, label: candidate.label }))}
+            onValueChange={(value) => {
+              if (value && isMiniMaxEndpointId(value)) setEndpointId(value);
+            }}
+            disabled={props.busy}
+          >
+            <SelectTrigger id="minimax-endpoint" className="w-full">
+              <SelectValue placeholder={endpoint.label} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {MINIMAX_ENDPOINTS.map((candidate) => (
+                  <SelectItem key={candidate.id} value={candidate.id}>
+                    {candidate.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">{endpoint.baseURL}</p>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="minimax-default-model" className="text-sm font-medium">Default model</label>
+          <Select
+            value={defaultModelId}
+            items={MINIMAX_PROVIDER.models.map((model) => ({ value: model.id, label: model.id }))}
+            onValueChange={(value) => {
+              if (value) setDefaultModelId(value);
+            }}
+            disabled={props.busy}
+          >
+            <SelectTrigger id="minimax-default-model" className="w-full">
+              <SelectValue placeholder={selectedModel.id} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {MINIMAX_PROVIDER.models.map((model) => (
+                  <SelectItem key={model.id} value={model.id}>
+                    {model.id}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {MINIMAX_PROVIDER.models.map((model) => (
+            <div key={model.id} className="rounded-md border border-border p-3 text-xs">
+              <div className="font-medium text-foreground">{model.id}</div>
+              <div className="mt-1 text-muted-foreground">
+                Context: {formatContextWindow(model.contextWindow)} - Input: {model.inputModalities.join(", ")}
+              </div>
+              <div className="mt-1 text-muted-foreground">Thinking: {model.thinking.join(", ")}</div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+      <CardFooter className="border-t border-border">
+        <FieldGroup className="gap-3">
+          <Field orientation="horizontal">
+            <Checkbox
+              id="minimax-set-default"
+              name="minimax-set-default"
+              checked={setDefault}
+              onCheckedChange={(checked) => setSetDefault(checked === true)}
+              nativeButton
+              render={<button type="button" />}
+            />
+            <FieldLabel htmlFor="minimax-set-default">Use the selected model as the default</FieldLabel>
+          </Field>
+        </FieldGroup>
+        <Button onClick={handleInstall} disabled={props.busy || !apiKey.trim()}>
+          {props.busy ? <Loader2 className="size-4 animate-spin" /> : null}
+          Add MiniMax
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/app/src/react-app/domains/settings/minimax-provider.ts
+++ b/apps/app/src/react-app/domains/settings/minimax-provider.ts
@@ -1,0 +1,133 @@
+import type { ProviderConfig } from "@opencode-ai/sdk/v2/client";
+
+export type MiniMaxEndpointId =
+  | "global-openai"
+  | "global-anthropic"
+  | "cn-openai"
+  | "cn-anthropic";
+
+type MiniMaxModelPreset = {
+  id: string;
+  contextWindow: number;
+  pricingUsdPerMillionTokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number | null;
+  };
+  inputModalities: readonly ("text" | "image" | "video")[];
+  thinking: readonly string[];
+};
+
+type MiniMaxEndpoint = {
+  id: MiniMaxEndpointId;
+  label: string;
+  region: "global_en" | "cn_zh";
+  protocol: "openai" | "anthropic";
+  npm: string;
+  baseURL: string;
+};
+
+export const MINIMAX_PROVIDER = {
+  providerId: "minimax",
+  name: "MiniMax",
+  models: [
+    {
+      id: "MiniMax-M3",
+      contextWindow: 1_000_000,
+      pricingUsdPerMillionTokens: {
+        input: 0.6,
+        output: 2.4,
+        cacheRead: 0.12,
+        cacheWrite: null,
+      },
+      inputModalities: ["text", "image", "video"],
+      thinking: ["adaptive", "disabled"],
+    },
+    {
+      id: "MiniMax-M2.7",
+      contextWindow: 204_800,
+      pricingUsdPerMillionTokens: {
+        input: 0.3,
+        output: 1.2,
+        cacheRead: 0.06,
+        cacheWrite: 0.375,
+      },
+      inputModalities: ["text"],
+      thinking: ["always_on"],
+    },
+  ] satisfies readonly MiniMaxModelPreset[],
+} as const;
+
+export const MINIMAX_ENDPOINTS: readonly MiniMaxEndpoint[] = [
+  {
+    id: "global-openai",
+    label: "Global - OpenAI-compatible",
+    region: "global_en",
+    protocol: "openai",
+    npm: "@ai-sdk/openai-compatible",
+    baseURL: "https://api.minimax.io/v1",
+  },
+  {
+    id: "global-anthropic",
+    label: "Global - Anthropic",
+    region: "global_en",
+    protocol: "anthropic",
+    npm: "@ai-sdk/anthropic",
+    baseURL: "https://api.minimax.io/anthropic",
+  },
+  {
+    id: "cn-openai",
+    label: "China - OpenAI-compatible",
+    region: "cn_zh",
+    protocol: "openai",
+    npm: "@ai-sdk/openai-compatible",
+    baseURL: "https://api.minimaxi.com/v1",
+  },
+  {
+    id: "cn-anthropic",
+    label: "China - Anthropic",
+    region: "cn_zh",
+    protocol: "anthropic",
+    npm: "@ai-sdk/anthropic",
+    baseURL: "https://api.minimaxi.com/anthropic",
+  },
+];
+
+export function getMiniMaxEndpoint(endpointId: MiniMaxEndpointId): MiniMaxEndpoint {
+  const endpoint = MINIMAX_ENDPOINTS.find((candidate) => candidate.id === endpointId);
+  if (!endpoint) throw new Error(`Unknown MiniMax endpoint: ${endpointId}`);
+  return endpoint;
+}
+
+export function buildMiniMaxProviderConfig(endpointId: MiniMaxEndpointId): ProviderConfig {
+  const endpoint = getMiniMaxEndpoint(endpointId);
+  const models = Object.fromEntries(
+    MINIMAX_PROVIDER.models.map((model) => {
+      const modelConfig: NonNullable<ProviderConfig["models"]>[string] = {
+        id: model.id,
+        name: model.id,
+        attachment: model.inputModalities.some((modality) => modality !== "text"),
+        reasoning: model.thinking.length > 0,
+        cost: {
+          input: model.pricingUsdPerMillionTokens.input,
+          output: model.pricingUsdPerMillionTokens.output,
+          cache_read: model.pricingUsdPerMillionTokens.cacheRead,
+          ...(model.pricingUsdPerMillionTokens.cacheWrite === null
+            ? {}
+            : { cache_write: model.pricingUsdPerMillionTokens.cacheWrite }),
+        },
+        modalities: { input: [...model.inputModalities] },
+      };
+      return [model.id, modelConfig];
+    }),
+  );
+
+  return {
+    id: MINIMAX_PROVIDER.providerId,
+    name: MINIMAX_PROVIDER.name,
+    npm: endpoint.npm,
+    api: endpoint.baseURL,
+    models,
+  };
+}

--- a/apps/app/src/react-app/domains/settings/openai-image-extension.ts
+++ b/apps/app/src/react-app/domains/settings/openai-image-extension.ts
@@ -1,9 +1,17 @@
+import type { ProviderConfig } from "@opencode-ai/sdk/v2/client";
+
+export type LocalProviderModelConfig = NonNullable<ProviderConfig["models"]>[string];
+
 export type LocalProviderInstallInput = {
   providerId: string;
   name: string;
-  baseURL: string;
+  baseURL?: string;
+  api?: string;
+  npm?: string;
+  apiKey?: string;
   modelId: string;
   modelName: string;
+  models?: Record<string, LocalProviderModelConfig>;
   setDefault: boolean;
 };
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -55,6 +55,7 @@ import { AiSettingsView } from "@/react-app/domains/settings/pages/ai-view";
 // Side-effect imports: register extension config components into the registry.
 import "@/react-app/domains/settings/openai-image-gen-config";
 import "@/react-app/domains/settings/ollama-config";
+import "@/react-app/domains/settings/minimax-config";
 import "@/react-app/domains/settings/computer-use-config";
 import "@/react-app/domains/settings/browser-extension-config";
 import "@/react-app/domains/settings/ipollowork-voice-config";
@@ -944,12 +945,21 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     const client = selectedWorkspaceEndpoint?.client ?? ipolloworkClient;
     const workspaceId = runtimeWorkspaceId?.trim() ?? "";
     const modelId = input.modelId.trim();
+    const api = input.api?.trim() ?? "";
+    const baseURL = input.baseURL?.trim() ?? "";
+    const models = input.models ?? {
+      [modelId]: { name: input.modelName.trim() || modelId },
+    };
     if (!client || !workspaceId) {
       setLocalProviderError("iPolloWork server is not connected for this workspace.");
       return;
     }
-    if (!modelId) {
+    if (!modelId || Object.keys(models).length === 0) {
       setLocalProviderError("Model ID is required.");
+      return;
+    }
+    if (!api && !baseURL) {
+      setLocalProviderError("A provider API URL is required.");
       return;
     }
 
@@ -961,14 +971,23 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         opencode: {
           provider: {
             [input.providerId]: {
-              npm: "@ai-sdk/openai-compatible",
+              npm: input.npm ?? "@ai-sdk/openai-compatible",
               name: input.name,
-              options: { baseURL: input.baseURL },
-              models: { [modelId]: { name: input.modelName.trim() || modelId } },
+              ...(api ? { api } : { options: { baseURL } }),
+              models,
             },
           },
         },
       });
+      if (input.apiKey?.trim()) {
+        if (!opencodeClient) {
+          throw new Error("OpenCode is not connected for this workspace.");
+        }
+        await opencodeClient.auth.set({
+          providerID: input.providerId,
+          auth: { type: "api", key: input.apiKey.trim() },
+        });
+      }
       if (input.setDefault) {
         local.setPrefs((previous) => ({
           ...previous,
@@ -988,13 +1007,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       } catch {
         // ignore browser event dispatch failures
       }
-      setLocalProviderStatus(`Added ${input.name} with ${modelId}.`);
+      setLocalProviderStatus(`Added ${input.name} with ${Object.keys(models).length} model${Object.keys(models).length === 1 ? "" : "s"}.`);
     } catch (error) {
       setLocalProviderError(describeRouteError(error));
     } finally {
       setLocalProviderBusy(false);
     }
-  }, [local, ipolloworkClient, reloadCoordinator, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
+  }, [local, ipolloworkClient, opencodeClient, reloadCoordinator, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
 
   useEffect(() => {
     local.setUi((previous) => ({ ...previous, view: "settings", tab: route.tab }));

--- a/apps/app/tests/minimax-provider.test.ts
+++ b/apps/app/tests/minimax-provider.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import { isRecommendedModel } from "../src/app/defaults/models";
+import { BUILT_IN_IPOLLOWORK_EXTENSION_MANIFESTS } from "../src/app/extensions";
+import {
+  buildMiniMaxProviderConfig,
+  MINIMAX_ENDPOINTS,
+  MINIMAX_PROVIDER,
+} from "../src/react-app/domains/settings/minimax-provider";
+
+describe("MiniMax provider preset", () => {
+  test("keeps the supplied regional OpenAI and Anthropic endpoints", () => {
+    expect(
+      MINIMAX_ENDPOINTS.map(({ id, region, protocol, baseURL }) => ({
+        id,
+        region,
+        protocol,
+        baseURL,
+      })),
+    ).toEqual([
+      {
+        id: "global-openai",
+        region: "global_en",
+        protocol: "openai",
+        baseURL: "https://api.minimax.io/v1",
+      },
+      {
+        id: "global-anthropic",
+        region: "global_en",
+        protocol: "anthropic",
+        baseURL: "https://api.minimax.io/anthropic",
+      },
+      {
+        id: "cn-openai",
+        region: "cn_zh",
+        protocol: "openai",
+        baseURL: "https://api.minimaxi.com/v1",
+      },
+      {
+        id: "cn-anthropic",
+        region: "cn_zh",
+        protocol: "anthropic",
+        baseURL: "https://api.minimaxi.com/anthropic",
+      },
+    ]);
+  });
+
+  test("keeps both current model fact sets without inventing an output limit", () => {
+    expect(MINIMAX_PROVIDER.models).toEqual([
+      {
+        id: "MiniMax-M3",
+        contextWindow: 1_000_000,
+        pricingUsdPerMillionTokens: {
+          input: 0.6,
+          output: 2.4,
+          cacheRead: 0.12,
+          cacheWrite: null,
+        },
+        inputModalities: ["text", "image", "video"],
+        thinking: ["adaptive", "disabled"],
+      },
+      {
+        id: "MiniMax-M2.7",
+        contextWindow: 204_800,
+        pricingUsdPerMillionTokens: {
+          input: 0.3,
+          output: 1.2,
+          cacheRead: 0.06,
+          cacheWrite: 0.375,
+        },
+        inputModalities: ["text"],
+        thinking: ["always_on"],
+      },
+    ]);
+
+    const models = buildMiniMaxProviderConfig("global-openai").models;
+    expect(models?.["MiniMax-M3"]).toMatchObject({
+      attachment: true,
+      reasoning: true,
+      cost: { input: 0.6, output: 2.4, cache_read: 0.12 },
+      modalities: { input: ["text", "image", "video"] },
+    });
+    expect(models?.["MiniMax-M3"]?.cost).not.toHaveProperty("cache_write");
+    expect(models?.["MiniMax-M3"]).not.toHaveProperty("limit");
+    expect(models?.["MiniMax-M2.7"]).toMatchObject({
+      attachment: false,
+      reasoning: true,
+      cost: {
+        input: 0.3,
+        output: 1.2,
+        cache_read: 0.06,
+        cache_write: 0.375,
+      },
+      modalities: { input: ["text"] },
+    });
+  });
+
+  test("builds the selected OpenCode provider package and API endpoint", () => {
+    expect(buildMiniMaxProviderConfig("global-openai")).toMatchObject({
+      id: "minimax",
+      name: "MiniMax",
+      npm: "@ai-sdk/openai-compatible",
+      api: "https://api.minimax.io/v1",
+    });
+    expect(buildMiniMaxProviderConfig("cn-anthropic")).toMatchObject({
+      id: "minimax",
+      name: "MiniMax",
+      npm: "@ai-sdk/anthropic",
+      api: "https://api.minimaxi.com/anthropic",
+    });
+  });
+
+  test("registers the executable extension and recommends both models", () => {
+    const extension = BUILT_IN_IPOLLOWORK_EXTENSION_MANIFESTS.find(
+      (manifest) => manifest.id === "minimax",
+    );
+    expect(extension?.resources).toContainEqual({
+      type: "provider",
+      id: "minimax",
+      label: "MiniMax",
+      providerId: "minimax",
+      required: true,
+    });
+    expect(extension?.contributions).toContainEqual({
+      type: "settings-panel",
+      ref: "ipollowork.minimax.settings",
+      location: "settings-detail",
+    });
+    expect(isRecommendedModel("MiniMax-M3")).toBe(true);
+    expect(isRecommendedModel("MiniMax-M2.7")).toBe(true);
+  });
+});


### PR DESCRIPTION
Reason: Add a MiniMax provider preset with current text models, regional endpoints, and model capability metadata.

Changes:
- Added MiniMax-M3 and MiniMax-M2.7 to the provider preset with supplied pricing, modality, attachment, reasoning, and context metadata.
- Added Global and China OpenAI-compatible and Anthropic endpoint choices.
- Added an executable settings panel that stores the API key, installs both models, and selects the default model.
- Added MiniMax provider labels, recommendations, and focused coverage.

Checks:
- `pnpm --filter @ipollowork/types build`
- `pnpm --filter @ipollowork/app typecheck`
- `pnpm --filter @ipollowork/app exec bun test --isolate tests/minimax-provider.test.ts`
- `pnpm --filter @ipollowork/app build`
- `git diff --check`
- Supplied secret scan regex
