### PR TITLE
chore(release): prepare iPolloWork v0.19.0

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/app",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/desktop",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "iPolloWork desktop shell",
   "author": {
     "name": "iPolloWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-orchestrator",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "iPolloWork host orchestrator for opencode + iPolloWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.18.3",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "ipollowork-server": "0.18.0",
+    "ipollowork-server": "0.19.0",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-server",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Filesystem-backed API for iPolloWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       ipollowork-server:
-        specifier: 0.18.0
+        specifier: 0.19.0
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
## Summary

- bump iPolloWork desktop, server, and orchestrator packages from 0.18.0 to 0.19.0
- keep the orchestrator's exact `ipollowork-server` dependency and lockfile aligned
- prepare the current `main` feature set for the v0.19.0 desktop release

## Why 0.19.0

Since v0.18.0, iPolloWork has added native template authoring, the canonical `.ipwp` package format with `.ipwt` compatibility, an expanded bundled extension catalog, Design and Video Agent packages, MiniMax provider support, and several desktop stability and usability improvements. This is a backward-compatible feature release rather than a patch-only release.

## Validation

- `pnpm release:review --strict` — passed
- `pnpm check` — passed; 90 desktop tests passed, 1 skipped
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed with 0 errors and 0 warnings
- `git diff --check` — passed

No application behavior is changed by this PR beyond the synchronized release version metadata.
