### PR TITLE
chore: upgrade OpenCode to 1.18.16

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,19 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.17.3"
+        "@opencode-ai/plugin": "1.18.16"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,19 +99,20 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.17.3.tgz",
-      "integrity": "sha512-Qz1ADiWxxXwuetXs6FE2T0kQmPXM6F8XDXE73SdC/oBZFYg7Oc1nf74GaEGhrvqQSMYm4kR6dHNF2jPVKn4eFw==",
+      "version": "1.18.16",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.18.16.tgz",
+      "integrity": "sha512-XvlZ9CFAXqrNrmpTe+EhhRYnDhca6db1ebcB10v5JO8kSm1iFbVbPP982Qzc4MRSrfpPjD8W1fg13Ubnff377g==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.17.3",
-        "effect": "4.0.0-beta.74",
+        "@ai-sdk/provider": "3.0.8",
+        "@opencode-ai/sdk": "1.18.16",
+        "effect": "4.0.0-beta.83",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.3.4",
-        "@opentui/keymap": ">=0.3.4",
-        "@opentui/solid": ">=0.3.4"
+        "@opentui/core": ">=0.4.5",
+        "@opentui/keymap": ">=0.4.5",
+        "@opentui/solid": ">=0.4.5"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -114,9 +127,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.17.3.tgz",
-      "integrity": "sha512-oXrEjOuP3+J9pPNw3cmOnRma/xiVQ4WIIvGd6YkhPQgqqi2PnD/b1qfNY0AMead3QfNhKwKdDM4QFJdN2LpByg==",
+      "version": "1.18.16",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.18.16.tgz",
+      "integrity": "sha512-UvaHyL93spLm7MttoprWTOBSYQN3aYWd7/3Ie5WNnG2pRAPq/U/d51qt0smYBTrkjxqlQmg+AJoGw8MEH6lGUg==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -153,9 +166,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.74",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.74.tgz",
-      "integrity": "sha512-Yx+Kh12U+i2FmjwEfKs+ePFmpMd43RPD1oGqc/VraSS9bYzvF0Ff3PojwEFEVEewp8xc92Uxu28gTspU4qyvHA==",
+      "version": "4.0.0-beta.83",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.83.tgz",
+      "integrity": "sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -171,9 +184,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
-      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
       "funding": [
         {
           "type": "individual",
@@ -213,6 +226,12 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
@@ -220,9 +239,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
-      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.5.tgz",
+      "integrity": "sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==",
       "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.4"
@@ -251,9 +270,9 @@
       }
     },
     "node_modules/multipasta": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
-      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
       "license": "MIT"
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -281,9 +300,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
-      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
       "funding": [
         {
           "type": "individual",
@@ -318,18 +337,18 @@
       }
     },
     "node_modules/toml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
-      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -49,7 +49,7 @@
     "@ipollowork/types": "workspace:*",
     "@ipollowork/ui": "workspace:*",
     "@lexical/react": "^0.35.0",
-    "@opencode-ai/sdk": "^1.17.11",
+    "@opencode-ai/sdk": "^1.18.16",
     "@shikijs/transformers": "^4.0.2",
     "@tanstack/react-query": "^5.90.3",
     "@xterm/addon-fit": "^0.11.0",
@@ -96,6 +96,5 @@
     "tailwindcss": "^4.1.18",
     "typescript": "^5.6.3",
     "vite": "^6.0.1"
-  },
-  "packageManager": "pnpm@10.27.0"
+  }
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@ffmpeg-installer/ffmpeg": "^1.1.0",
     "@ffprobe-installer/ffprobe": "^2.1.2",
-    "@opencode-ai/sdk": "^1.17.11",
+    "@opencode-ai/sdk": "^1.18.16",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "electron-updater": "^6.3.9",
@@ -44,6 +44,5 @@
     "electron": "^35.0.0",
     "electron-builder": "^25.1.8",
     "electron-devtools-installer": "^4.0.0"
-  },
-  "packageManager": "pnpm@10.27.0"
+  }
 }

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.18.3",
+    "@opencode-ai/sdk": "^1.18.16",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
     "ipollowork-server": "0.20.0",
@@ -59,6 +59,5 @@
     "@types/node": "^22.10.2",
     "bun-types": "^1.3.6",
     "typescript": "^5.6.3"
-  },
-  "packageManager": "pnpm@10.27.0"
+  }
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@ipollowork/types": "workspace:*",
-    "@opencode-ai/sdk": "^1.18.3",
+    "@opencode-ai/sdk": "^1.18.16",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
     "jsonc-parser": "^3.2.1",
@@ -61,6 +61,5 @@
     "@types/node": "^22.10.2",
     "bun-types": "^1.3.6",
     "typescript": "^5.6.3"
-  },
-  "packageManager": "pnpm@10.27.0"
+  }
 }

--- a/apps/server/src/hyperframes-catalog.test.ts
+++ b/apps/server/src/hyperframes-catalog.test.ts
@@ -59,11 +59,12 @@ describe("HyperFrames catalog parameters", () => {
     const animations = gsapItems.filter((item) => item.kind === "animation");
     const effects = gsapItems.filter((item) => item.kind === "effect");
 
-    expect(gsapItems).toHaveLength(151);
-    expect(animations).toHaveLength(69);
-    expect(effects).toHaveLength(82);
+    expect(gsapItems).toHaveLength(167);
+    expect(animations).toHaveLength(74);
+    expect(effects).toHaveLength(93);
     expect(gsapItems.filter((item) => item.source?.provider === "gsap-docs")).toHaveLength(25);
     expect(gsapItems.filter((item) => item.source?.provider === "hyperframes")).toHaveLength(126);
+    expect(gsapItems.filter((item) => item.source?.provider === "ipollowork")).toHaveLength(16);
     expect(gsapItems.find((item) => item.name === "app-showcase")?.engine?.version).toBe("3.14.2");
     expect(
       gsapItems.find((item) => item.name === "gsap-scrolltrigger-story")?.engine?.plugins,

--- a/constants.json
+++ b/constants.json
@@ -1,3 +1,3 @@
 {
-  "opencodeVersion": "v1.18.3"
+  "opencodeVersion": "v1.18.16"
 }

--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
   },
   "engines": {
     "pnpm": ">=11.4.0 <12"
-  }
+  },
+  "packageManager": "pnpm@11.4.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
       '@opencode-ai/sdk':
-        specifier: ^1.17.11
-        version: 1.17.11
+        specifier: ^1.18.16
+        version: 1.18.16
       '@shikijs/transformers':
         specifier: ^4.0.2
         version: 4.0.2
@@ -211,8 +211,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@opencode-ai/sdk':
-        specifier: ^1.17.11
-        version: 1.17.11
+        specifier: ^1.18.16
+        version: 1.18.16
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -266,8 +266,8 @@ importers:
   apps/orchestrator:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: ^1.18.3
-        version: 1.18.3
+        specifier: ^1.18.16
+        version: 1.18.16
       '@opentui/core':
         specifier: 0.1.77
         version: 0.1.77(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
@@ -315,8 +315,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/types
       '@opencode-ai/sdk':
-        specifier: ^1.18.3
-        version: 1.18.3
+        specifier: ^1.18.16
+        version: 1.18.16
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -2052,11 +2052,8 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@opencode-ai/sdk@1.17.11':
-    resolution: {integrity: sha512-UdSwnNM4/cD5rHnI8O7VaHuiwYnsEOglpRPVeeYE2S5Nm1K34ijCyZGDvBecb0ShdBQgn49XvyQWJH6cREsIPw==}
-
-  '@opencode-ai/sdk@1.18.3':
-    resolution: {integrity: sha512-Mevo4e6kQwbvto9E+42KSIVMhp+JBu+SwQhC5AomAvrV6Xkio3U249T+xDILDCXhl5Z/Hi/DlAuVLzpGnuh0gg==}
+  '@opencode-ai/sdk@1.18.16':
+    resolution: {integrity: sha512-UvaHyL93spLm7MttoprWTOBSYQN3aYWd7/3Ie5WNnG2pRAPq/U/d51qt0smYBTrkjxqlQmg+AJoGw8MEH6lGUg==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -8287,11 +8284,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opencode-ai/sdk@1.17.11':
-    dependencies:
-      cross-spawn: 7.0.6
-
-  '@opencode-ai/sdk@1.18.3':
+  '@opencode-ai/sdk@1.18.16':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary

- Upgrade the bundled OpenCode sidecar from 1.18.3 to 1.18.16.
- Align all `@opencode-ai/sdk` and `@opencode-ai/plugin` consumers on 1.18.16.
- Pin pnpm 11.4.0 once at the workspace root and remove conflicting package-level pnpm 10.27.0 declarations.
- Update the stale HyperFrames catalog assertion to include the 16 existing iPolloWork animation/effect entries.

## Why

The repository had mixed OpenCode SDK/plugin versions across the app, desktop, server, orchestrator, and `.opencode` workspace. Aligning the runtime and supported SDK/plugin boundaries reduces provider, MCP, session-streaming, and configuration compatibility risk while keeping OpenCode external to iPolloWork.

The HyperFrames catalog failure was unrelated to the OpenCode upgrade: the runtime catalog already contained 16 iPolloWork entries, but the older aggregate test counts had not been updated.

## User impact

There are no intended UI or workflow changes. Design templates, Video Studio behavior, Markdown, Spreadsheet, and right-side panels remain unchanged. This is a runtime/dependency reliability update.

## Validation

- App tests: 708 passed, 0 failed.
- Desktop tests: 102 passed, 1 skipped, 0 failed.
- Server tests: 434 passed, 2 skipped, 0 failed.
- OpenCode-focused server tests: 41 passed, 2 skipped, 0 failed.
- Focused HyperFrames catalog test: 3 passed, 0 failed.
- Maintainability audit: 0 errors, 0 warnings.
- `git diff --check`: passed.
- Real Electron development startup verified with Vite, CDP, embedded server health, OpenCode 1.18.16, session creation, SSE events, configuration, providers, MCP, agents, and plugin loading.

Fraimz was not generated because this change has no intended user-visible UI behavior; the real development runtime path was exercised instead.