### PR TITLE
Fix Moonshot Kimi K3 temperature

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "dev": "cross-env IPOLLOWORK_DEV_MODE=1 bun src/cli.ts",
     "test": "bun test src",
     "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
-    "build": "pnpm --filter @ipollowork/types build && tsc -p tsconfig.json && node script/copy-bundled-templates.mjs && bun build src/templates.ts --outfile dist/templates.js --target node --format esm --external zod && bun build src/opencode-plugins/ipollowork-extensions-preview.ts src/opencode-plugins/ipollowork-capabilities-knowledge.ts src/opencode-plugins/ipollowork-anthropic-adaptive-thinking.ts src/opencode-plugins/ipollowork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
+    "build": "pnpm --filter @ipollowork/types build && tsc -p tsconfig.json && node script/copy-bundled-templates.mjs && bun build src/templates.ts --outfile dist/templates.js --target node --format esm --external zod && bun build src/opencode-plugins/ipollowork-extensions-preview.ts src/opencode-plugins/ipollowork-capabilities-knowledge.ts src/opencode-plugins/ipollowork-anthropic-adaptive-thinking.ts src/opencode-plugins/ipollowork-anthropic-tool-schema.ts src/opencode-plugins/ipollowork-moonshot-temperature.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "pnpm --filter @ipollowork/types build && node script/copy-bundled-templates.mjs && bun build --compile src/cli.ts --outfile dist/bin/ipollowork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
     "start": "bun dist/cli.js",

--- a/apps/server/src/ipollowork-extensions-plugin-path.ts
+++ b/apps/server/src/ipollowork-extensions-plugin-path.ts
@@ -29,3 +29,4 @@ export const ipolloworkExtensionsPreviewPluginPath = () => ipolloworkPluginPath(
 export const ipolloworkCapabilitiesKnowledgePluginPath = () => ipolloworkPluginPath("ipollowork-capabilities-knowledge");
 export const ipolloworkAnthropicAdaptiveThinkingPluginPath = () => ipolloworkPluginPath("ipollowork-anthropic-adaptive-thinking");
 export const ipolloworkAnthropicToolSchemaPluginPath = () => ipolloworkPluginPath("ipollowork-anthropic-tool-schema");
+export const ipolloworkMoonshotTemperaturePluginPath = () => ipolloworkPluginPath("ipollowork-moonshot-temperature");

--- a/apps/server/src/ipollowork-runtime-config.ts
+++ b/apps/server/src/ipollowork-runtime-config.ts
@@ -20,6 +20,7 @@ import {
   ipolloworkCapabilitiesKnowledgePluginPath,
   ipolloworkAnthropicAdaptiveThinkingPluginPath,
   ipolloworkAnthropicToolSchemaPluginPath,
+  ipolloworkMoonshotTemperaturePluginPath,
 } from "./ipollowork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
 import {
@@ -106,6 +107,7 @@ export async function buildiPolloWorkRuntimeConfigObject(
       ipolloworkCapabilitiesKnowledgePluginPath(),
       ipolloworkAnthropicAdaptiveThinkingPluginPath(),
       ipolloworkAnthropicToolSchemaPluginPath(),
+      ipolloworkMoonshotTemperaturePluginPath(),
       ...runtimePluginList(runtimeConfig),
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),

--- a/apps/server/src/opencode-plugins/ipollowork-moonshot-temperature.test.ts
+++ b/apps/server/src/opencode-plugins/ipollowork-moonshot-temperature.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { iPolloWorkMoonshotTemperature } from "./ipollowork-moonshot-temperature.js";
+
+async function runHook(providerID: string, apiId: string, temperature: number) {
+  const hooks = await iPolloWorkMoonshotTemperature();
+  const output = { temperature };
+  await hooks["chat.params"]({ model: { id: apiId, providerID, api: { id: apiId } } }, output);
+  return output;
+}
+
+describe("iPolloWorkMoonshotTemperature chat.params", () => {
+  test("sets Kimi K3 temperature to 1 for both Moonshot endpoints", async () => {
+    expect(await runHook("moonshotai", "kimi-k3", 0.2)).toEqual({ temperature: 1 });
+    expect(await runHook("moonshotai-cn", "kimi-k3", 0.2)).toEqual({ temperature: 1 });
+  });
+
+  test("leaves other Moonshot models untouched", async () => {
+    expect(await runHook("moonshotai-cn", "kimi-k2.6", 0.2)).toEqual({ temperature: 0.2 });
+  });
+
+  test("leaves other providers untouched even when they use the same model id", async () => {
+    expect(await runHook("custom-gateway", "kimi-k3", 0.2)).toEqual({ temperature: 0.2 });
+  });
+
+  test("module exposes only the plugin factory", async () => {
+    const mod = await import("./ipollowork-moonshot-temperature.js");
+    expect(Object.keys(mod)).toEqual(["iPolloWorkMoonshotTemperature"]);
+  });
+});

--- a/apps/server/src/opencode-plugins/ipollowork-moonshot-temperature.ts
+++ b/apps/server/src/opencode-plugins/ipollowork-moonshot-temperature.ts
@@ -1,0 +1,23 @@
+/**
+ * Moonshot's Kimi K3 endpoint only accepts temperature 1. iPolloWork keeps a
+ * lower default for its agent, so normalize this single provider/model pair
+ * immediately before OpenCode sends the request.
+ */
+
+const MOONSHOT_PROVIDER_IDS = new Set(["moonshotai", "moonshotai-cn"]);
+
+function requiresFixedTemperature(model: { id: string; providerID?: string; api?: { id?: string } }): boolean {
+  if (!model.providerID || !MOONSHOT_PROVIDER_IDS.has(model.providerID)) return false;
+  return (model.api?.id ?? model.id).toLowerCase() === "kimi-k3";
+}
+
+// Single export: the OpenCode plugin loader treats every export of a plugin
+// module as a plugin factory, so helpers must stay module-private.
+export const iPolloWorkMoonshotTemperature = async () => ({
+  "chat.params": async (
+    input: { model: { id: string; providerID?: string; api?: { id?: string } } },
+    output: { temperature?: number },
+  ) => {
+    if (requiresFixedTemperature(input.model)) output.temperature = 1;
+  },
+});


### PR DESCRIPTION
## What changed

- add a narrowly scoped OpenCode `chat.params` compatibility hook for Moonshot Kimi K3
- force `temperature: 1` only for `moonshotai/kimi-k3` and `moonshotai-cn/kimi-k3`
- preserve iPolloWork's existing `temperature: 0.2` behavior for every other provider and model
- include the hook in server builds and packaged Electron resources
- add focused coverage for both Moonshot endpoints and non-target models/providers

## Root cause

The iPolloWork default agent sets `temperature: 0.2`. Moonshot's Kimi K3 endpoint rejects every value except `1`, so authenticated requests failed with HTTP 400: `invalid temperature: only 1 is allowed for this model`.

## Impact

Users with valid Moonshot API credentials can use Kimi K3 without changing the behavior of existing models.

## Validation

- `bun test src` — 407 passed, 2 skipped, 0 failed
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`
- `node ../../.codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`
- real development-runtime request to `moonshotai-cn/kimi-k3` returned exactly `OK`; the disposable verification session was removed afterward

The repository does not currently include the referenced Fraimz skill, so no `fraimz.html` artifact was generated.