### PR TITLE
feat: support signed plugin package imports

### DIFF
--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -158,6 +158,7 @@ export type iPolloWorkPluginPackageMetadata = {
   updateId: string;
   entrypoints: { opencode?: string; service?: string };
   checksum?: { algorithm: "sha256"; value: string };
+  signature?: { algorithm: "ed25519"; keyId: string; value: string };
 };
 
 export type iPolloWorkPluginAuthorizationMethodTranslation = {

--- a/apps/app/src/app/lib/ipollowork-server.ts
+++ b/apps/app/src/app/lib/ipollowork-server.ts
@@ -314,11 +314,19 @@ export type iPolloWorkPluginPackagePreview = {
   safety: iPolloWorkPluginPackageImportSafety;
 };
 
-export type iPolloWorkPluginPackageImportSafety = {
-  level: "declarative";
-  localCode: false;
-  allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp">;
-};
+export type iPolloWorkPluginPackageImportSafety =
+  | {
+      level: "declarative";
+      localCode: false;
+      allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp">;
+    }
+  | {
+      level: "signed";
+      localCode: boolean;
+      allowedResourceTypes: iPolloWorkExtensionManifest["resources"][number]["type"][];
+      publisher: { id: string; name: string };
+      signature: { algorithm: "ed25519"; keyId: string; status: "verified" };
+    };
 
 export type iPolloWorkPluginPackageUpload = {
   archiveName: string;

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -62,6 +62,8 @@ export default {
   "plugin_platform.import_agents": "Agents",
   "plugin_platform.import_commands": "Commands",
   "plugin_platform.import_safety": "Declarative safety check passed: no local service, system process, native binary, or host-process code will be loaded.",
+  "plugin_platform.import_signed_safety": "The publisher signature from {publisher} is verified. This plugin contains local code and will run the local services declared in its manifest.",
+  "plugin_platform.import_permissions": "Permissions granted after installation",
   "plugin_platform.import_error": "Could not import this plugin package.",
   "plugin_platform.publisher_unknown": "Unknown publisher",
   "plugin_platform.integrity_verified": "Checksum verified",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -65,6 +65,8 @@ export default {
   "plugin_platform.import_agents": "Agent",
   "plugin_platform.import_commands": "命令",
   "plugin_platform.import_safety": "已通过声明式安全检查：不会加载本地服务、系统进程、原生程序或主进程代码。",
+  "plugin_platform.import_signed_safety": "已验证{publisher}的发布者签名。这个插件包含本地代码，安装后会运行清单中声明的本地服务。",
+  "plugin_platform.import_permissions": "安装后将获得以下权限",
   "plugin_platform.import_error": "无法导入这个插件包。",
   "plugin_platform.publisher_unknown": "未知发布者",
   "plugin_platform.integrity_verified": "校验值已验证",

--- a/apps/app/src/react-app/domains/settings/plugin-package-import-modal.tsx
+++ b/apps/app/src/react-app/domains/settings/plugin-package-import-modal.tsx
@@ -105,6 +105,7 @@ export function PluginPackageImportModal(props: PluginPackageImportModalProps) {
 
   const isUpdate = preview ? props.installedPluginIds.includes(preview.manifest.id) : false;
   const previewManifest = preview ? localizePluginPackageManifest(preview.manifest, locale) : null;
+  const signedSafety = preview?.safety.level === "signed" ? preview.safety : null;
 
   return (
     <Dialog open={props.open} onOpenChange={(open) => { if (!open) close(); }}>
@@ -173,10 +174,22 @@ export function PluginPackageImportModal(props: PluginPackageImportModalProps) {
                   </div>
                 ))}
               </div>
-              <div className="flex items-start gap-2 border-t border-green-6 bg-green-2 px-4 py-3 text-xs leading-5 text-green-11">
+              <div className={`flex items-start gap-2 border-t px-4 py-3 text-xs leading-5 ${signedSafety ? "border-amber-6 bg-amber-2 text-amber-11" : "border-green-6 bg-green-2 text-green-11"}`}>
                 <ShieldCheck size={16} className="mt-0.5 shrink-0" />
-                <span>{t("plugin_platform.import_safety")}</span>
+                <span>
+                  {signedSafety
+                    ? t("plugin_platform.import_signed_safety", { publisher: signedSafety.publisher.name })
+                    : t("plugin_platform.import_safety")}
+                </span>
               </div>
+              {signedSafety && previewManifest.permissions?.length ? (
+                <div className="border-t border-dls-border px-4 py-3">
+                  <p className="text-xs font-medium text-dls-text">{t("plugin_platform.import_permissions")}</p>
+                  <ul className="mt-2 space-y-1.5 text-xs leading-5 text-dls-secondary">
+                    {previewManifest.permissions.map((permission) => <li key={permission.id}>• {permission.reason}</li>)}
+                  </ul>
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/apps/server/src/plugin-package-lifecycle.test.ts
+++ b/apps/server/src/plugin-package-lifecycle.test.ts
@@ -89,6 +89,55 @@ async function writeDeclarativePackage(packageRoot: string, version = "1.0.0") {
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
 }
 
+async function writeSignedExecutablePackage(packageRoot: string) {
+  const skillPath = ".opencode/skills/signed-research/SKILL.md";
+  await mkdir(join(packageRoot, dirname(skillPath)), { recursive: true });
+  await writeFile(join(packageRoot, "service.mjs"), "export default async () => ({ actions: { ping: async () => ({ pong: true }) } });\n", "utf8");
+  await writeFile(join(packageRoot, skillPath), "# Signed Research\n", "utf8");
+  await writeFile(join(packageRoot, "ipollowork.plugin.json"), JSON.stringify({
+    schemaVersion: 1,
+    id: "signed-research",
+    name: "Signed Research",
+    description: "Signed executable test package.",
+    source: { format: "ipollowork-extension-manifest", origin: "local", trusted: false },
+    package: {
+      version: "1.0.0",
+      publisher: { id: "smart-future-school", name: "智慧未来学校" },
+      updateId: "smart-future-school/signed-research",
+      entrypoints: { service: "service.mjs" },
+      checksum: { algorithm: "sha256", value: "e1f0989fd33e680640c020a16309a1ac88b01412b837181aacdc1f059e257346" },
+      signature: {
+        algorithm: "ed25519",
+        keyId: "smart-future-school-2026",
+        value: "zz4FD0ePLKBuyasb69aanwG5GemRzLF6uZCQ23Zg4Pc+H3QxWpANef5RGfGoIMNriqbW2e96X7vRSmBrvIy7Dw==",
+      },
+    },
+    permissions: [{ id: "network", reason: "Run the signed local service." }],
+    resources: [
+      {
+        type: "local-service",
+        id: "signed-research-service",
+        path: "service.mjs",
+        actions: [{
+          id: "ping",
+          title: "Ping",
+          description: "Return a test response.",
+          effect: "read",
+          inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        }],
+        required: true,
+      },
+      {
+        type: "skill",
+        id: "signed-research-skill",
+        path: skillPath,
+        requires: ["service:signed-research-service"],
+        required: true,
+      },
+    ],
+  }, null, 2), "utf8");
+}
+
 async function expectMissing(path: string) {
   await expect(stat(path)).rejects.toThrow();
 }
@@ -414,6 +463,93 @@ describe("plugin package lifecycle", () => {
       const removal = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/acme-research`, { method: "DELETE", headers });
       expect(removal.status).toBe(200);
       expect(await (await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages`, { headers })).json()).toEqual({ items: [] });
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("imports, runs, and uninstalls a trusted publisher-signed executable archive", async () => {
+    const workspaceRoot = await createRoot("ipollowork-signed-plugin-workspace-");
+    const packageRoot = await createRoot("ipollowork-signed-plugin-package-");
+    process.env.IPOLLOWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    await writeSignedExecutablePackage(packageRoot);
+    const upload = {
+      archiveName: "signed-research.ipollowork-plugin",
+      files: await Promise.all([
+        "ipollowork.plugin.json",
+        "service.mjs",
+        ".opencode/skills/signed-research/SKILL.md",
+      ].map(async (path) => ({ path, contentBase64: (await readFile(join(packageRoot, path))).toString("base64") }))),
+    };
+    const config = serverConfig(workspaceRoot);
+    const server = await startServer(config);
+    const base = `http://127.0.0.1:${server.port}`;
+    const headers = { authorization: "Bearer token", "content-type": "application/json" };
+    try {
+      const validation = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/import/validate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(upload),
+      });
+      expect(validation.status).toBe(200);
+      expect(await validation.json()).toMatchObject({
+        preview: {
+          manifest: { id: "signed-research", source: { trusted: false } },
+          integrity: { status: "verified" },
+          safety: {
+            level: "signed",
+            localCode: true,
+            publisher: { id: "smart-future-school", name: "智慧未来学校" },
+            signature: { algorithm: "ed25519", keyId: "smart-future-school-2026", status: "verified" },
+          },
+        },
+      });
+
+      const installation = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/import`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(upload),
+      });
+      expect(installation.status).toBe(200);
+      expect(await installation.json()).toMatchObject({
+        result: { status: "installed", pluginId: "signed-research", version: "1.0.0" },
+        safety: { level: "signed", localCode: true },
+      });
+      expect(await readFile(join(workspaceRoot, ".opencode", "skills", "signed-research", "SKILL.md"), "utf8"))
+        .toBe("# Signed Research\n");
+
+      const call = await fetch(`${base}/experimental/extensions/call`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          extensionId: "signed-research",
+          action: "ping",
+          args: {},
+          context: { directory: workspaceRoot },
+        }),
+      });
+      expect(call.status).toBe(200);
+      expect(await call.json()).toMatchObject({ result: { pong: true } });
+
+      const removal = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/signed-research`, { method: "DELETE", headers });
+      expect(removal.status).toBe(200);
+      await expectMissing(join(workspaceRoot, ".opencode", "skills", "signed-research", "SKILL.md"));
+
+      const tamperedManifest = JSON.parse(Buffer.from(upload.files[0]?.contentBase64 ?? "", "base64").toString("utf8"));
+      tamperedManifest.package.signature.value = `${"A".repeat(86)}==`;
+      const tamperedUpload = {
+        ...upload,
+        files: upload.files.map((file) => file.path === "ipollowork.plugin.json"
+          ? { ...file, contentBase64: Buffer.from(JSON.stringify(tamperedManifest)).toString("base64") }
+          : file),
+      };
+      const rejected = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/import/validate`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(tamperedUpload),
+      });
+      expect(rejected.status).toBe(400);
+      expect(await rejected.json()).toMatchObject({ code: "plugin_package_signature_invalid" });
     } finally {
       await server.stop();
     }

--- a/apps/server/src/plugin-package-lifecycle.ts
+++ b/apps/server/src/plugin-package-lifecycle.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, createPublicKey, randomUUID, verify } from "node:crypto";
 import { chmod, copyFile, lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -14,6 +14,13 @@ import serverPackage from "../package.json" with { type: "json" };
 import constants from "../../../constants.json" with { type: "json" };
 
 const MANIFEST_FILE = "ipollowork.plugin.json";
+const PACKAGE_SIGNATURE_PREFIX = "ipollowork-plugin-package-v1\0";
+const TRUSTED_IMPORT_PUBLISHER_KEYS = new Map([
+  [
+    "smart-future-school/smart-future-school-2026",
+    "MCowBQYDK2VwAyEANqxN7w94IK3NWdYZWtoyz/Y6daP7MEqWnKrJHz+XAyI=",
+  ],
+]);
 
 const ownedFileSchema = z.object({ path: z.string(), sha256: z.string() });
 const installedVersionSchema = z.object({
@@ -47,11 +54,21 @@ export type PluginPackagePreview = {
   integrity: { sha256: string; status: "verified" | "unsigned" };
 };
 
-export type PluginPackageImportSafety = {
-  level: "declarative";
-  localCode: false;
-  allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp">;
-};
+type PluginPackageResourceType = PluginPackageManifest["resources"][number]["type"];
+
+export type PluginPackageImportSafety =
+  | {
+      level: "declarative";
+      localCode: false;
+      allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp">;
+    }
+  | {
+      level: "signed";
+      localCode: boolean;
+      allowedResourceTypes: PluginPackageResourceType[];
+      publisher: { id: string; name: string };
+      signature: { algorithm: "ed25519"; keyId: string; status: "verified" };
+    };
 
 export type InstalledPluginPackageSummary = {
   pluginId: string;
@@ -186,17 +203,21 @@ function canonicalJson(value: unknown): string {
   return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(",")}}`;
 }
 
+function compareRelativePaths(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
 function packageSha256(manifest: PluginPackageManifest, files: OwnedFile[]): string {
   const hash = createHash("sha256");
   const packageMetadata = manifest.package;
   const checksumFreeManifest = packageMetadata
-    ? { ...manifest, package: { ...packageMetadata, checksum: undefined } }
+    ? { ...manifest, package: { ...packageMetadata, checksum: undefined, signature: undefined } }
     : manifest;
   hash.update(MANIFEST_FILE);
   hash.update("\0");
   hash.update(createHash("sha256").update(canonicalJson(checksumFreeManifest)).digest("hex"));
   hash.update("\n");
-  for (const file of [...files].sort((left, right) => left.path.localeCompare(right.path))) {
+  for (const file of [...files].sort((left, right) => compareRelativePaths(left.path, right.path))) {
     hash.update(file.path);
     hash.update("\0");
     hash.update(file.sha256);
@@ -534,6 +555,42 @@ export async function previewPluginPackage(input: { packageRoot: string; workspa
 
 const SAFE_IMPORT_RESOURCE_TYPES = new Set(["skill", "agent", "command", "file", "mcp"]);
 
+function signedImportSafety(manifest: PluginPackageManifest, integrity: PluginPackagePreview["integrity"]): PluginPackageImportSafety | null {
+  const signature = manifest.package?.signature;
+  if (!signature) return null;
+  const publisher = manifest.package?.publisher;
+  if (!publisher) {
+    throw new ApiError(400, "plugin_package_signature_untrusted", "Signed plugin packages must declare their publisher");
+  }
+  if (integrity.status !== "verified") {
+    throw new ApiError(400, "plugin_package_signature_requires_checksum", "Signed plugin packages must declare a matching SHA-256 checksum");
+  }
+  const publicKey = TRUSTED_IMPORT_PUBLISHER_KEYS.get(`${publisher.id}/${signature.keyId}`);
+  if (!publicKey) {
+    throw new ApiError(400, "plugin_package_signature_untrusted", "Plugin publisher or signing key is not trusted by this iPolloWork build", {
+      publisherId: publisher.id,
+      keyId: signature.keyId,
+    });
+  }
+  const signatureBytes = Buffer.from(signature.value, "base64");
+  const valid = signatureBytes.byteLength === 64 && verify(
+    null,
+    Buffer.from(`${PACKAGE_SIGNATURE_PREFIX}${integrity.sha256}`, "utf8"),
+    createPublicKey({ key: Buffer.from(publicKey, "base64"), format: "der", type: "spki" }),
+    signatureBytes,
+  );
+  if (!valid) {
+    throw new ApiError(400, "plugin_package_signature_invalid", "Plugin package publisher signature is invalid");
+  }
+  return {
+    level: "signed",
+    localCode: Boolean(manifest.package?.entrypoints.opencode || manifest.package?.entrypoints.service),
+    allowedResourceTypes: [...new Set(manifest.resources.map((resource) => resource.type))],
+    publisher,
+    signature: { algorithm: "ed25519", keyId: signature.keyId, status: "verified" },
+  };
+}
+
 function safeImportResourcePath(type: string, path: string): boolean {
   if (type === "skill") return path.startsWith(".opencode/skills/");
   if (type === "agent") return path.startsWith(".opencode/agents/");
@@ -566,6 +623,10 @@ export async function assertPluginPackageSafeForImport(input: {
   const { manifest } = input.preview;
   const reasons: string[] = [];
   if (manifest.source.trusted) reasons.push("Imported packages cannot declare themselves trusted");
+  if (reasons.length === 0) {
+    const signedSafety = signedImportSafety(manifest, input.preview.integrity);
+    if (signedSafety) return signedSafety;
+  }
   if (manifest.package?.entrypoints.opencode || manifest.package?.entrypoints.service) {
     reasons.push("Imported packages cannot include executable entrypoints");
   }

--- a/apps/server/src/plugin-package-manifest.ts
+++ b/apps/server/src/plugin-package-manifest.ts
@@ -181,6 +181,11 @@ const packageSchema = z.object({
     algorithm: z.literal("sha256"),
     value: z.string().regex(/^[a-f0-9]{64}$/i),
   }).strict().optional(),
+  signature: z.object({
+    algorithm: z.literal("ed25519"),
+    keyId: z.string().regex(SIMPLE_ID_RE),
+    value: z.string().regex(/^[A-Za-z0-9+/]{86}==$/, "must be a base64 Ed25519 signature"),
+  }).strict().optional(),
 }).strict();
 
 const localizedTextSchema = z.string().trim().min(1);

--- a/scripts/package-plugin.mjs
+++ b/scripts/package-plugin.mjs
@@ -1,0 +1,164 @@
+import { createHash, sign } from "node:crypto";
+import { createRequire } from "node:module";
+import { lstat, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+
+const requireFromApp = createRequire(new URL("../apps/app/package.json", import.meta.url));
+const JSZip = requireFromApp("jszip");
+
+const MANIFEST_FILE = "ipollowork.plugin.json";
+const PACKAGE_SIGNATURE_PREFIX = "ipollowork-plugin-package-v1\0";
+const MAX_PACKAGE_BYTES = 10 * 1024 * 1024;
+const MAX_PACKAGE_FILES = 512;
+
+function usage() {
+  return "Usage: node scripts/package-plugin.mjs --root <package-root> --out <archive.ipollowork-plugin> --private-key <ed25519.pem> --key-id <id>";
+}
+
+function options(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || !value) throw new Error(usage());
+    values.set(key.slice(2), value);
+  }
+  const root = values.get("root");
+  const out = values.get("out");
+  const privateKey = values.get("private-key");
+  const keyId = values.get("key-id");
+  if (!root || !out || !privateKey || !keyId) throw new Error(usage());
+  return { root: resolve(root), out: resolve(out), privateKey: resolve(privateKey), keyId };
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const entries = Object.entries(value)
+    .filter(([, entry]) => entry !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(",")}}`;
+}
+
+function compareRelativePaths(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function pathWithin(root, path) {
+  const suffix = relative(root, path);
+  return suffix && !suffix.startsWith(`..${sep}`) && suffix !== ".." && !suffix.startsWith(sep);
+}
+
+function safeResourcePath(root, value) {
+  if (typeof value !== "string" || !value || value.startsWith("/") || value.startsWith("\\")) {
+    throw new Error(`Unsafe plugin resource path: ${String(value)}`);
+  }
+  const normalized = value.replaceAll("\\", "/");
+  if (normalized.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error(`Unsafe plugin resource path: ${value}`);
+  }
+  const path = resolve(root, normalized);
+  if (!pathWithin(root, path)) throw new Error(`Plugin resource escapes its root: ${value}`);
+  return { path, relativePath: normalized };
+}
+
+async function resourceFiles(root, resourcePath) {
+  const source = safeResourcePath(root, resourcePath);
+  const metadata = await lstat(source.path);
+  if (metadata.isSymbolicLink()) throw new Error(`Plugin resources may not be symbolic links: ${resourcePath}`);
+  if (metadata.isFile()) return [source.relativePath];
+  if (!metadata.isDirectory()) throw new Error(`Plugin resource must be a file or directory: ${resourcePath}`);
+  const files = [];
+  const visit = async (directory) => {
+    const entries = await readdir(resolve(root, directory), { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+    for (const entry of entries) {
+      const path = `${directory}/${entry.name}`;
+      if (entry.isSymbolicLink()) throw new Error(`Plugin resources may not be symbolic links: ${path}`);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile()) files.push(path);
+      else throw new Error(`Plugin resource must be a regular file: ${path}`);
+    }
+  };
+  await visit(source.relativePath);
+  if (!files.length) throw new Error(`Plugin resource directory is empty: ${resourcePath}`);
+  return files;
+}
+
+function packageSha256(manifest, files) {
+  const hash = createHash("sha256");
+  const packageMetadata = manifest.package;
+  const checksumFreeManifest = packageMetadata
+    ? { ...manifest, package: { ...packageMetadata, checksum: undefined, signature: undefined } }
+    : manifest;
+  hash.update(MANIFEST_FILE);
+  hash.update("\0");
+  hash.update(createHash("sha256").update(canonicalJson(checksumFreeManifest)).digest("hex"));
+  hash.update("\n");
+  for (const file of [...files].sort((left, right) => compareRelativePaths(left.path, right.path))) {
+    hash.update(file.path);
+    hash.update("\0");
+    hash.update(file.sha256);
+    hash.update("\n");
+  }
+  return hash.digest("hex");
+}
+
+async function main() {
+  const input = options(process.argv.slice(2));
+  const manifestPath = resolve(input.root, MANIFEST_FILE);
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+  if (!manifest.package?.publisher) throw new Error("Plugin package publisher metadata is required for signing");
+  if (!Array.isArray(manifest.resources)) throw new Error("Plugin package resources are required");
+
+  const paths = new Set();
+  for (const resource of manifest.resources) {
+    if (!resource.path) continue;
+    for (const path of await resourceFiles(input.root, resource.path)) paths.add(path);
+  }
+  const files = [];
+  for (const path of [...paths].sort(compareRelativePaths)) {
+    const content = await readFile(resolve(input.root, path));
+    files.push({ path, content, sha256: createHash("sha256").update(content).digest("hex") });
+  }
+
+  const distributableManifest = {
+    ...manifest,
+    source: {
+      ...manifest.source,
+      format: "ipollowork-extension-manifest",
+      origin: "local",
+      trusted: false,
+    },
+    package: {
+      ...manifest.package,
+      checksum: undefined,
+      signature: undefined,
+    },
+  };
+  const digest = packageSha256(distributableManifest, files);
+  const signature = sign(
+    null,
+    Buffer.from(`${PACKAGE_SIGNATURE_PREFIX}${digest}`, "utf8"),
+    await readFile(input.privateKey),
+  ).toString("base64");
+  if (Buffer.from(signature, "base64").byteLength !== 64) throw new Error("Signing key did not produce an Ed25519 signature");
+  distributableManifest.package.checksum = { algorithm: "sha256", value: digest };
+  distributableManifest.package.signature = { algorithm: "ed25519", keyId: input.keyId, value: signature };
+
+  const manifestContent = Buffer.from(`${JSON.stringify(distributableManifest, null, 2)}\n`, "utf8");
+  const totalFiles = files.length + 1;
+  const totalBytes = files.reduce((sum, file) => sum + file.content.byteLength, manifestContent.byteLength);
+  if (totalFiles > MAX_PACKAGE_FILES) throw new Error(`Plugin package has ${totalFiles} files; maximum is ${MAX_PACKAGE_FILES}`);
+  if (totalBytes > MAX_PACKAGE_BYTES) throw new Error(`Plugin package has ${totalBytes} bytes; maximum is ${MAX_PACKAGE_BYTES}`);
+
+  const archive = new JSZip();
+  archive.file(MANIFEST_FILE, manifestContent);
+  for (const file of files) archive.file(file.path, file.content);
+  const output = await archive.generateAsync({ type: "nodebuffer", compression: "DEFLATE", compressionOptions: { level: 9 } });
+  await mkdir(dirname(input.out), { recursive: true });
+  await writeFile(input.out, output, { mode: 0o644 });
+  process.stdout.write(`${JSON.stringify({ output: input.out, pluginId: manifest.id, version: manifest.package.version, sha256: digest, files: totalFiles, bytes: totalBytes, archiveBytes: output.byteLength })}\n`);
+}
+
+await main();


### PR DESCRIPTION
## What changed

- add Ed25519 signature metadata to the plugin package manifest
- verify signed executable plugin packages against the registered publisher key
- show verified publisher identity and requested permissions before import
- add a generic plugin package signing utility
- cover signed import, runtime action calls, uninstall, and signature tampering

## Why

Executable plugins are distributed separately from the iPolloWork repository. Users should be able to import a signed `.ipollowork-plugin` package without bundling that plugin's source, UI, assets, service, or Skill into the main application.

## Scope

This PR contains only the generic package import and verification mechanism. It does not contain the Data Annotation Training Cloud plugin source or package artifact.

## Validation

- `pnpm --filter ipollowork-server exec bun test src/plugin-package-lifecycle.test.ts` — 14 passed
- `pnpm --filter ipollowork-server typecheck` — passed
- `pnpm --filter @ipollowork/app typecheck` — passed
- `pnpm --filter ipollowork-server build` — passed
- `pnpm --filter @ipollowork/app build` — passed with existing Vite chunk/deprecation warnings
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed, no warnings
- `git diff --check` — passed
