### PR TITLE
fix: keep new sessions in active project group

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -64,7 +64,7 @@ import { RenameSessionModal } from "../modals/rename-session-modal";
 import { AppSidebar } from "../sidebar/app-sidebar";
 import type { iPolloWorkSessionType, iPolloWorkTemplateId } from "../sidebar/app-sidebar-provider";
 import { readSessionType, sessionTypeForTemplate, setSessionType } from "../sidebar/session-type";
-import { useSessionManagementStore } from "../sidebar/session-management-store";
+import { useSessionManagementStore, useActiveWorkspaceGroupId } from "../sidebar/session-management-store";
 import { SessionSurface, type SessionSurfaceProps } from "../surface/session-surface";
 import { replaceDesignSelectionToken } from "../surface/composer/composer-draft";
 import { getComposerDraft, useComposerStateStore } from "../surface/composer-state-store";
@@ -181,11 +181,13 @@ export type SessionPageSidebarProps = {
     type?: iPolloWorkSessionType,
     templateId?: iPolloWorkTemplateId,
     templateScope?: WorkContextId,
+    groupId?: string | null,
   ) => Promise<string | null> | string | null | void;
   onCreateTaskWithPrompt?: (workspaceId: string, prompt: string) => void;
   onCreateTemplateAuthoring: (
     workspaceId: string,
     input: { category: TemplateCategory; pptxCompatibility?: PptxCompatibility },
+    groupId?: string | null,
   ) => Promise<string | null> | string | null | void;
   onRecoverWorkspace: (workspaceId: string) => Promise<boolean> | boolean | void;
   onTestWorkspaceConnection: (workspaceId: string) => Promise<boolean> | boolean | void;
@@ -625,6 +627,7 @@ export function SessionPage(props: SessionPageProps) {
       ? readSessionType(props.selectedSessionId)
       : null
   ), [props.selectedSessionId, sessionTypeRevision]);
+  const activeSessionGroupId = useActiveWorkspaceGroupId(props.selectedWorkspaceId);
   const isDesignSession = selectedSessionType === "design";
   const isVideoSession = selectedSessionType === "video";
   const currentVideoEntryPath = props.selectedSessionId && isVideoSession
@@ -2725,6 +2728,7 @@ export function SessionPage(props: SessionPageProps) {
                           type,
                           templateId,
                           PERSONAL_WORK_CONTEXT_ID,
+                          activeSessionGroupId,
                         )}
                         onMaterializeTemplate={async (templateId, surface) => {
                           if (!props.ipolloworkServerClient || !props.runtimeWorkspaceId || !props.selectedSessionId) return;
@@ -3012,7 +3016,7 @@ export function SessionPage(props: SessionPageProps) {
         onExport={(template) => void exportPersonalTemplate(template)}
         onImport={importDesignTemplate}
         canCreate={props.selectedWorkspaceDisplay.workspaceType === "local"}
-        onCreate={(input) => props.sidebar.onCreateTemplateAuthoring(props.selectedWorkspaceId, input)}
+        onCreate={(input) => props.sidebar.onCreateTemplateAuthoring(props.selectedWorkspaceId, input, activeSessionGroupId)}
         onUse={(template) => {
           if (template.manifest.surface === "video" && props.selectedWorkspaceDisplay.workspaceType === "remote") {
             toast.error(t("templates.video_local_only"));
@@ -3024,6 +3028,7 @@ export function SessionPage(props: SessionPageProps) {
             sessionTypeForTemplate(template.manifest),
             template.manifest.id,
             templateResourceScope,
+            activeSessionGroupId,
           );
         }}
       /> : null}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -25,6 +25,7 @@ export type SidebarContextValue = {
     type?: iPolloWorkSessionType,
     templateId?: iPolloWorkTemplateId,
     templateScope?: WorkContextId,
+    groupId?: string | null,
   ) => Promise<string | null> | string | null | void;
   onOpenRenameSession?: (sessionId: string) => void;
   onOpenDeleteSession?: (sessionId: string) => void;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -96,6 +96,7 @@ import {
 import type { FlattenedSessionRow, SessionListItem, SessionTreeState } from "./utils";
 import {
   useSessionManagementStore,
+  useActiveWorkspaceGroupId,
   usePinnedSessionIds,
   useSessionOrder,
   useWorkspaceGroups,
@@ -493,6 +494,7 @@ export type AppSidebarProps = {
     type?: iPolloWorkSessionType,
     templateId?: iPolloWorkTemplateId,
     templateScope?: WorkContextId,
+    groupId?: string | null,
   ) => Promise<string | null> | string | null | void;
   onOpenRenameSession?: (sessionId: string) => void;
   onOpenDeleteSession?: (sessionId: string) => void;
@@ -627,6 +629,7 @@ export function AppSidebar(props: AppSidebarProps) {
     ? activeEnterprise.logoUrl ?? DEFAULT_BRAND_LOGO_URL
     : brandLogoUrl ?? shellConfig.brandLogoDataUrl ?? DEFAULT_BRAND_LOGO_URL;
   const effectiveBrandAppName = activeEnterprise?.name ?? brandAppName;
+  const activeSessionGroupId = useActiveWorkspaceGroupId(props.selectedWorkspaceId);
   const sidebarWorkspaceSessionGroups = React.useMemo(() => {
     const selectedGroup = props.workspaceSessionGroups.find(
       (entry) => entry.workspace.id === props.selectedWorkspaceId,
@@ -686,7 +689,7 @@ export function AppSidebar(props: AppSidebarProps) {
                 disabled={props.newTaskDisabled || !props.selectedWorkspaceId}
                 aria-label={t("session.new_task")}
                 aria-keyshortcuts={isMacPlatform() ? "Meta+N" : "Control+N"}
-                onClick={() => props.onCreateTaskInWorkspace(props.selectedWorkspaceId, "work")}
+                onClick={() => props.onCreateTaskInWorkspace(props.selectedWorkspaceId, "work", undefined, undefined, activeSessionGroupId)}
               >
                 <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
                   <img src={publicAssetUrl("sidebar-icon/figma-square-pen.svg")} alt="" className="size-[11px] dark:invert" />
@@ -868,6 +871,7 @@ function WorkspaceSidebarGroup({
   const pinnedIds = usePinnedSessionIds();
   const orderIds = useSessionOrder(workspace.id);
   const { groups: wsGroups, assignments: wsAssignments } = useWorkspaceGroups(workspace.id);
+  const activeSessionGroupId = useActiveWorkspaceGroupId(workspace.id);
   const store = useSessionManagementStore;
 
   const { archived: archivedSessions } = React.useMemo(
@@ -925,6 +929,7 @@ function WorkspaceSidebarGroup({
                       workspaceId={workspace.id}
                       forcedExpandedSessionIds={forcedExpandedSessionIds}
                       store={store}
+                      activeSessionGroupId={activeSessionGroupId}
                     />
                     {archivedSessions.length > 0 ? (
                       <ArchivedSessionsSection
@@ -1038,9 +1043,10 @@ function SidebarSectionHeader({ label, expanded, onToggle, onAdd, addDisabled, a
   );
 }
 
-function SessionGroupSeparator({ label, expanded, onToggle, onAdd, addDisabled, onRename, onRemove, onTitlePointerDown }: {
+function SessionGroupSeparator({ label, expanded, isActive, onToggle, onAdd, addDisabled, onRename, onRemove, onTitlePointerDown }: {
   label: string;
   expanded: boolean;
+  isActive: boolean;
   onToggle: () => void;
   onAdd: () => void;
   addDisabled?: boolean;
@@ -1049,7 +1055,7 @@ function SessionGroupSeparator({ label, expanded, onToggle, onAdd, addDisabled, 
   onTitlePointerDown?: React.PointerEventHandler<HTMLButtonElement>;
 }) {
   return (
-    <div className="group/session-group-row flex h-8 w-full items-center justify-between rounded-[8px] px-1 transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent focus-within:ring-1 focus-within:ring-sidebar-ring">
+    <div className={cn("group/session-group-row flex h-8 w-full items-center justify-between rounded-[8px] px-1 transition-colors hover:bg-sidebar-accent active:bg-sidebar-accent focus-within:ring-1 focus-within:ring-sidebar-ring", isActive && "bg-sidebar-accent ring-1 ring-sidebar-ring")}>
       <button
         type="button"
         onClick={onToggle}
@@ -1152,7 +1158,7 @@ function GroupDropZone({ groupId, workspaceId, children }: {
 }
 
 /** Renders sessions partitioned by group. Empty groups always show. Ungrouped sessions render at the end. */
-function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree, workspaceId, forcedExpandedSessionIds, store }: {
+function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree, workspaceId, forcedExpandedSessionIds, store, activeSessionGroupId }: {
   sessionRows: FlattenedSessionRow[];
   groups: SessionGroupDefinition[];
   assignments: Record<string, string>;
@@ -1161,6 +1167,7 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
   workspaceId: string;
   forcedExpandedSessionIds: Set<string>;
   store: typeof useSessionManagementStore;
+  activeSessionGroupId: string | null;
 }) {
   const ctx = useSidebarContext();
   const [programExpanded, setProgramExpanded] = React.useState(true);
@@ -1218,7 +1225,7 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
   for (const rows of childrenByParent.values()) rows.sort(compareByMostRecent);
   ungroupedRows.sort(compareByMostRecent);
 
-  const renderRow = (row: FlattenedSessionRow) => (
+  const renderRow = (row: FlattenedSessionRow, groupContextId?: string | null) => (
     <React.Fragment key={row.session.id}>
       <SessionMenuItem
         session={row.session}
@@ -1228,8 +1235,9 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
         forcedExpandedSessionIds={forcedExpandedSessionIds}
         isPinned={pinnedIds.has(row.session.id)}
         rootIndent="group"
+        groupContextId={groupContextId}
       />
-      {(childrenByParent.get(row.session.id) ?? []).map(renderRow)}
+      {(childrenByParent.get(row.session.id) ?? []).map((child) => renderRow(child, groupContextId))}
     </React.Fragment>
   );
 
@@ -1246,6 +1254,7 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
         expanded={expanded}
         workspaceId={workspaceId}
         store={store}
+        activeSessionGroupId={activeSessionGroupId}
         renderRow={renderRow}
         previewCount={limit}
         onShowMore={() => showMoreInGroup(group.id, rows.length)}
@@ -1359,8 +1368,9 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
                       isPinned={pinnedIds.has(row.session.id)}
                       draggable={row.depth === 0}
                       rootIndent="recent"
+                      groupContextId={null}
                     />
-                    {(childrenByParent.get(row.session.id) ?? []).map(renderRow)}
+                    {(childrenByParent.get(row.session.id) ?? []).map((child) => renderRow(child, null))}
                   </React.Fragment>
                 ))}
               </Reorder.Group>
@@ -1384,13 +1394,14 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
   );
 }
 
-function SessionGroupSection({ group, rows, expanded, workspaceId, store, renderRow, previewCount, onShowMore }: {
+function SessionGroupSection({ group, rows, expanded, workspaceId, store, activeSessionGroupId, renderRow, previewCount, onShowMore }: {
   group: SessionGroupDefinition;
   rows: FlattenedSessionRow[];
   expanded: boolean;
   workspaceId: string;
   store: typeof useSessionManagementStore;
-  renderRow: (row: FlattenedSessionRow) => React.ReactNode;
+  activeSessionGroupId: string | null;
+  renderRow: (row: FlattenedSessionRow, groupContextId?: string | null) => React.ReactNode;
   previewCount: number;
   onShowMore: () => void;
 }) {
@@ -1419,8 +1430,13 @@ function SessionGroupSection({ group, rows, expanded, workspaceId, store, render
           <SessionGroupSeparator
             label={group.label}
             expanded={expanded}
-            onToggle={() => store.getState().toggleGroupExpanded(workspaceId, group.id)}
+            isActive={activeSessionGroupId === group.id}
+            onToggle={() => {
+              store.getState().setActiveGroup(workspaceId, group.id);
+              store.getState().toggleGroupExpanded(workspaceId, group.id);
+            }}
             onAdd={() => {
+              store.getState().setActiveGroup(workspaceId, group.id);
               void Promise.resolve(ctx.onCreateTaskInWorkspace(workspaceId, "work")).then((sessionId) => {
                 if (sessionId) store.getState().assignGroup(workspaceId, sessionId, group.id);
               });
@@ -1434,7 +1450,7 @@ function SessionGroupSection({ group, rows, expanded, workspaceId, store, render
             {visibleRows.length > 0
               ? (
                 <>
-                  {visibleRows.map(renderRow)}
+                  {visibleRows.map((row) => renderRow(row, group.id))}
                   {remaining > 0 ? (
                     <SidebarMenuSubItem>
                       <SidebarMenuSubButton
@@ -1482,6 +1498,7 @@ type SessionMenuItemProps = {
   isPinned?: boolean;
   draggable?: boolean;
   rootIndent?: "group" | "recent";
+  groupContextId?: string | null;
 };
 
 function SessionMenuItem({
@@ -1493,6 +1510,7 @@ function SessionMenuItem({
   isPinned = false,
   draggable = false,
   rootIndent,
+  groupContextId,
 }: SessionMenuItemProps) {
   const ctx = useSidebarContext();
   const isSelected = ctx.selectedSessionId === session.id;
@@ -1509,6 +1527,11 @@ function SessionMenuItem({
   const sessionFontWeight = ctx.language === "zh" ? "font-medium" : "font-normal";
 
   const openSession = () => {
+    const store = useSessionManagementStore.getState();
+    const groupId = groupContextId !== undefined
+      ? groupContextId
+      : store.groupsByWorkspace[workspaceId]?.assignments[session.id] ?? null;
+    store.setActiveGroup(workspaceId, groupId);
     ctx.onOpenSession(workspaceId, session.id);
   };
 

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -58,12 +58,14 @@ type SessionManagementState = {
   pinnedIds: string[];
   orderByWorkspace: Record<string, string[]>;
   groupsByWorkspace: Record<string, WorkspaceGroupState>;
+  activeGroupByWorkspace: Record<string, string>;
 };
 
 type SessionManagementActions = {
   togglePin: (sessionId: string) => void;
   reorderSessions: (workspaceId: string, sessionIds: string[]) => void;
   assignGroup: (workspaceId: string, sessionId: string, groupId: string | null) => void;
+  setActiveGroup: (workspaceId: string, groupId: string | null) => void;
   createGroup: (workspaceId: string, label: string) => void;
   reorderGroups: (workspaceId: string, groupIds: string[]) => void;
   renameGroup: (workspaceId: string, groupId: string, label: string) => void;
@@ -170,6 +172,7 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
       pinnedIds: [],
       orderByWorkspace: {},
       groupsByWorkspace: {},
+      activeGroupByWorkspace: {},
 
       togglePin: (sessionId) =>
         set((state) => {
@@ -208,6 +211,21 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
           workspaceId,
         );
       },
+
+      setActiveGroup: (workspaceId, groupId) =>
+        set((state) => {
+          const ws = state.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
+          if (groupId && ws.groups.some((group) => group.id === groupId)) {
+            return {
+              activeGroupByWorkspace: {
+                ...state.activeGroupByWorkspace,
+                [workspaceId]: groupId,
+              },
+            };
+          }
+          const { [workspaceId]: _active, ...rest } = state.activeGroupByWorkspace;
+          return { activeGroupByWorkspace: rest };
+        }),
 
       createGroup: (workspaceId, label) => {
         const id = `grp_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
@@ -291,6 +309,11 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
           const collapsedGroupIds = (ws.collapsedGroupIds ?? []).filter(
             (id) => id === "__ipollowork_ungrouped" || knownGroupIds.has(id),
           );
+          const activeGroupByWorkspace = knownGroupIds.has(state.activeGroupByWorkspace[workspaceId] ?? "")
+            ? state.activeGroupByWorkspace
+            : Object.fromEntries(
+                Object.entries(state.activeGroupByWorkspace).filter(([id]) => id !== workspaceId),
+              );
           return {
             groupsByWorkspace: {
               ...state.groupsByWorkspace,
@@ -300,6 +323,7 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
                 collapsedGroupIds,
               },
             },
+            activeGroupByWorkspace,
           };
         }),
 
@@ -318,6 +342,11 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
               ...state.groupsByWorkspace,
               [workspaceId]: { groups, assignments, collapsedGroupIds },
             },
+            activeGroupByWorkspace: state.activeGroupByWorkspace[workspaceId] === groupId
+              ? Object.fromEntries(
+                  Object.entries(state.activeGroupByWorkspace).filter(([id]) => id !== workspaceId),
+                )
+              : state.activeGroupByWorkspace,
           };
         });
         syncServerState(sessionGroupSyncHandler?.removeGroup(workspaceId, groupId), workspaceId);
@@ -327,7 +356,8 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
         set((state) => {
           const { [workspaceId]: _o, ...orderRest } = state.orderByWorkspace;
           const { [workspaceId]: _g, ...groupsRest } = state.groupsByWorkspace;
-          return { orderByWorkspace: orderRest, groupsByWorkspace: groupsRest };
+          const { [workspaceId]: _active, ...activeRest } = state.activeGroupByWorkspace;
+          return { orderByWorkspace: orderRest, groupsByWorkspace: groupsRest, activeGroupByWorkspace: activeRest };
         }),
     }),
     {
@@ -357,4 +387,13 @@ export function useSessionOrder(workspaceId: string): string[] {
 
 export function useWorkspaceGroups(workspaceId: string): WorkspaceGroupState {
   return useSessionManagementStore((s) => s.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE);
+}
+
+export function useActiveWorkspaceGroupId(workspaceId: string): string | null {
+  return useSessionManagementStore((s) => {
+    const groupId = s.activeGroupByWorkspace[workspaceId] ?? null;
+    if (!groupId) return null;
+    const ws = s.groupsByWorkspace[workspaceId] ?? EMPTY_GROUP_STATE;
+    return ws.groups.some((group) => group.id === groupId) ? groupId : null;
+  });
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1182,6 +1182,7 @@ export function SessionRoute() {
     type: iPolloWorkSessionType = "work",
     templateId?: iPolloWorkTemplateId,
     templateScope?: WorkContextId,
+    groupId?: string | null,
     authoring?: { category: TemplateCategory; pptxCompatibility?: PptxCompatibility },
   ): Promise<string | null> => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
@@ -1240,6 +1241,9 @@ export function SessionRoute() {
         }
       }
       setSessionType(session.id, sessionType);
+      if (groupId?.trim()) {
+        sessionManagementStore.getState().assignGroup(workspaceId, session.id, groupId);
+      }
       captureAnalyticsEvent("task_created", {
         source: "new_task",
         workspace_type: workspace.workspaceType ?? "unknown",
@@ -1291,7 +1295,7 @@ export function SessionRoute() {
           description: message,
           action: {
             label: "Retry",
-            onClick: () => void handleCreateTaskInWorkspace(workspaceId, type, templateId, templateScope, authoring),
+            onClick: () => void handleCreateTaskInWorkspace(workspaceId, type, templateId, templateScope, groupId, authoring),
           },
           duration: Infinity,
         });
@@ -1304,7 +1308,7 @@ export function SessionRoute() {
         description: message,
         action: {
           label: "Retry",
-          onClick: () => void handleCreateTaskInWorkspace(workspaceId, type, templateId, templateScope),
+          onClick: () => void handleCreateTaskInWorkspace(workspaceId, type, templateId, templateScope, groupId),
         },
         duration: Infinity,
       });
@@ -1781,10 +1785,10 @@ export function SessionRoute() {
           navigateToWorkspaceSession(workspaceId, sessionId);
         },
         onPrefetchSession: () => {},
-        onCreateTaskInWorkspace: (workspaceId, type, templateId, templateScope) =>
-          handleCreateTaskInWorkspace(workspaceId, type, templateId, templateScope),
-        onCreateTemplateAuthoring: (workspaceId, input) =>
-          handleCreateTaskInWorkspace(workspaceId, "work", undefined, undefined, input),
+        onCreateTaskInWorkspace: (workspaceId, type, templateId, templateScope, groupId) =>
+          handleCreateTaskInWorkspace(workspaceId, type, templateId, templateScope, groupId),
+        onCreateTemplateAuthoring: (workspaceId, input, groupId) =>
+          handleCreateTaskInWorkspace(workspaceId, "work", undefined, undefined, groupId, input),
         onCreateTaskWithPrompt: (workspaceId, prompt) => {
           void (async () => {
             const workspace = workspaces.find((item) => item.id === workspaceId);

--- a/apps/app/tests/sidebar-program-sections.test.ts
+++ b/apps/app/tests/sidebar-program-sections.test.ts
@@ -53,6 +53,18 @@ describe("sidebar Program and Ungrouped sections", () => {
     expect(sidebarSource).toContain("assignGroup(workspaceId, sessionId, group.id)");
   });
 
+  test("keeps global new conversations and template launches in the active project group", () => {
+    expect(storeSource).toContain("activeGroupByWorkspace: Record<string, string>;");
+    expect(storeSource).toContain("setActiveGroup: (workspaceId: string, groupId: string | null) => void;");
+    expect(sidebarSource).toContain("const activeSessionGroupId = useActiveWorkspaceGroupId(props.selectedWorkspaceId)");
+    expect(sidebarSource).toContain("isActive={activeSessionGroupId === group.id}");
+    expect(sidebarSource).toContain("setActiveGroup(workspaceId, group.id)");
+    expect(sidebarSource).toContain('props.onCreateTaskInWorkspace(props.selectedWorkspaceId, "work", undefined, undefined, activeSessionGroupId)');
+    expect(sessionPageSource).toContain("const activeSessionGroupId = useActiveWorkspaceGroupId(props.selectedWorkspaceId)");
+    expect(sessionPageSource).toContain("templateResourceScope,\n            activeSessionGroupId,");
+    expect(sessionPageSource).toContain("props.sidebar.onCreateTemplateAuthoring(props.selectedWorkspaceId, input, activeSessionGroupId)");
+  });
+
   test("reveals section and conversation actions only during interaction", () => {
     expect(sidebarSource).toContain("group-hover/section-header:opacity-100");
     expect(sidebarSource).toContain("group-focus-within/section-header:opacity-100");


### PR DESCRIPTION
## Summary

Fix session creation behavior for project folders.

When a user selects a project folder in the sidebar, the selected folder now remains active even after focusing the chat composer. New sessions created from the global new-session button or Template Market are assigned to the active project folder instead of falling back to Ungrouped.

## Changes

- Track the active project group per workspace.
- Keep sidebar project folder selection persistent after composer focus.
- Pass the active group id through new session and template authoring flows.
- Assign newly created sessions/templates to the active project folder.
- Add regression coverage for active project group creation behavior.

## Testing

```bash
bun.exe test apps/app/tests/sidebar-program-sections.test.ts apps/app/tests/template-market-actions.test.ts apps/app/tests/work-context-entry-wiring.test.ts