### PR TITLE
fix: return from settings to active task

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2043,7 +2043,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         developerMode={developerMode}
         headerStatus={routeiPolloWorkStatus}
         busyHint={loading ? t("session.loading_detail") : busyLabel}
-        onClose={props.onClose ?? (() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session"))}
+        onClose={props.onClose ?? (() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId, navigationSessionId) : "/session"))}
         compact={props.embedded}
         hidePageHeader={Boolean(route.pluginPackageId)}
         hideShellHeader={Boolean(route.pluginPackageId)}

--- a/apps/app/tests/settings-route.test.ts
+++ b/apps/app/tests/settings-route.test.ts
@@ -1,7 +1,13 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, test } from "bun:test";
 
 import { getCloudSettingsTabs } from "../src/react-app/domains/settings/shell/settings-page";
 import { parseSettingsPath } from "../src/react-app/shell/settings-route";
+
+const settingsRouteSource = readFileSync(
+  new URL("../src/react-app/shell/settings-route.tsx", import.meta.url),
+  "utf8",
+);
 
 describe("settings route parsing", () => {
   test("redirects the settings root to preferences while keeping the overview route available", () => {
@@ -40,5 +46,9 @@ describe("settings route parsing", () => {
       extensionsSection: "all",
       pluginPackageId: "figma",
     });
+  });
+
+  test("returns to the task that opened settings", () => {
+    expect(settingsRouteSource).toContain("workspaceSessionRoute(selectedWorkspaceId, navigationSessionId)");
   });
 });


### PR DESCRIPTION
## Summary

- Preserve the active task ID when leaving Settings.
- Return to the exact task route instead of the workspace-level empty session route.
- Add a focused regression assertion for the Settings return path.

## Root cause

Opening Settings already stored the current `sessionId` in navigation state. The Settings shell read that ID but dropped it from the Back to app route, navigating to `/workspace/:workspaceId/session` instead of `/workspace/:workspaceId/session/:sessionId`.

With no selected task in the route, the session page remained on the Preparing workspace / Pulling in the latest messages state.

## User impact

Users can open Settings from an active task and return to the same conversation immediately. No settings behavior, session content, Design, Video, templates, plugins, or OpenCode runtime behavior changes.

## Validation

- Focused Settings route test: 6 passed, 0 failed.
- Full App tests: 709 passed, 0 failed.
- App TypeScript check: passed.
- Maintainability audit: 0 errors, 0 warnings.
- `git diff --check`: passed.
- Real Electron CDP flow: opened Settings from task `ses_01344ea02ffevOlrtoDfnPMlau`, clicked Back to app, returned to the same `/session/:sessionId` URL, rendered the existing transcript, and confirmed both loading messages were absent.

No video or Fraimz artifact was captured because this checkout does not include a loadable Fraimz skill; the exact user flow was exercised against the running Electron client via CDP.