### PR TITLE
feat(studio): improve context-aware property inspection

### DIFF
--- a/vendor/hyperframes/packages/studio/src/components/editor/PropertyPanel.tsx
+++ b/vendor/hyperframes/packages/studio/src/components/editor/PropertyPanel.tsx
@@ -30,7 +30,7 @@ import {
   STUDIO_GSAP_PANEL_ENABLED,
   STUDIO_KEYFRAMES_ENABLED,
 } from "./manualEditingAvailability";
-import { PropertyPanelFlat } from "./PropertyPanelFlat";
+import { PropertyPanelFlat, resolveInspectorElementKind } from "./PropertyPanelFlat";
 import { createGsapLivePreview } from "./gsapLivePreview";
 import { usePlayerStore, liveTime } from "../../player";
 import { TimingSection } from "./propertyPanelTimingSection";
@@ -276,7 +276,7 @@ export const PropertyPanel = memo(function PropertyPanel(props: PropertyPanelPro
     return (
       <PropertyPanelFlat
         {...props}
-        key={selectionIdentityKey(element)}
+        key={resolveInspectorElementKind(element.tagName, sections.text)}
         element={element}
         styles={styles}
         sections={sections}

--- a/vendor/hyperframes/packages/studio/src/components/editor/PropertyPanelFlat.tsx
+++ b/vendor/hyperframes/packages/studio/src/components/editor/PropertyPanelFlat.tsx
@@ -34,24 +34,117 @@ type EditingSections = ReturnType<typeof resolveEditingSections>;
 type FlatGroupDescriptor = {
   id: string;
   title: string;
-  summary?: string;
+  summary: string;
   accessory?: ReactNode;
   content: ReactNode;
 };
 
-// Type-only fallback for the Motion effect-card callbacks. Used solely to
-// satisfy FlatMotionSection's required-callback shape when the effect list is
-// gated off (showEffects === false, so none of these are ever invoked). Keeps
-// the gated-off path free of `!` non-null assertions — the real, narrowed
-// handlers flow through only when the double-gate below passes.
-const EMPTY_GSAP_EFFECT_HANDLERS = {
-  onAddAnimation: () => {},
-  onUpdateProperty: () => {},
-  onUpdateMeta: () => {},
-  onDeleteAnimation: () => {},
-  onAddProperty: () => {},
-  onRemoveProperty: () => {},
+export type InspectorElementKind = "text" | "image" | "video" | "audio" | "other";
+
+const INSPECTOR_GROUP_PRIORITIES: Record<InspectorElementKind, readonly string[]> = {
+  text: [
+    "text",
+    "layout",
+    "fill",
+    "appearance",
+    "stroke",
+    "mask",
+    "timing",
+    "transform-3d",
+    "grade",
+    "media",
+  ],
+  image: [
+    "layout",
+    "mask",
+    "appearance",
+    "media",
+    "grade",
+    "fill",
+    "stroke",
+    "timing",
+    "transform-3d",
+    "text",
+  ],
+  video: [
+    "media",
+    "mask",
+    "layout",
+    "appearance",
+    "grade",
+    "timing",
+    "fill",
+    "stroke",
+    "transform-3d",
+    "text",
+  ],
+  audio: ["media", "timing"],
+  other: [
+    "layout",
+    "fill",
+    "appearance",
+    "stroke",
+    "mask",
+    "timing",
+    "transform-3d",
+    "text",
+    "media",
+    "grade",
+  ],
 };
+
+export function resolveInspectorElementKind(
+  tagName: string,
+  isTextEditable: boolean,
+): InspectorElementKind {
+  const normalizedTag = tagName.toLowerCase();
+  if (normalizedTag === "img") return "image";
+  if (normalizedTag === "video") return "video";
+  if (normalizedTag === "audio") return "audio";
+  return isTextEditable ? "text" : "other";
+}
+
+export function resolveInspectorGroupOrder({
+  elementKind,
+  hasAnimationParameters,
+  availableGroupIds,
+}: {
+  elementKind: InspectorElementKind;
+  hasAnimationParameters: boolean;
+  availableGroupIds: readonly string[];
+}): string[] {
+  const available = new Set(availableGroupIds);
+  const ordered: string[] = [];
+  const priorities = hasAnimationParameters
+    ? ["animation", ...INSPECTOR_GROUP_PRIORITIES[elementKind]]
+    : INSPECTOR_GROUP_PRIORITIES[elementKind];
+
+  for (const groupId of priorities) {
+    if (available.has(groupId) && !ordered.includes(groupId)) ordered.push(groupId);
+  }
+  for (const groupId of availableGroupIds) {
+    if (!ordered.includes(groupId)) ordered.push(groupId);
+  }
+  return ordered;
+}
+
+export function resolveOpenInspectorGroup({
+  currentGroupId,
+  orderedGroupIds,
+  hasManualSelection,
+}: {
+  currentGroupId: string;
+  orderedGroupIds: readonly string[];
+  hasManualSelection: boolean;
+}): string {
+  if (
+    hasManualSelection &&
+    (currentGroupId === "" || orderedGroupIds.includes(currentGroupId))
+  ) {
+    return currentGroupId;
+  }
+  return orderedGroupIds[0] ?? "";
+}
 
 /**
  * The flat "Ledger" inspector shell (design_handoff_studio_inspector).
@@ -214,15 +307,82 @@ export function PropertyPanelFlat({
     showEditableSections: boolean;
     currentTime: number;
   }) {
-  // Lazy initializer: pick whichever group actually renders for this element
-  // (Text if text-editable, else Style if style-editable, else none open) so a
-  // style-only element doesn't start with everything collapsed. Only runs on
-  // mount — PropertyPanel.tsx keys <PropertyPanelFlat> by element identity so
-  // switching the selection re-mounts this component and re-derives the
-  // default instead of preserving stale state across unrelated elements.
+  const isTextEditable = isTextEditableSelection(element);
+  const elementKind = resolveInspectorElementKind(element.tagName, isTextEditable);
+  const headerElementKind =
+    elementKind === "text"
+      ? "text"
+      : elementKind === "image" || elementKind === "video" || elementKind === "audio"
+        ? "media"
+        : "other";
+  const hasAnimationParameters =
+    gsapAnimations.length > 0 &&
+    STUDIO_GSAP_PANEL_ENABLED &&
+    Boolean(
+      onUpdateGsapProperty &&
+        onUpdateGsapMeta &&
+        onDeleteGsapAnimation &&
+        onAddGsapProperty &&
+        onAddGsapAnimation,
+    );
+  const showMotionTiming = Boolean(sections.timing);
+  const gsapEffectHandlers =
+    hasAnimationParameters &&
+    onUpdateGsapProperty &&
+    onUpdateGsapMeta &&
+    onDeleteGsapAnimation &&
+    onAddGsapProperty &&
+    onAddGsapAnimation
+      ? {
+          onAddAnimation: onAddGsapAnimation,
+          onUpdateProperty: onUpdateGsapProperty,
+          onUpdateMeta: onUpdateGsapMeta,
+          onDeleteAnimation: onDeleteGsapAnimation,
+          onAddProperty: onAddGsapProperty,
+          onRemoveProperty: onRemoveGsapProperty ?? (() => {}),
+          onUpdateFromProperty: onUpdateGsapFromProperty,
+          onAddFromProperty: onAddGsapFromProperty,
+          onRemoveFromProperty: onRemoveGsapFromProperty,
+          onSetArcPath,
+          onUpdateArcSegment,
+          onUnroll,
+          onUpdateKeyframeEase,
+          onSetAllKeyframeEases,
+        }
+      : null;
+  const showMotionEffects = gsapEffectHandlers !== null;
+  const availableGroupIds = [
+    ...(showMotionTiming ? ["timing"] : []),
+    ...(isTextEditable ? ["text"] : []),
+    ...(showEditableSections ? ["fill", "stroke", "appearance", "mask"] : []),
+    ...(sections.layout ? ["layout", "transform-3d"] : []),
+    ...(showMotionEffects ? ["animation"] : []),
+    ...(sections.colorGrading ? ["grade"] : []),
+    ...(sections.media ? ["media"] : []),
+  ];
+  const orderedGroupIds = resolveInspectorGroupOrder({
+    elementKind,
+    hasAnimationParameters,
+    availableGroupIds,
+  });
+  const orderedGroupKey = orderedGroupIds.join("|");
   const [openGroupId, setOpenGroupId] = useState<string>(() =>
-    sections.timing ? "timing" : sections.layout ? "layout" : showEditableSections ? "fill" : "",
+    resolveOpenInspectorGroup({
+      currentGroupId: "",
+      orderedGroupIds,
+      hasManualSelection: false,
+    }),
   );
+  const hasManualGroupSelectionRef = useRef(false);
+  useEffect(() => {
+    setOpenGroupId((currentGroupId) =>
+      resolveOpenInspectorGroup({
+        currentGroupId,
+        orderedGroupIds: orderedGroupKey ? orderedGroupKey.split("|") : [],
+        hasManualSelection: hasManualGroupSelectionRef.current,
+      }),
+    );
+  }, [orderedGroupKey]);
 
   // Tracks which group(s) are actively transitioning this toggle cycle, so
   // their header/body gets the fast entrance animation (hf-flat-group-enter)
@@ -259,9 +419,8 @@ export function PropertyPanelFlat({
     onApplyScope: onApplyColorGradingScope,
   });
 
-  const isTextEditable = isTextEditableSelection(element);
-  const elementKind = sections.media ? "media" : element.textFields.length > 0 ? "text" : "other";
   const toggleOpen = (groupId: string) => {
+    hasManualGroupSelectionRef.current = true;
     // Capture what was open BEFORE this click (this render's closure over
     // openGroupId), so the group that's about to be implicitly closed can be
     // tracked too — not just the one the user clicked.
@@ -290,42 +449,8 @@ export function PropertyPanelFlat({
   // (follow-up fix to 684ec4e87, which corrected the seek basis but left this
   // one still naive).
   const currentPct = elDuration > 0 ? ((currentTime - elStart) / elDuration) * 100 : 0;
-
-  // Motion group double-gate — reproduces the legacy PropertyPanel gate exactly:
-  //  • Timing (sections.timing) shows via resolveEditingSections, same as today.
-  //  • The effect-card list shows only when STUDIO_GSAP_PANEL_ENABLED is on AND
-  //    all five edit handlers are present (identical to PropertyPanel's legacy
-  //    `<GsapAnimationSection>` guard).
-  // Computing the narrowed handler bundle inside the `&&`-guarded ternary lets
-  // TypeScript prove each handler non-undefined without a `!` assertion; the
-  // noop bundle only fills the type when the gate is off (never invoked, since
-  // FlatMotionSection guards every call behind showEffects).
-  const showMotionTiming = Boolean(sections.timing);
-  const gsapEffectHandlers =
-    STUDIO_GSAP_PANEL_ENABLED &&
-    onUpdateGsapProperty &&
-    onUpdateGsapMeta &&
-    onDeleteGsapAnimation &&
-    onAddGsapProperty &&
-    onAddGsapAnimation
-      ? {
-          onAddAnimation: onAddGsapAnimation,
-          onUpdateProperty: onUpdateGsapProperty,
-          onUpdateMeta: onUpdateGsapMeta,
-          onDeleteAnimation: onDeleteGsapAnimation,
-          onAddProperty: onAddGsapProperty,
-          onRemoveProperty: onRemoveGsapProperty ?? (() => {}),
-          onUpdateFromProperty: onUpdateGsapFromProperty,
-          onAddFromProperty: onAddGsapFromProperty,
-          onRemoveFromProperty: onRemoveGsapFromProperty,
-          onSetArcPath,
-          onUpdateArcSegment,
-          onUnroll,
-          onUpdateKeyframeEase,
-          onSetAllKeyframeEases,
-        }
-      : null;
-  const showMotionEffects = gsapEffectHandlers !== null;
+  const parsedOpacity = Number.parseFloat(styles.opacity ?? "1");
+  const opacityPercent = Math.round((Number.isFinite(parsedOpacity) ? parsedOpacity : 1) * 100);
 
   // Ordered group descriptors — one per FlatGroup this panel renders, gated by
   // the same conditions the inline JSX used. Split below into before-open/
@@ -335,6 +460,7 @@ export function PropertyPanelFlat({
     groups.push({
       id: "timing",
       title: "Timing",
+      summary: `${elDuration.toFixed(2)}s · 2 parameters`,
       content: (
         <FlatTimingRow
           element={element}
@@ -368,6 +494,10 @@ export function PropertyPanelFlat({
     groups.push({
       id: "fill",
       title: "Fill",
+      summary:
+        styles["background-image"] && styles["background-image"] !== "none"
+          ? "Image fill"
+          : styles["background-color"] || "Color · image",
       content: (
         <FlatFillSection
           projectId={projectId}
@@ -383,6 +513,7 @@ export function PropertyPanelFlat({
       {
         id: "stroke",
         title: "Stroke",
+        summary: styles["border-width"] || "Width · color · style",
         content: (
           <FlatStrokeSection
             styles={styles}
@@ -394,6 +525,7 @@ export function PropertyPanelFlat({
       {
         id: "appearance",
         title: "Appearance",
+        summary: `${opacityPercent}% opacity`,
         content: (
           <FlatAppearanceSection
             styles={styles}
@@ -406,6 +538,10 @@ export function PropertyPanelFlat({
       {
         id: "mask",
         title: "Mask",
+        summary:
+          styles["clip-path"] && styles["clip-path"] !== "none"
+            ? "Crop applied"
+            : "Crop · overflow",
         content: (
           <FlatMaskSection
             styles={styles}
@@ -461,7 +597,7 @@ export function PropertyPanelFlat({
       ),
     });
   }
-  if (showMotionEffects) {
+  if (gsapEffectHandlers) {
     groups.push({
       id: "animation",
       title: "Animation",
@@ -476,7 +612,7 @@ export function PropertyPanelFlat({
           unsupportedTimelinePattern={gsapUnsupportedTimelinePattern}
           onSetAttribute={onSetAttribute}
           onSetAttributes={onSetAttributes}
-          {...(gsapEffectHandlers ?? EMPTY_GSAP_EFFECT_HANDLERS)}
+          {...gsapEffectHandlers}
         />
       ),
     });
@@ -485,6 +621,7 @@ export function PropertyPanelFlat({
     groups.push({
       id: "transform-3d",
       title: "3D Transform",
+      summary: "9 parameters",
       content: (
         <LayoutTransform3DBlock
           gsapRuntimeValues={gsapRuntimeValues}
@@ -528,10 +665,11 @@ export function PropertyPanelFlat({
     });
   }
   if (sections.media) {
+    const mediaParameterCount = elementKind === "video" ? 10 : elementKind === "audio" ? 5 : 3;
     groups.push({
       id: "media",
       title: "Media",
-      summary: element.tagName,
+      summary: `${element.tagName} · ${mediaParameterCount} parameters`,
       content: (
         <FlatMediaSection
           projectDir={projectDir}
@@ -553,20 +691,7 @@ export function PropertyPanelFlat({
   // a dedicated region between the two fixed header stacks. When no group is
   // open, every group is just a collapsed header — there's no scrollable
   // middle region at all, since nothing is expanded.
-  const groupOrder = [
-    "timing",
-    "layout",
-    "fill",
-    "stroke",
-    "appearance",
-    "mask",
-    "animation",
-    "transform-3d",
-    "text",
-    "grade",
-    "media",
-  ];
-  groups.sort((a, b) => groupOrder.indexOf(a.id) - groupOrder.indexOf(b.id));
+  groups.sort((a, b) => orderedGroupIds.indexOf(a.id) - orderedGroupIds.indexOf(b.id));
   return (
     <DesignPanelInputProvider ui="flat">
       <div
@@ -578,7 +703,7 @@ export function PropertyPanelFlat({
           <PropertyPanelFlatHeader
             name={element.label}
             meta={`${sourceLabel} · ${element.tagName}`}
-            elementKind={elementKind}
+            elementKind={headerElementKind}
             onAskAgent={onAskAgent}
           />
         </DesignPanelInputProvider>

--- a/vendor/hyperframes/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
+++ b/vendor/hyperframes/packages/studio/src/components/editor/propertyPanelFlatPrimitives.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { useTrackDesignInput } from "../../contexts/DesignPanelInputContext";
 import { useStudioI18n } from "../../i18n";
-import { ChevronDown, RotateCcw } from "../../icons/SystemIcons";
+import { ChevronDown, ChevronRight, RotateCcw } from "../../icons/SystemIcons";
 import { CommitField } from "./propertyPanelPrimitives";
 import {
   VALUE_TIER_LABEL_CLASS,

--- a/vendor/hyperframes/packages/studio/src/components/nle/previewEditingInteractions.test.ts
+++ b/vendor/hyperframes/packages/studio/src/components/nle/previewEditingInteractions.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parsePreviewAssetPayload } from "./usePreviewBlockDrop";
 import { buildTimelineAssetInsertHtml, getTimelineAssetKind } from "../../utils/timelineAssetDrop";
+import { resolveTimelineSelectionSeekTime } from "../../utils/studioHelpers";
 
 describe("preview editing interactions", () => {
   it("selects canvas elements on one click without opening Design automatically", () => {
@@ -97,6 +98,25 @@ describe("preview editing interactions", () => {
     expect(syncSource).toContain("const visibleIds = resolved.map");
     expect(syncSource).toContain("preserveTimelineSelection: true");
     expect(syncSource).not.toContain("if (selections.length < resolvableCount) return");
+  });
+
+  it("seeks inactive child layers to a visible inspection frame before resolving them", () => {
+    const selectionSource = readFileSync(
+      new URL("../../hooks/useDomSelection.ts", import.meta.url),
+      "utf8",
+    );
+    const childLayer = { start: 3, duration: 2 };
+
+    expect(resolveTimelineSelectionSeekTime(1, childLayer)).toBe(3);
+    expect(resolveTimelineSelectionSeekTime(4, childLayer)).toBe(4);
+    expect(resolveTimelineSelectionSeekTime(8, childLayer)).toBeCloseTo(4.999);
+    const seekIndex = selectionSource.indexOf("player.requestSeek(inspectTime)");
+    const retryIndex = selectionSource.indexOf(
+      "selection = await buildDomSelectionForTimelineElement(element)",
+      seekIndex,
+    );
+    expect(seekIndex).toBeGreaterThan(-1);
+    expect(retryIndex).toBeGreaterThan(seekIndex);
   });
 
   it("authors resizable geometry for visual assets dragged from the library", () => {

--- a/vendor/hyperframes/packages/studio/src/components/studioRightPanelLayout.test.ts
+++ b/vendor/hyperframes/packages/studio/src/components/studioRightPanelLayout.test.ts
@@ -1,6 +1,11 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { flipScaleValue } from "./editor/propertyPanelFlatLayoutSection";
+import {
+  resolveInspectorElementKind,
+  resolveInspectorGroupOrder,
+  resolveOpenInspectorGroup,
+} from "./editor/PropertyPanelFlat";
 
 describe("Studio right panel layout", () => {
   it("offers six selectable HTML illustration capabilities", () => {
@@ -14,6 +19,103 @@ describe("Studio right panel layout", () => {
     expect(illustration).toContain("onChange={(event) =>");
     expect(illustration).not.toContain("disabled");
     expect(illustration).toContain("自包含 HTML 插画");
+  });
+
+  it("orders populated inspector groups for the selected element type", () => {
+    const availableGroupIds = [
+      "timing",
+      "layout",
+      "fill",
+      "stroke",
+      "appearance",
+      "mask",
+      "animation",
+      "transform-3d",
+      "text",
+      "grade",
+      "media",
+    ];
+    expect(
+      resolveInspectorGroupOrder({
+        elementKind: "text",
+        hasAnimationParameters: true,
+        availableGroupIds,
+      }),
+    ).toEqual([
+      "animation",
+      "text",
+      "layout",
+      "fill",
+      "appearance",
+      "stroke",
+      "mask",
+      "timing",
+      "transform-3d",
+      "grade",
+      "media",
+    ]);
+    expect(
+      resolveInspectorGroupOrder({
+        elementKind: "image",
+        hasAnimationParameters: false,
+        availableGroupIds,
+      }).slice(0, 4),
+    ).toEqual(["layout", "mask", "appearance", "media"]);
+    expect(
+      resolveInspectorGroupOrder({
+        elementKind: "video",
+        hasAnimationParameters: false,
+        availableGroupIds,
+      }).slice(0, 4),
+    ).toEqual(["media", "mask", "layout", "appearance"]);
+    expect(
+      resolveInspectorGroupOrder({
+        elementKind: "audio",
+        hasAnimationParameters: false,
+        availableGroupIds: ["timing", "media"],
+      }),
+    ).toEqual(["media", "timing"]);
+  });
+
+  it("opens the best available group without overriding a manual choice", () => {
+    expect(
+      resolveOpenInspectorGroup({
+        currentGroupId: "timing",
+        orderedGroupIds: ["animation", "timing"],
+        hasManualSelection: false,
+      }),
+    ).toBe("animation");
+    expect(
+      resolveOpenInspectorGroup({
+        currentGroupId: "layout",
+        orderedGroupIds: ["animation", "layout"],
+        hasManualSelection: true,
+      }),
+    ).toBe("layout");
+    expect(
+      resolveOpenInspectorGroup({
+        currentGroupId: "",
+        orderedGroupIds: ["media"],
+        hasManualSelection: false,
+      }),
+    ).toBe("media");
+    expect(
+      resolveOpenInspectorGroup({
+        currentGroupId: "",
+        orderedGroupIds: ["media", "timing"],
+        hasManualSelection: true,
+      }),
+    ).toBe("");
+  });
+
+  it("classifies inspector element types before preserving manual state", () => {
+    const panel = readFileSync(new URL("./editor/PropertyPanel.tsx", import.meta.url), "utf8");
+    expect(resolveInspectorElementKind("p", true)).toBe("text");
+    expect(resolveInspectorElementKind("IMG", false)).toBe("image");
+    expect(resolveInspectorElementKind("video", false)).toBe("video");
+    expect(resolveInspectorElementKind("audio", false)).toBe("audio");
+    expect(resolveInspectorElementKind("div", false)).toBe("other");
+    expect(panel).toContain("key={resolveInspectorElementKind(element.tagName, sections.text)}");
   });
 
   it("matches the Figma property-inspector group and timing states", () => {

--- a/vendor/hyperframes/packages/studio/src/hooks/useDomSelection.ts
+++ b/vendor/hyperframes/packages/studio/src/hooks/useDomSelection.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
-import type { SelectElementOptions, TimelineElement } from "../player";
+import { usePlayerStore, type SelectElementOptions, type TimelineElement } from "../player";
 import {
   getAllPreviewTargetsFromPointer,
   getPreviewTargetFromPointer,
@@ -7,6 +7,7 @@ import {
 import {
   findMatchingTimelineElementId,
   findTimelineIdByAncestor,
+  resolveTimelineSelectionSeekTime,
   type RightPanelTab,
 } from "../utils/studioHelpers";
 import {
@@ -378,7 +379,15 @@ export function useDomSelection({
         return;
       }
 
-      const selection = await buildDomSelectionForTimelineElement(element);
+      let selection = await buildDomSelectionForTimelineElement(element);
+      if (!selection) {
+        const player = usePlayerStore.getState();
+        const inspectTime = resolveTimelineSelectionSeekTime(player.currentTime, element);
+        if (inspectTime != null) {
+          player.requestSeek(inspectTime);
+          selection = await buildDomSelectionForTimelineElement(element);
+        }
+      }
       // A newer selection superseded this one while we were resolving — drop the stale result.
       if (seq !== timelineSelectSeqRef.current) return;
       if (selection) applyDomSelection(selection);

--- a/vendor/hyperframes/packages/studio/src/utils/studioHelpers.ts
+++ b/vendor/hyperframes/packages/studio/src/utils/studioHelpers.ts
@@ -284,8 +284,10 @@ export function resolveTimelineSelectionSeekTime(
   const start = Math.max(0, element.start);
   const end = Math.max(start, start + Math.max(0, element.duration));
   const time = Number.isFinite(currentTime) ? currentTime : start;
-
-  return clampNumber(time, start, end);
+  if (end === start) return start;
+  // Runtime clip windows are end-exclusive. Seeking exactly to `end` leaves
+  // the selected layer hidden, so keep the inspection frame just inside it.
+  return clampNumber(time, start, Math.max(start, end - 0.001));
 }
 
 export function clampNumber(value: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary
-

## Why
-

## Issue
- Closes #

## Scope
-

## Out of scope
-

## Testing
### Ran
- `...`

### Result
- pass/fail:
- if fail, exact files/errors:

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1.
2.
3.

## Evidence
- video/screenshot link, or `N/A (docs-only)`

## Risk
-

## Rollback
-
