### PR TITLE
release: iPolloWork v0.21.0

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/app",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/app/tests/video-hyperframes-panel.test.ts
+++ b/apps/app/tests/video-hyperframes-panel.test.ts
@@ -214,7 +214,7 @@ describe("HyperFrames Video Studio", () => {
     expect(urlStateSource.indexOf("setRightPanelTab(\"design\")")).toBeLessThan(urlStateSource.indexOf("applyUrlSelection(command.selection)"));
   });
 
-  test("deletes selected canvas elements in place without forcing a full preview reload", () => {
+  test("deletes selected canvas elements optimistically and refreshes once after persistence", () => {
     const desktopSource = readFileSync(
       new URL("../../../apps/desktop/electron/main.mjs", import.meta.url),
       "utf8",
@@ -231,7 +231,9 @@ describe("HyperFrames Video Studio", () => {
     expect(lifecycleSource).toContain("function removeLivePreviewElement");
     expect(lifecycleSource).toContain("findElementForSelection(doc, selection, activeCompPath)");
     expect(lifecycleSource).toContain("parent.insertBefore(element, nextSibling?.parentNode === parent ? nextSibling : null)");
-    expect(lifecycleSource).toContain("if (!liveRemoval) reloadPreview()");
+    expect(lifecycleSource).toContain("const requestPreviewRefresh = () => {");
+    expect(lifecycleSource).toContain("if (!previewRefreshRequested && loadingShown)");
+    expect(lifecycleSource).not.toContain("if (!liveRemoval) reloadPreview()");
     expect(lifecycleSource).not.toContain("forceReloadSdkSession?.();\n        reloadPreview();");
     expect(commitsSource).toContain("previewIframeRef,");
     const deleteFunctionStart = desktopSource.indexOf("const deleteSelectedElement = async () => {");

--- a/apps/app/tests/work-context-entry-wiring.test.ts
+++ b/apps/app/tests/work-context-entry-wiring.test.ts
@@ -58,7 +58,7 @@ describe("personal and Enterprise chat entry wiring", () => {
   test("scopes workspaces and therefore all sessions to the active work context", () => {
     expect(routeState).toContain("canonicalWorkspacesForWorkContext(");
     expect(routeState).toContain("pruneServerWorkspacesForWorkContext(");
-    expect(routeState).toContain("workContextRef.current !== requestedContextId");
+    expect(routeState).toContain("workContextRef.current === requestedContextId");
     expect(sessionRoute).toContain("workContextId: activeWorkContextId");
     expect(sessionRoute).toContain("sessionsByWorkspaceId,");
     expect(sessionRoute).not.toContain("ChatSpace");

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/desktop",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "iPolloWork desktop shell",
   "author": {
     "name": "iPolloWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-orchestrator",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "iPolloWork host orchestrator for opencode + iPolloWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.18.16",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "ipollowork-server": "0.20.0",
+    "ipollowork-server": "0.21.0",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-server",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Filesystem-backed API for iPolloWork remote clients",
   "type": "module",
   "bin": {

--- a/apps/server/src/hyperframes-catalog.test.ts
+++ b/apps/server/src/hyperframes-catalog.test.ts
@@ -59,12 +59,12 @@ describe("HyperFrames catalog parameters", () => {
     const animations = gsapItems.filter((item) => item.kind === "animation");
     const effects = gsapItems.filter((item) => item.kind === "effect");
 
-    expect(gsapItems).toHaveLength(167);
+    expect(gsapItems).toHaveLength(163);
     expect(animations).toHaveLength(74);
-    expect(effects).toHaveLength(93);
+    expect(effects).toHaveLength(89);
     expect(gsapItems.filter((item) => item.source?.provider === "gsap-docs")).toHaveLength(25);
-    expect(gsapItems.filter((item) => item.source?.provider === "hyperframes")).toHaveLength(126);
-    expect(gsapItems.filter((item) => item.source?.provider === "ipollowork")).toHaveLength(16);
+    expect(gsapItems.filter((item) => item.source?.provider === "hyperframes")).toHaveLength(111);
+    expect(gsapItems.filter((item) => item.source?.provider === "ipollowork")).toHaveLength(27);
     expect(gsapItems.find((item) => item.name === "app-showcase")?.engine?.version).toBe("3.14.2");
     expect(
       gsapItems.find((item) => item.name === "gsap-scrolltrigger-story")?.engine?.plugins,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       ipollowork-server:
-        specifier: 0.20.0
+        specifier: 0.21.0
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
## Changes
- align stale Enterprise workspace and Video Studio test contracts with the current merged runtime behavior
- align the HyperFrames catalog snapshot with the migrated bundled catalog
- bump app, desktop, orchestrator, server, and lockfile versions to 0.21.0

## Why
Prepare the latest main branch for the next stable iPolloWork desktop release.

## User impact
Publishes the current main branch as iPolloWork v0.21.0 across macOS, Linux, and Windows, with matching updater and sidecar artifacts.

## Validation
- node scripts/release/verify-tag.mjs --tag v0.21.0
- node scripts/release/review.mjs --strict
- ./ipollowork check
- app tests: 717 passed
- server tests: 434 passed, 2 environment-dependent tests skipped
- orchestrator typecheck
- ./ipollowork build
- orchestrator sidecars built and reviewed for all supported targets
- git diff --check