### PR TITLE
Fix template market CI regression

### DIFF
--- a/apps/app/tests/session-output-regressions.test.ts
+++ b/apps/app/tests/session-output-regressions.test.ts
@@ -166,7 +166,7 @@ describe("session output issue regressions", () => {
     }
   });
 
-  test("template market exposes category counts and clean import separators", () => {
+  test("template market exposes category counts, import details, and installed enterprise actions", () => {
     const source = readFileSync(
       new URL("../src/react-app/domains/session/templates/template-market-dialog.tsx", import.meta.url),
       "utf8",
@@ -188,7 +188,8 @@ describe("session output issue regressions", () => {
     expect(sessionSource).toContain("requestId !== templateCatalogRequestIdRef.current");
     expect(source).toContain("enterpriseTemplateInstallations");
     expect(source).toContain("resource.sourceTemplateId");
-    expect(source).toContain('t("plugin_platform.status.installed")');
+    expect(source).toContain("return <TemplateCard template={installedTemplate}");
+    expect(source).toContain("primaryAction={action} primaryLabel={label} sourceLabel={sourceLabel}");
   });
 
   test("enterprise extensions reflect local package installation versions", () => {


### PR DESCRIPTION
## What changed

- replace the obsolete template-market assertion for the removed installed badge
- assert the current installed Enterprise template behavior: reuse the unified template card with its use/update action and source label
- rename the regression case so its scope matches the behavior it protects

## Root cause

The Enterprise template card was refactored to reuse `TemplateCard`. The old explicit `plugin_platform.status.installed` badge was removed, but the source-regression test still required that translation call. This made the macOS App test job fail even though the current installed template workflow remained intact.

## Impact

Test-only change. No application, template, Design, Video Studio, plugin, or runtime behavior changes.

## Validation

- `bun test --isolate apps/app/tests/session-output-regressions.test.ts` — 12 passed
- `pnpm --filter @ipollowork/app test` — 708 passed
- `pnpm --filter @ipollowork/app typecheck` — passed
- `git diff --check` — passed
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs` — passed with no errors or warnings

Fraimz was skipped because this changes only a source-regression assertion and has no user-visible runtime path.