### PR TITLE
fix: raise macOS release file limit

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -421,6 +421,7 @@ jobs:
           APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
         run: |
           set -euo pipefail
+          ulimit -n 65536
           pnpm --dir apps/desktop exec electron-builder \
             --config electron-builder.yml \
             ${{ matrix.electron_args }} \


### PR DESCRIPTION
## What changed

Raise the macOS packaging step file-descriptor limit to 65536 before electron-builder signs the app.

## Why

The v0.21.1 Apple Silicon release build reached the default macOS runner limit while signing the bundled DeepSeek Harness runtime and failed with EMFILE: too many open files. The certificate and notarization credentials were accepted correctly.

## Impact

Release workflow only. No client code, runtime behavior, package content, Design, Video, template, plugin, or Skill behavior changes.

## Verification

- Failure root cause confirmed from GitHub job 94722459036.
- Workflow YAML parses successfully.
- Maintainability audit passed.
- Git diff check passed.