### PR TITLE
test: strengthen creative agent package lifecycle

### DIFF
--- a/apps/server/src/plugin-package-lifecycle.test.ts
+++ b/apps/server/src/plugin-package-lifecycle.test.ts
@@ -623,6 +623,22 @@ describe("plugin package lifecycle", () => {
         expect(await readFile(item.skillPath, "utf8")).toContain(item.heading);
       }
 
+      const disabled = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/design-agent/resources/ipollowork-design-studio`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ enabled: false }),
+      });
+      expect(disabled.status).toBe(200);
+      await expectMissing(packages[0].skillPath);
+
+      const enabled = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/design-agent/resources/ipollowork-design-studio`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(enabled.status).toBe(200);
+      expect(await readFile(packages[0].skillPath, "utf8")).toContain(packages[0].heading);
+
       for (const item of packages) {
         const removal = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/${item.pluginId}`, {
           method: "DELETE",

--- a/apps/server/src/plugin-package-manifest.test.ts
+++ b/apps/server/src/plugin-package-manifest.test.ts
@@ -138,6 +138,8 @@ describe("plugin package manifest", () => {
     expect(video.manifest.relatedSkills).toContain("hyperframes-cli");
     expect(video.manifest.relatedSkills).toContain("media-use");
     expect(video.manifest.resources.map((resource) => resource.id)).not.toContain("hyperframes-cli");
+    expect(design.manifest.contributions).toBeUndefined();
+    expect(video.manifest.contributions).toBeUndefined();
     expect(design.manifest.source).toMatchObject({ origin: "builtin", trusted: true });
     expect(video.manifest.source).toMatchObject({ origin: "builtin", trusted: true });
   });


### PR DESCRIPTION
## What changed

- verify the Design Studio Skill can be disabled and enabled independently through the package resource lifecycle
- assert the official Design and Video Agent packages do not register package-owned UI contributions

## Why

The creative Agent packages already ship from the latest `main`. This adds the remaining regression coverage from the older local worktree without carrying forward its outdated package versions or catalog state.

## Validation

- `pnpm --filter ipollowork-server exec bun test src/plugin-package-lifecycle.test.ts src/plugin-package-manifest.test.ts` — 25 passed
- `pnpm --filter ipollowork-server build` — passed
- `pnpm --filter ipollowork-server test` — 401 passed, 6 skipped, 0 failed
- `pnpm --filter ipollowork-server typecheck` — passed
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed
- `git diff --check` — passed
