### PR TITLE
Add MiniMax image-to-video generation

### DIFF
--- a/apps/server/src/extensions/media-center.test.ts
+++ b/apps/server/src/extensions/media-center.test.ts
@@ -9,6 +9,8 @@ import type { ServerConfig } from "../types.js";
 import {
   MEDIA_EXTENSION_ACTIONS,
   MEDIA_EXTENSION_ID,
+  MINIMAX_IMAGE_TO_VIDEO_ENDPOINTS,
+  MINIMAX_IMAGE_TO_VIDEO_MODELS,
   callMediaExtensionAction,
   estimateVoiceoverDurationSeconds,
   planSceneVoiceoverTiming,
@@ -63,6 +65,160 @@ async function workspaceConfig() {
 }
 
 describe("Media Center extension", () => {
+  test("registers MiniMax image-to-video models and regional endpoints", () => {
+    expect(MINIMAX_IMAGE_TO_VIDEO_MODELS).toEqual({
+      defaultModel: "MiniMax-H3",
+      v2: ["MiniMax-H3"],
+      v1: [
+        "MiniMax-Hailuo-2.3",
+        "MiniMax-Hailuo-2.3-Fast",
+        "MiniMax-Hailuo-02",
+        "I2V-01-Director",
+        "I2V-01-live",
+        "I2V-01",
+      ],
+    });
+    expect(MINIMAX_IMAGE_TO_VIDEO_ENDPOINTS).toHaveLength(4);
+  });
+
+  test("creates a MiniMax H3 image-to-video task", async () => {
+    globalThis.fetch = ((input, init) => {
+      expect(init?.headers).toMatchObject({ Authorization: "Bearer test-key" });
+      if (init?.method === "GET") {
+        expect(String(input)).toBe("https://api.minimax.io/v2/query/video_generation/video-task-123");
+        return Promise.resolve(Response.json({
+          task: {
+            id: "video-task-123",
+            model: "MiniMax-H3",
+            status: "succeeded",
+            content: { url: "https://cdn.example.test/video.mp4" },
+          },
+        }));
+      }
+      expect(String(input)).toBe("https://api.minimax.io/v2/video_generation");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        model: "MiniMax-H3",
+        content: [
+          { type: "text", text: "A paper boat crossing a moonlit lake" },
+          {
+            type: "image_url",
+            image_url: { url: "https://assets.example.test/boat.png" },
+            role: "first_frame",
+          },
+        ],
+        resolution: "2K",
+        duration: 6,
+        ratio: "adaptive",
+      });
+      return Promise.resolve(new Response(JSON.stringify({ task_id: "video-task-123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }));
+    }) as typeof fetch;
+
+    const result = await callMediaExtensionAction(config, env({ MINIMAX_API_KEY: "test-key" }), "video_generate", {
+      provider: "minimax",
+      prompt: "A paper boat crossing a moonlit lake",
+      imageUrl: "https://assets.example.test/boat.png",
+      duration: 6,
+    }, {});
+    const queried = await callMediaExtensionAction(config, env({ MINIMAX_API_KEY: "test-key" }), "task_get", {
+      provider: "minimax",
+      taskId: "video-task-123",
+    }, {});
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: {
+        provider: "minimax",
+        apiVersion: "v2",
+        taskId: "video-task-123",
+      },
+    });
+    expect(queried).toMatchObject({
+      result: {
+        provider: "minimax",
+        apiVersion: "v2",
+        taskId: "video-task-123",
+        output: {
+          providerResponse: {
+            task: {
+              status: "succeeded",
+              content: { url: "https://cdn.example.test/video.mp4" },
+            },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("test-key");
+  });
+
+  test("creates and queries a MiniMax Hailuo image-to-video task in China", async () => {
+    const urls: string[] = [];
+    globalThis.fetch = ((input, init) => {
+      urls.push(String(input));
+      if (init?.method !== "GET") {
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          model: "MiniMax-Hailuo-2.3",
+          first_frame_image: "https://assets.example.test/boat.png",
+          prompt: "A paper boat moving through mist",
+          duration: 10,
+          resolution: "768P",
+        });
+        return Promise.resolve(Response.json({ task_id: "hailuo-task-456", base_resp: { status_code: 0 } }));
+      }
+      return Promise.resolve(Response.json({
+        task_id: "hailuo-task-456",
+        status: "success",
+        file_id: "video-file-789",
+        base_resp: { status_code: 0 },
+      }));
+    }) as typeof fetch;
+
+    const created = await callMediaExtensionAction(config, env({ MINIMAX_API_KEY: "test-key" }), "video_generate", {
+      provider: "minimax",
+      region: "cn_zh",
+      model: "MiniMax-Hailuo-2.3",
+      prompt: "A paper boat moving through mist",
+      imageUrl: "https://assets.example.test/boat.png",
+      duration: 10,
+      resolution: "768P",
+    }, {});
+    const queried = await callMediaExtensionAction(config, env({ MINIMAX_API_KEY: "test-key" }), "task_get", {
+      provider: "minimax",
+      region: "cn_zh",
+      apiVersion: "v1",
+      taskId: "hailuo-task-456",
+    }, {});
+
+    expect(urls).toEqual([
+      "https://api.minimaxi.com/v1/video_generation",
+      "https://api.minimaxi.com/v1/query/video_generation?task_id=hailuo-task-456",
+    ]);
+    expect(created).toMatchObject({ result: { apiVersion: "v1", taskId: "hailuo-task-456" } });
+    expect(queried).toMatchObject({
+      result: {
+        apiVersion: "v1",
+        taskId: "hailuo-task-456",
+        output: { providerResponse: { status: "success", file_id: "video-file-789" } },
+      },
+    });
+  });
+
+  test("rejects MiniMax image-to-video requests without an image", async () => {
+    let requested = false;
+    globalThis.fetch = (() => {
+      requested = true;
+      return Promise.reject(new Error("MiniMax must not be called"));
+    }) as unknown as typeof fetch;
+
+    await expect(callMediaExtensionAction(config, env({ MINIMAX_API_KEY: "test-key" }), "video_generate", {
+      provider: "minimax",
+      prompt: "A paper boat",
+    }, {})).rejects.toMatchObject({ code: "invalid_payload" });
+    expect(requested).toBe(false);
+  });
+
   test("estimates multilingual narration duration before provider synthesis", () => {
     expect(estimateVoiceoverDurationSeconds("这是八个汉字的旁白。")).toBeGreaterThan(2);
     expect(estimateVoiceoverDurationSeconds("Five clear words for this scene.")).toBeGreaterThan(2);

--- a/apps/server/src/extensions/media-center.ts
+++ b/apps/server/src/extensions/media-center.ts
@@ -29,6 +29,24 @@ const LEGACY_COSYVOICE_V3_PRESET_MIGRATIONS: Record<string, string> = {
   longlaotie: "longanlang_v3",
   longfei: "longanlang_v3",
 };
+export const MINIMAX_IMAGE_TO_VIDEO_MODELS = {
+  defaultModel: "MiniMax-H3",
+  v2: ["MiniMax-H3"],
+  v1: [
+    "MiniMax-Hailuo-2.3",
+    "MiniMax-Hailuo-2.3-Fast",
+    "MiniMax-Hailuo-02",
+    "I2V-01-Director",
+    "I2V-01-live",
+    "I2V-01",
+  ],
+};
+export const MINIMAX_IMAGE_TO_VIDEO_ENDPOINTS = [
+  { region: "global_en", apiVersion: "v2", url: "https://api.minimax.io/v2/video_generation" },
+  { region: "cn_zh", apiVersion: "v2", url: "https://api.minimaxi.com/v2/video_generation" },
+  { region: "global_en", apiVersion: "v1", url: "https://api.minimax.io/v1/video_generation" },
+  { region: "cn_zh", apiVersion: "v1", url: "https://api.minimaxi.com/v1/video_generation" },
+];
 
 type JsonRecord = Record<string, unknown>;
 
@@ -757,10 +775,18 @@ export const MEDIA_EXTENSION_ACTIONS = [
     inputSchema: {
       type: "object",
       properties: {
+        provider: { type: "string", enum: ["minimax"], description: "Set to minimax to use MiniMax image-to-video generation." },
+        region: { type: "string", enum: ["global_en", "cn_zh"], description: "Optional MiniMax region. Defaults to global_en." },
         prompt: { type: "string", description: "Video prompt." },
-        model: { type: "string", description: "Optional Wan model. Defaults to wan2.6-t2v." },
+        model: { type: "string", description: "Optional video model. MiniMax defaults to MiniMax-H3." },
         imageUrl: { type: "string", description: "Optional public image URL for models that support image guidance." },
         audioUrl: { type: "string", description: "Optional public audio URL for models that support audio guidance." },
+        resolution: { type: "string", description: "Optional MiniMax output resolution." },
+        duration: { type: "integer", description: "Optional MiniMax output duration in seconds." },
+        ratio: { type: "string", enum: ["adaptive"], description: "MiniMax H3 image-to-video uses the input image ratio." },
+        promptOptimizer: { type: "boolean", description: "Optional MiniMax v1 prompt optimization setting." },
+        fastPretreatment: { type: "boolean", description: "Optional MiniMax v1 fast pretreatment setting." },
+        callbackUrl: { type: "string", description: "Optional MiniMax task callback URL." },
         parameters: { type: "object", description: "Optional documented Wan parameters such as size, duration, or prompt_extend." },
       },
       required: ["prompt"],
@@ -807,6 +833,9 @@ export const MEDIA_EXTENSION_ACTIONS = [
     inputSchema: {
       type: "object",
       properties: {
+        provider: { type: "string", enum: ["minimax"], description: "Set to minimax to query a MiniMax video task." },
+        region: { type: "string", enum: ["global_en", "cn_zh"], description: "Optional MiniMax region. Defaults to global_en." },
+        apiVersion: { type: "string", enum: ["v1", "v2"], description: "MiniMax API version used to create the task. Defaults to v2." },
         taskId: { type: "string", description: "Task id returned by a media generation or transcription action." },
       },
       required: ["taskId"],
@@ -881,9 +910,11 @@ function compatibleCosyVoiceVoice(model: string, voice: string) {
 }
 
 function taskIdFromPayload(payload: unknown): string | null {
-  if (!isRecord(payload) || !isRecord(payload.output)) return null;
-  const taskId = payload.output.task_id;
-  return typeof taskId === "string" && taskId.trim() ? taskId.trim() : null;
+  if (!isRecord(payload)) return null;
+  return readStringField(payload, "task_id")
+    || readStringField(readRecord(payload, "task"), "id")
+    || readStringField(readRecord(payload, "output"), "task_id")
+    || null;
 }
 
 function voiceIdFromPayload(payload: unknown): string {
@@ -1220,6 +1251,121 @@ async function resolveBailianCredentials(env: EnvService): Promise<{ apiKey: str
   return { apiKey, baseUrl: safeProviderBaseUrl(configuredBaseUrl) };
 }
 
+function miniMaxImageToVideoApiVersion(model: string) {
+  if (MINIMAX_IMAGE_TO_VIDEO_MODELS.v2.includes(model)) return "v2";
+  if (MINIMAX_IMAGE_TO_VIDEO_MODELS.v1.includes(model)) return "v1";
+  throw new ApiError(
+    400,
+    "invalid_minimax_video_model",
+    `MiniMax image-to-video model must be one of: ${[
+      ...MINIMAX_IMAGE_TO_VIDEO_MODELS.v2,
+      ...MINIMAX_IMAGE_TO_VIDEO_MODELS.v1,
+    ].join(", ")}`,
+  );
+}
+
+function miniMaxImageToVideoEndpoint(region: string, apiVersion: string) {
+  const endpoint = MINIMAX_IMAGE_TO_VIDEO_ENDPOINTS.find(
+    (candidate) => candidate.region === region && candidate.apiVersion === apiVersion,
+  );
+  if (!endpoint) {
+    throw new ApiError(400, "invalid_minimax_video_endpoint", "MiniMax region must be global_en or cn_zh, and API version must be v1 or v2.");
+  }
+  return endpoint;
+}
+
+async function resolveMiniMaxCredentials(env: EnvService) {
+  const records = await env.list();
+  const values = new Map(records.map((item) => [item.key, item.value.trim()]));
+  const apiKey = values.get("MINIMAX_API_KEY") || process.env.MINIMAX_API_KEY?.trim() || "";
+  if (!apiKey) {
+    throw new ApiError(400, "minimax_api_key_missing", "MiniMax API key missing. Configure MINIMAX_API_KEY before generating video.");
+  }
+  return apiKey;
+}
+
+async function requestMiniMaxVideo(input: {
+  apiKey: string;
+  url: string;
+  method?: "GET" | "POST";
+  body?: JsonRecord;
+}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), BAILIAN_REQUEST_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await mediaProviderFetch(input.url, {
+      method: input.method ?? "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiKey}`,
+        ...(input.body ? { "Content-Type": "application/json" } : {}),
+      },
+      ...(input.body ? { body: JSON.stringify(input.body) } : {}),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new ApiError(504, "minimax_video_timeout", "MiniMax video generation did not respond before the request timed out.");
+    }
+    throw new ApiError(502, "minimax_video_unreachable", "Could not reach MiniMax video generation. Check the network and try again.");
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const payload: unknown = await response.json().catch(() => null);
+  const baseResponse = readRecord(payload, "base_resp");
+  const statusCode = readOptionalNumber(baseResponse, "status_code");
+  if (!response.ok || (statusCode !== undefined && statusCode !== 0)) {
+    const message = readStringField(baseResponse, "status_msg") || providerMessage(payload);
+    const fallback = response.ok
+      ? `MiniMax video generation failed (status_code ${statusCode}).`
+      : `MiniMax video generation failed (HTTP ${response.status}).`;
+    throw new ApiError(response.ok ? 502 : response.status, "minimax_video_request_failed", message || fallback);
+  }
+  return payload;
+}
+
+function miniMaxImageToVideoBody(args: JsonRecord, model: string, apiVersion: string) {
+  const prompt = requireString(args, "prompt");
+  const imageUrl = requireString(args, "imageUrl");
+  const callbackUrl = readStringField(args, "callbackUrl");
+  if (apiVersion === "v2") {
+    const duration = boundedInteger(args, "duration", 6, 4, 15);
+    const resolution = readStringField(args, "resolution") || "2K";
+    if (resolution !== "2K") {
+      throw new ApiError(400, "invalid_minimax_video_resolution", "MiniMax H3 resolution must be 2K.");
+    }
+    return {
+      model,
+      content: [
+        { type: "text", text: prompt },
+        { type: "image_url", image_url: { url: imageUrl }, role: "first_frame" },
+      ],
+      resolution,
+      duration,
+      ratio: "adaptive",
+      ...(callbackUrl ? { callback_url: callbackUrl } : {}),
+    };
+  }
+
+  const duration = readOptionalNumber(args, "duration");
+  const resolution = readStringField(args, "resolution");
+  return {
+    model,
+    first_frame_image: imageUrl,
+    prompt,
+    ...(readOptionalBoolean(args, "promptOptimizer") === undefined
+      ? {}
+      : { prompt_optimizer: readOptionalBoolean(args, "promptOptimizer") }),
+    ...(readOptionalBoolean(args, "fastPretreatment") === undefined
+      ? {}
+      : { fast_pretreatment: readOptionalBoolean(args, "fastPretreatment") }),
+    ...(duration === undefined ? {} : { duration }),
+    ...(resolution ? { resolution } : {}),
+    ...(callbackUrl ? { callback_url: callbackUrl } : {}),
+  };
+}
+
 function endpoint(baseUrl: string, path: string): string {
   return `${baseUrl}${path}`;
 }
@@ -1520,6 +1666,51 @@ export async function callMediaExtensionAction(
         provider: "local",
         operation: action,
         output: { sourcePath: source.relativePath, ...output },
+      },
+      context,
+    };
+  }
+
+  if (readStringField(args, "provider") === "minimax") {
+    if (action !== "video_generate" && action !== "task_get") {
+      throw new ApiError(400, "unsupported_minimax_media_action", "MiniMax is not configured for this Media Center action.");
+    }
+    const region = readStringField(args, "region") || "global_en";
+    const apiKey = await resolveMiniMaxCredentials(env);
+    let apiVersion: string;
+    let providerResponse: unknown;
+    if (action === "video_generate") {
+      const model = readStringField(args, "model") || MINIMAX_IMAGE_TO_VIDEO_MODELS.defaultModel;
+      apiVersion = miniMaxImageToVideoApiVersion(model);
+      const endpoint = miniMaxImageToVideoEndpoint(region, apiVersion);
+      providerResponse = await requestMiniMaxVideo({
+        apiKey,
+        url: endpoint.url,
+        body: miniMaxImageToVideoBody(args, model, apiVersion),
+      });
+    } else {
+      apiVersion = readStringField(args, "apiVersion") || "v2";
+      const taskId = requireString(args, "taskId");
+      if (!/^[A-Za-z0-9_-]+$/.test(taskId)) {
+        throw new ApiError(400, "invalid_payload", "taskId contains unsupported characters");
+      }
+      const endpoint = miniMaxImageToVideoEndpoint(region, apiVersion);
+      const queryUrl = apiVersion === "v2"
+        ? `${new URL(endpoint.url).origin}/v2/query/video_generation/${encodeURIComponent(taskId)}`
+        : `${new URL(endpoint.url).origin}/v1/query/video_generation?task_id=${encodeURIComponent(taskId)}`;
+      providerResponse = await requestMiniMaxVideo({ apiKey, url: queryUrl, method: "GET" });
+    }
+    const result = asMediaTask(action, providerResponse);
+    return {
+      ok: true,
+      extensionId: MEDIA_EXTENSION_ID,
+      action,
+      result: {
+        provider: "minimax",
+        apiVersion,
+        operation: action,
+        ...(typeof result.taskId === "string" ? { taskId: result.taskId } : {}),
+        output: result,
       },
       context,
     };


### PR DESCRIPTION
Reason: Add the missing MiniMax image-to-video workflow to Media Center.

- Route MiniMax H3 and Hailuo image-guided requests through the matching global or China API version.
- Build first-frame request payloads and parse both v1 and v2 task responses.
- Validate required image input, model selection, regional endpoints, and provider errors before returning results.

Checks:
- `pnpm exec bun test apps/server/src/extensions/media-center.test.ts`
- `pnpm --filter ipollowork-server typecheck`
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`
- `git diff --check`

Experience proof: Incomplete. A live MiniMax credential and approved fraimz voiceover were not available in this worker, so no live provider request or fraimz artifact was produced. To reproduce, configure `MINIMAX_API_KEY`, invoke `video_generate` with `provider: "minimax"`, a prompt, and an `imageUrl`, then query the returned task with `task_get`.
