### PR TITLE
fix: resolve template types in clean Bun tests

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -43,6 +43,7 @@
     "./templates": {
       "types": "./src/templates.ts",
       "development": "./src/templates.ts",
+      "bun": "./src/templates.ts",
       "default": "./dist/templates.js"
     }
   },


### PR DESCRIPTION
## Summary

- add the missing Bun export condition for `@ipollowork/types/templates`
- make clean-checkout Bun tests resolve the TypeScript source, matching the existing `./hyperframes` export strategy
- follow up #218 without changing package contents, manifests, import compatibility, or runtime behavior

## Root cause

The App started using runtime symbols from `@ipollowork/types/templates`. Local worktrees with `packages/types/dist/templates.js` already built passed, while clean GitHub Actions checkouts resolved the default export to a file that did not exist yet.

## Validation

- clean-worktree reproduction before patch: focused App test failed with `Cannot find module '@ipollowork/types/templates'`
- same test after patch, with `dist/templates.js` absent: 9 passed, 0 failed
- full App test command after patch: 586 passed; the 16 module-resolution errors are gone; 9 existing source-assertion failures plus the existing Bun `import.meta.glob` environment error remain and are also present on PRs #215 and #217
- `pnpm --filter @ipollowork/app typecheck` — passed
- `pnpm --filter ipollowork-server build` — passed
- focused Server template/API suite — 41 passed, 0 failed, 5,029 assertions
- maintainability audit — 0 errors, 0 warnings
- `git diff --check` — passed

This is package-export metadata only, so no user-visible Fraimz flow applies.