### PR TITLE
Fix sidebar panel white screen

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1235,12 +1235,15 @@ export function SessionPage(props: SessionPageProps) {
     });
   }, [rightPanelExpanded, videoStudioExpanded]);
   useEffect(() => {
-    const panel = browserPanelRef.current;
-    if (!panel) return;
+    if (!effectiveSidePanelView) return;
 
-    window.requestAnimationFrame(() => {
+    const frame = window.requestAnimationFrame(() => {
+      const panel = browserPanelRef.current;
+      if (!panel) return;
       panel.resize(`${rightPanelRestoreWidthRef.current}px`);
     });
+
+    return () => window.cancelAnimationFrame(frame);
   }, [browserPanelRef, effectiveSidePanelView, rightPanelExpanded]);
   const browserUrlForTarget = useCallback((target: OpenTarget) => {
     if (/^wss?:\/\//i.test(target.value)) return target.value.replace(/^ws:/i, "http:").replace(/^wss:/i, "https:");
@@ -1410,6 +1413,7 @@ export function SessionPage(props: SessionPageProps) {
     const restoredPanel = autoCollapsedSidePanelRef.current;
     if (
       restoredPanel &&
+      !userOpenedSidebarWhileNarrowRef.current &&
       !sidePanelOpen &&
       expandedRightPanelWorkspaceWidth >= AUTO_RESTORE_WORKSPACE_WIDTH
     ) {

--- a/apps/app/tests/video-hyperframes-panel.test.ts
+++ b/apps/app/tests/video-hyperframes-panel.test.ts
@@ -251,11 +251,29 @@ describe("HyperFrames Video Studio", () => {
     const sessionPageSource = readFileSync(
       new URL("../src/react-app/domains/session/chat/session-page.tsx", import.meta.url),
       "utf8",
-    );
+    ).replaceAll("\r\n", "\n");
 
     expect(sessionPageSource).toContain("const openLeftSidebar = useCallback(() => {");
     expect(sessionPageSource).toContain("closeRightPane({ preserveAutoCollapse: true });");
+    expect(sessionPageSource).toContain("restoredPanel &&\n      !userOpenedSidebarWhileNarrowRef.current &&\n      !sidePanelOpen");
     expect(sessionPageSource).toContain("onClick={openLeftSidebar}");
+  });
+
+  test("cancels a deferred right-panel resize before the panel unmounts", () => {
+    const sessionPageSource = readFileSync(
+      new URL("../src/react-app/domains/session/chat/session-page.tsx", import.meta.url),
+      "utf8",
+    );
+
+    const effectStart = sessionPageSource.indexOf("if (!effectiveSidePanelView) return;");
+    const effectEnd = sessionPageSource.indexOf("const browserUrlForTarget", effectStart);
+    const resizeEffect = sessionPageSource.slice(effectStart, effectEnd);
+
+    expect(effectStart).toBeGreaterThan(-1);
+    expect(effectEnd).toBeGreaterThan(effectStart);
+    expect(resizeEffect).toContain("const frame = window.requestAnimationFrame");
+    expect(resizeEffect).toContain("const panel = browserPanelRef.current;");
+    expect(resizeEffect).toContain("return () => window.cancelAnimationFrame(frame);");
   });
 
   test("lets the latest right-panel action take priority in a narrow window", () => {


### PR DESCRIPTION
## What changed

- prevent deferred right-panel resize work from running after the panel starts unmounting
- re-read the current panel handle inside the animation frame and cancel pending frames during cleanup
- keep a user-opened left sidebar prioritized so the automatically collapsed right panel cannot immediately restore and remount in a loop
- extend the existing Video Studio panel regression tests for both lifecycle guards

## Root cause

Opening the left sidebar while a widened Video Studio panel was open triggered two overlapping layout transitions:

1. a queued right-panel `resize()` could run after the resizable group had unregistered
2. the right panel could oscillate between automatic collapse and automatic restore while the left sidebar was being opened

That repeatedly registered the resizable separator, hit React's maximum update depth, unmounted the React root, and left the Electron window white.

## User impact

The existing Video Studio, Design, templates, and project data paths are unchanged. In constrained or manually resized layouts, opening the left sidebar now closes the right panel once and leaves the application usable.

## Validation

- `pnpm exec bun test ./tests/video-hyperframes-panel.test.ts --test-name-pattern 'opens the left sidebar|cancels a deferred'` — 2 passed
- `pnpm --filter @ipollowork/app typecheck` — passed
- `git diff --check` — passed
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed with existing cross-domain import warnings only
- Electron runtime: widened the left workspace area, collapsed the sidebar, opened Video Studio, then reopened the sidebar; after 5 seconds the left sidebar was visible, the right panel was closed, the React root remained mounted, and CDP captured zero errors

The full `video-hyperframes-panel.test.ts` file currently has one unrelated existing assertion failure for the sidebar titlebar class; the two focused regressions added for this fix pass.