### PR TITLE
feat: add DeepSeek Design public repository mirror

### DIFF
--- a/.github/workflows/ci-dsh-design-studio.yml
+++ b/.github/workflows/ci-dsh-design-studio.yml
@@ -1,34 +1,41 @@
-name: DeepSeek Harness iDesign external plugin
+name: DeepSeek Harness Studio plugins
 
 on:
   push:
     branches: [main, dev]
     paths:
-      - "external-plugins/deepseek-harness/design-studio/**"
+      - "external-plugins/deepseek-harness/**"
       - "packages/design-studio/**"
-      - "apps/app/src/react-app/domains/session/design/**"
+      - "packages/types/**"
+      - "apps/app/src/**"
+      - "apps/server/bundled-templates/**"
+      - "scripts/export-deepseek-design-repository.mjs"
       - ".github/workflows/ci-dsh-design-studio.yml"
     tags:
       - "deepseek-idesign-v*"
+      - "deepseek-ippt-v*"
   pull_request:
     branches: [main, dev]
     paths:
-      - "external-plugins/deepseek-harness/design-studio/**"
+      - "external-plugins/deepseek-harness/**"
       - "packages/design-studio/**"
-      - "apps/app/src/react-app/domains/session/design/**"
+      - "packages/types/**"
+      - "apps/app/src/**"
+      - "apps/server/bundled-templates/**"
+      - "scripts/export-deepseek-design-repository.mjs"
       - ".github/workflows/ci-dsh-design-studio.yml"
 
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: external-plugins/deepseek-harness/design-studio
-
 jobs:
   check:
-    name: Build and inspect package
+    name: Build ${{ matrix.package }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [design-studio, ppt-studio]
 
     steps:
       - name: Checkout
@@ -43,25 +50,24 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           cache: pnpm
 
       - name: Install iPolloWork workspace
-        run: pnpm --dir ../../.. install --frozen-lockfile
-
-      - name: Install plugin workspace
         run: pnpm install --frozen-lockfile
 
-      - name: Typecheck and build
-        run: pnpm run check && pnpm run build
+      - name: Install plugin workspace
+        run: pnpm --dir external-plugins/deepseek-harness/${{ matrix.package }} install --frozen-lockfile
 
-      - name: Dry-run publish
-        run: npm publish --dry-run --access public
+      - name: Typecheck and package
+        run: |
+          mkdir -p "${RUNNER_TEMP}/packages"
+          pnpm --dir external-plugins/deepseek-harness/${{ matrix.package }} run check
+          pnpm --dir external-plugins/deepseek-harness/${{ matrix.package }} pack --pack-destination "${RUNNER_TEMP}/packages"
 
   publish:
-    name: Publish to npm
+    name: Publish tagged package to npm
     needs: check
-    if: startsWith(github.ref, 'refs/tags/deepseek-idesign-v')
+    if: startsWith(github.ref, 'refs/tags/deepseek-idesign-v') || startsWith(github.ref, 'refs/tags/deepseek-ippt-v')
     runs-on: ubuntu-latest
 
     permissions:
@@ -84,13 +90,29 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: pnpm
 
-      - name: Install iPolloWork workspace
-        run: pnpm --dir ../../.. install --frozen-lockfile
+      - name: Resolve tagged package
+        id: package
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          if [[ "${RELEASE_TAG}" == deepseek-idesign-v* ]]; then
+            package_directory="external-plugins/deepseek-harness/design-studio"
+            tag_version="${RELEASE_TAG#deepseek-idesign-v}"
+          else
+            package_directory="external-plugins/deepseek-harness/ppt-studio"
+            tag_version="${RELEASE_TAG#deepseek-ippt-v}"
+          fi
+          package_version="$(node -p "require('./${package_directory}/package.json').version")"
+          test "${package_version}" = "${tag_version}"
+          echo "directory=${package_directory}" >> "${GITHUB_OUTPUT}"
 
-      - name: Install plugin workspace
+      - name: Install iPolloWork workspace
         run: pnpm install --frozen-lockfile
 
+      - name: Install plugin workspace
+        run: pnpm --dir "${{ steps.package.outputs.directory }}" install --frozen-lockfile
+
       - name: Publish
-        run: npm publish --access public --provenance
+        run: pnpm --dir "${{ steps.package.outputs.directory }}" publish --access public --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/sync-deepseek-design.yml
+++ b/.github/workflows/sync-deepseek-design.yml
@@ -1,0 +1,104 @@
+name: Sync DeepSeek Design repository
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "external-plugins/deepseek-harness/**"
+      - "packages/design-studio/**"
+      - "packages/types/**"
+      - "apps/app/src/**"
+      - "apps/server/bundled-templates/**"
+      - "LICENSE"
+      - "LICENSES/**"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
+      - "SECURITY.md"
+      - "scripts/export-deepseek-design-repository.mjs"
+      - ".github/workflows/sync-deepseek-design.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-deepseek-design
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Build and synchronize public mirror
+    if: github.repository == 'Devin-AXIS/iPolloWork'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout iPolloWork
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install iPolloWork workspace
+        run: pnpm install --frozen-lockfile
+
+      - name: Install plugin workspaces
+        run: |
+          pnpm --dir external-plugins/deepseek-harness/design-studio install --frozen-lockfile
+          pnpm --dir external-plugins/deepseek-harness/ppt-studio install --frozen-lockfile
+
+      - name: Build runnable packages
+        run: |
+          mkdir -p "${RUNNER_TEMP}/deepseek-design-packages"
+          pnpm --dir external-plugins/deepseek-harness/design-studio run check
+          pnpm --dir external-plugins/deepseek-harness/design-studio pack --pack-destination "${RUNNER_TEMP}/deepseek-design-packages"
+          pnpm --dir external-plugins/deepseek-harness/ppt-studio run check
+          pnpm --dir external-plugins/deepseek-harness/ppt-studio pack --pack-destination "${RUNNER_TEMP}/deepseek-design-packages"
+
+      - name: Configure repository deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.DEEPSEEK_DESIGN_DEPLOY_KEY }}
+        run: |
+          test -n "${DEPLOY_KEY}"
+          install -m 700 -d "${RUNNER_TEMP}/deepseek-design-ssh"
+          printf '%s\n' "${DEPLOY_KEY}" > "${RUNNER_TEMP}/deepseek-design-ssh/id_ed25519"
+          chmod 600 "${RUNNER_TEMP}/deepseek-design-ssh/id_ed25519"
+          ssh-keyscan github.com > "${RUNNER_TEMP}/deepseek-design-ssh/known_hosts"
+          echo "GIT_SSH_COMMAND=ssh -i ${RUNNER_TEMP}/deepseek-design-ssh/id_ed25519 -o IdentitiesOnly=yes -o UserKnownHostsFile=${RUNNER_TEMP}/deepseek-design-ssh/known_hosts" >> "${GITHUB_ENV}"
+
+      - name: Export public repository
+        run: |
+          git clone git@github.com:Devin-AXIS/deepseek-design.git "${RUNNER_TEMP}/deepseek-design"
+          idesign_tarball="$(find "${RUNNER_TEMP}/deepseek-design-packages" -maxdepth 1 -name 'deepseek-idesign-*.tgz' -print -quit)"
+          ippt_tarball="$(find "${RUNNER_TEMP}/deepseek-design-packages" -maxdepth 1 -name 'deepseek-ippt-*.tgz' -print -quit)"
+          test -n "${idesign_tarball}"
+          test -n "${ippt_tarball}"
+          pnpm export:deepseek-design -- \
+            --output "${RUNNER_TEMP}/deepseek-design" \
+            --idesign "${idesign_tarball}" \
+            --ippt "${ippt_tarball}"
+
+      - name: Push synchronized snapshot
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          git -C "${RUNNER_TEMP}/deepseek-design" config user.name "iPolloWork Sync"
+          git -C "${RUNNER_TEMP}/deepseek-design" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "${RUNNER_TEMP}/deepseek-design" add --all
+          if git -C "${RUNNER_TEMP}/deepseek-design" diff --cached --quiet; then
+            echo "DeepSeek Design is already synchronized."
+            exit 0
+          fi
+          git -C "${RUNNER_TEMP}/deepseek-design" commit -m "sync: iPolloWork ${SOURCE_SHA:0:12}"
+          git -C "${RUNNER_TEMP}/deepseek-design" push origin main
+
+      - name: Remove deploy key
+        if: always()
+        run: rm -f "${RUNNER_TEMP}/deepseek-design-ssh/id_ed25519"

--- a/external-plugins/deepseek-harness/README.md
+++ b/external-plugins/deepseek-harness/README.md
@@ -1,0 +1,42 @@
+# DeepSeek Design
+
+Native iPolloWork Design and PPT Studios for DeepSeek Harness.
+
+This directory is the source of two independently installed plugins:
+
+- [`deepseek-idesign`](https://www.npmjs.com/package/deepseek-idesign) — websites, app prototypes, posters,
+  information cards, reports, magazines, and other non-slide designs.
+- [`deepseek-ippt`](https://www.npmjs.com/package/deepseek-ippt) — presentations and slide templates only.
+
+## Install
+
+```sh
+dsh plugin --profile web add deepseek-idesign
+dsh plugin --profile web add deepseek-ippt
+dsh --profile web
+```
+
+Install either package or both. Each one contains its browser assets and does
+not install the iPolloWork desktop app.
+
+## One source, two entry points
+
+The iPolloWork repository is the only source of truth for product code. Every
+change to the shared Design Studio is built once and flows to both DeepSeek
+plugins. The public
+[`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) repository is
+an automatically generated distribution mirror: it provides complete runnable
+packages, source references, issues, and a focused discovery page without
+creating a second implementation to maintain.
+
+## License
+
+These plugins use the same iPolloWork Source Available License as the main
+repository. Third-party components and previously licensed portions retain
+their respective licenses.
+
+---
+
+DeepSeek Design 将 iPolloWork 的 Design Studio 与 PPT Studio 作为两个可独立安装
+的 DeepSeek Harness 插件提供。产品代码只在 iPolloWork 主库维护；公开的
+`deepseek-design` 仓库由主库自动生成和同步，不会形成两套代码。

--- a/external-plugins/deepseek-harness/design-studio/LICENSE
+++ b/external-plugins/deepseek-harness/design-studio/LICENSE
@@ -1,0 +1,145 @@
+iPolloWork Source Available License
+Version 1.0, 13 July 2026
+
+Copyright (c) 2026 Different AI, Inc. All rights reserved.
+
+By using, copying, modifying, or distributing the Software, You accept this
+License.
+
+1. License Grant
+
+Subject to this License, the Licensor grants You a non-exclusive,
+royalty-free, worldwide, non-sublicensable, and non-transferable license to
+use, copy, modify, and distribute the Software solely as permitted below.
+
+2. Permitted Uses
+
+You may use and modify the Software without prior written authorization only
+for the limited uses below:
+
+  a. Individual Personal Use by one natural person for that person's own
+     non-commercial work, learning, research, evaluation, or testing; and
+  b. Small Internal Use by fewer than three total Users solely for internal,
+     non-commercial evaluation, testing, or operations.
+
+Small Internal Use is permitted only when the Software and its functionality
+are not sold, hosted for, provided to, or otherwise made available to
+customers, clients, or other external third parties. The three-User threshold
+is measured across all people who access, operate, deploy, administer, or
+benefit from a shared deployment of the Software, whether they are employees,
+contractors, founders, collaborators, or other personnel.
+
+3. Prior Written Authorization Required
+
+You must obtain prior written authorization from the Licensor before You do
+any of the following:
+
+  a. use the Software with three or more total Users, regardless of whether
+     the use is personal, internal, commercial, non-commercial, individual,
+     organizational, hosted, local, private, or public;
+  b. provide the Software or its functionality to any external third party as
+     a hosted, managed, cloud, SaaS, single-tenant, or multi-tenant service;
+  c. sell, rent, lease, sublicense, resell, or distribute the Software for a
+     fee or other commercial advantage, whether by an individual or an
+     organization;
+  d. incorporate the Software as a material component of a product or service
+     offered to external third parties for revenue or other commercial
+     advantage;
+  e. use the Software to provide paid customer delivery, implementation,
+     customization, operation, consulting, or outsourcing services;
+  f. use the Software in any paid, revenue-generating, resale, white-label,
+     agency, marketplace, or customer-facing context; or
+  g. remove, alter, obscure, hide, or replace the iPolloWork brand attribution
+     required by Section 4.
+
+Written authorization may grant some or all of these rights under separate
+terms. To request authorization, contact the repository owner through
+https://github.com/Devin-AXIS/iPolloWork.
+
+4. Required Brand Attribution
+
+All copies, deployments, and modified versions of the Software must preserve
+the iPolloWork name, logo, product attribution, copyright notice, and license
+notice in the source code, documentation, about screens, settings screens, and
+other user-facing frontend displays where the Software identifies itself or is
+presented to users. You may not remove, hide, obscure, replace, or make the
+iPolloWork brand attribution materially less visible without the Licensor's
+prior written authorization.
+
+This brand attribution requirement applies to all permitted and authorized
+uses, including Individual Personal Use, Small Internal Use, internal
+deployments, modified versions, and any separately authorized commercial use,
+unless the written authorization expressly permits different branding.
+
+5. Non-Commercial Redistribution
+
+You may distribute unmodified or modified copies of the Software only free of
+charge and for non-commercial purposes. Every copy must include this License
+and all copyright, attribution, trademark, and third-party notices. Modified
+copies must prominently state that You changed the Software. You may not
+impose terms that weaken or bypass this License.
+
+6. Third-Party and Previously Licensed Code
+
+Third-party components, templates, dependencies, and other portions identified
+by a separate license remain governed by that license. Nothing in this License
+restricts rights already granted under an earlier license. In particular,
+versions or portions previously released under the MIT License remain
+available under those prior, irrevocable terms. A copy of the historical MIT
+notice is included in LICENSES/MIT-legacy.txt.
+
+This License applies only to portions for which the Licensor owns or controls
+the necessary rights and that are first released under this License.
+
+7. Patents
+
+The Licensor grants You a patent license only to the extent necessary for the
+Permitted Uses. If You or Your Company assert in writing that the Software
+infringes a patent, any patent license granted under this License terminates
+immediately.
+
+8. No Trademark License
+
+This License does not grant permission to use the Licensor's names, logos, or
+trademarks except as required to preserve notices and accurately describe the
+origin of the Software.
+
+9. Termination
+
+Any use outside this License is unlicensed and automatically terminates Your
+rights. If this is Your first violation and You cure it within 30 days after
+written notice, the Licensor may reinstate Your rights. A later violation
+terminates them permanently unless the Licensor agrees otherwise in writing.
+
+10. No Warranty and Limitation of Liability
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, TITLE, AND NON-INFRINGEMENT. TO THE MAXIMUM EXTENT PERMITTED BY LAW,
+THE LICENSOR AND CONTRIBUTORS WILL NOT BE LIABLE FOR ANY CLAIM, DAMAGES, OR
+OTHER LIABILITY ARISING FROM THE SOFTWARE OR ITS USE.
+
+11. Definitions
+
+"Licensor" means Different AI, Inc. or a successor authorized to license the
+applicable Software.
+
+"Software" means the iPolloWork source code, object code, documentation, and
+other materials made available with this License, excluding separately
+licensed portions.
+
+"You" means the individual or legal entity exercising rights under this
+License.
+
+"Individual Personal Use" means use by one natural person for that person's
+own purposes, without selling, hosting, sublicensing, reselling, providing
+services, or making the Software or its functionality available to any external
+third party.
+
+"Small Internal Use" means use by fewer than three total Users solely for
+internal purposes and not to provide the Software or its functionality to
+external third parties.
+
+"User" means any individual who accesses, operates, deploys, administers,
+modifies, receives output from, or otherwise benefits from a shared deployment
+or coordinated use of the Software.

--- a/external-plugins/deepseek-harness/design-studio/README.md
+++ b/external-plugins/deepseek-harness/design-studio/README.md
@@ -23,7 +23,7 @@ For a local release artifact:
 
 ```sh
 pnpm pack
-dsh plugin --profile web add ./deepseek-idesign-0.2.0.tgz
+dsh plugin --profile web add ./deepseek-idesign-0.2.1.tgz
 ```
 
 The plugin contains its own browser assets. It does not install or start the

--- a/external-plugins/deepseek-harness/design-studio/package.json
+++ b/external-plugins/deepseek-harness/design-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-idesign",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "iPolloWork Design Studio and its curated design templates as a native DeepSeek Harness conversation view.",
   "type": "module",
   "main": "lib/index.js",
@@ -13,7 +13,8 @@
     "lib",
     "studio/dist",
     "cordis.patch.yml",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "pnpm run build:plugin && pnpm run build:studio",
@@ -40,7 +41,7 @@
     "design-studio",
     "ipollowork"
   ],
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "packageManager": "pnpm@11.4.0",
   "publishConfig": {
     "access": "public"
@@ -53,7 +54,7 @@
   "bugs": {
     "url": "https://github.com/Devin-AXIS/iPolloWork/issues"
   },
-  "homepage": "https://github.com/Devin-AXIS/iPolloWork/tree/main/external-plugins/deepseek-harness/design-studio#readme",
+  "homepage": "https://github.com/Devin-AXIS/deepseek-design#deepseek-idesign",
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-client-runtime": ">=0.0.1-rc.1 <0.2.0-0",

--- a/external-plugins/deepseek-harness/ppt-studio/LICENSE
+++ b/external-plugins/deepseek-harness/ppt-studio/LICENSE
@@ -1,0 +1,145 @@
+iPolloWork Source Available License
+Version 1.0, 13 July 2026
+
+Copyright (c) 2026 Different AI, Inc. All rights reserved.
+
+By using, copying, modifying, or distributing the Software, You accept this
+License.
+
+1. License Grant
+
+Subject to this License, the Licensor grants You a non-exclusive,
+royalty-free, worldwide, non-sublicensable, and non-transferable license to
+use, copy, modify, and distribute the Software solely as permitted below.
+
+2. Permitted Uses
+
+You may use and modify the Software without prior written authorization only
+for the limited uses below:
+
+  a. Individual Personal Use by one natural person for that person's own
+     non-commercial work, learning, research, evaluation, or testing; and
+  b. Small Internal Use by fewer than three total Users solely for internal,
+     non-commercial evaluation, testing, or operations.
+
+Small Internal Use is permitted only when the Software and its functionality
+are not sold, hosted for, provided to, or otherwise made available to
+customers, clients, or other external third parties. The three-User threshold
+is measured across all people who access, operate, deploy, administer, or
+benefit from a shared deployment of the Software, whether they are employees,
+contractors, founders, collaborators, or other personnel.
+
+3. Prior Written Authorization Required
+
+You must obtain prior written authorization from the Licensor before You do
+any of the following:
+
+  a. use the Software with three or more total Users, regardless of whether
+     the use is personal, internal, commercial, non-commercial, individual,
+     organizational, hosted, local, private, or public;
+  b. provide the Software or its functionality to any external third party as
+     a hosted, managed, cloud, SaaS, single-tenant, or multi-tenant service;
+  c. sell, rent, lease, sublicense, resell, or distribute the Software for a
+     fee or other commercial advantage, whether by an individual or an
+     organization;
+  d. incorporate the Software as a material component of a product or service
+     offered to external third parties for revenue or other commercial
+     advantage;
+  e. use the Software to provide paid customer delivery, implementation,
+     customization, operation, consulting, or outsourcing services;
+  f. use the Software in any paid, revenue-generating, resale, white-label,
+     agency, marketplace, or customer-facing context; or
+  g. remove, alter, obscure, hide, or replace the iPolloWork brand attribution
+     required by Section 4.
+
+Written authorization may grant some or all of these rights under separate
+terms. To request authorization, contact the repository owner through
+https://github.com/Devin-AXIS/iPolloWork.
+
+4. Required Brand Attribution
+
+All copies, deployments, and modified versions of the Software must preserve
+the iPolloWork name, logo, product attribution, copyright notice, and license
+notice in the source code, documentation, about screens, settings screens, and
+other user-facing frontend displays where the Software identifies itself or is
+presented to users. You may not remove, hide, obscure, replace, or make the
+iPolloWork brand attribution materially less visible without the Licensor's
+prior written authorization.
+
+This brand attribution requirement applies to all permitted and authorized
+uses, including Individual Personal Use, Small Internal Use, internal
+deployments, modified versions, and any separately authorized commercial use,
+unless the written authorization expressly permits different branding.
+
+5. Non-Commercial Redistribution
+
+You may distribute unmodified or modified copies of the Software only free of
+charge and for non-commercial purposes. Every copy must include this License
+and all copyright, attribution, trademark, and third-party notices. Modified
+copies must prominently state that You changed the Software. You may not
+impose terms that weaken or bypass this License.
+
+6. Third-Party and Previously Licensed Code
+
+Third-party components, templates, dependencies, and other portions identified
+by a separate license remain governed by that license. Nothing in this License
+restricts rights already granted under an earlier license. In particular,
+versions or portions previously released under the MIT License remain
+available under those prior, irrevocable terms. A copy of the historical MIT
+notice is included in LICENSES/MIT-legacy.txt.
+
+This License applies only to portions for which the Licensor owns or controls
+the necessary rights and that are first released under this License.
+
+7. Patents
+
+The Licensor grants You a patent license only to the extent necessary for the
+Permitted Uses. If You or Your Company assert in writing that the Software
+infringes a patent, any patent license granted under this License terminates
+immediately.
+
+8. No Trademark License
+
+This License does not grant permission to use the Licensor's names, logos, or
+trademarks except as required to preserve notices and accurately describe the
+origin of the Software.
+
+9. Termination
+
+Any use outside this License is unlicensed and automatically terminates Your
+rights. If this is Your first violation and You cure it within 30 days after
+written notice, the Licensor may reinstate Your rights. A later violation
+terminates them permanently unless the Licensor agrees otherwise in writing.
+
+10. No Warranty and Limitation of Liability
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE, TITLE, AND NON-INFRINGEMENT. TO THE MAXIMUM EXTENT PERMITTED BY LAW,
+THE LICENSOR AND CONTRIBUTORS WILL NOT BE LIABLE FOR ANY CLAIM, DAMAGES, OR
+OTHER LIABILITY ARISING FROM THE SOFTWARE OR ITS USE.
+
+11. Definitions
+
+"Licensor" means Different AI, Inc. or a successor authorized to license the
+applicable Software.
+
+"Software" means the iPolloWork source code, object code, documentation, and
+other materials made available with this License, excluding separately
+licensed portions.
+
+"You" means the individual or legal entity exercising rights under this
+License.
+
+"Individual Personal Use" means use by one natural person for that person's
+own purposes, without selling, hosting, sublicensing, reselling, providing
+services, or making the Software or its functionality available to any external
+third party.
+
+"Small Internal Use" means use by fewer than three total Users solely for
+internal purposes and not to provide the Software or its functionality to
+external third parties.
+
+"User" means any individual who accesses, operates, deploys, administers,
+modifies, receives output from, or otherwise benefits from a shared deployment
+or coordinated use of the Software.

--- a/external-plugins/deepseek-harness/ppt-studio/README.md
+++ b/external-plugins/deepseek-harness/ppt-studio/README.md
@@ -20,5 +20,5 @@ For a local release artifact:
 
 ```sh
 pnpm pack
-dsh plugin --profile web add ./deepseek-ippt-0.1.0.tgz
+dsh plugin --profile web add ./deepseek-ippt-0.1.1.tgz
 ```

--- a/external-plugins/deepseek-harness/ppt-studio/package.json
+++ b/external-plugins/deepseek-harness/ppt-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-ippt",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "iPolloWork PPT Studio and its curated slide templates as a native DeepSeek Harness conversation view.",
   "type": "module",
   "main": "lib/index.js",
@@ -9,7 +9,7 @@
     "./client": "./lib/client.js",
     "./package.json": "./package.json"
   },
-  "files": ["lib", "studio/dist", "cordis.patch.yml", "README.md"],
+  "files": ["lib", "studio/dist", "cordis.patch.yml", "README.md", "LICENSE"],
   "scripts": {
     "build": "pnpm run build:plugin && pnpm run build:studio",
     "build:plugin": "tsdown",
@@ -25,7 +25,7 @@
     }
   },
   "keywords": ["deepseek-harness", "dsh-plugin", "ppt", "slides", "ipollowork"],
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "packageManager": "pnpm@11.4.0",
   "publishConfig": { "access": "public" },
   "repository": {
@@ -34,7 +34,7 @@
     "directory": "external-plugins/deepseek-harness/ppt-studio"
   },
   "bugs": { "url": "https://github.com/Devin-AXIS/iPolloWork/issues" },
-  "homepage": "https://github.com/Devin-AXIS/iPolloWork/tree/main/external-plugins/deepseek-harness/ppt-studio#readme",
+  "homepage": "https://github.com/Devin-AXIS/deepseek-design#deepseek-ippt",
   "peerDependencies": {
     "@deepseek-ai/cordis": "^4.0.1",
     "@deepseek-ai/dsh-client-runtime": ">=0.0.1-rc.1 <0.2.0-0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:fs-engine": "pnpm --filter @ipollowork/app test:fs-engine",
     "test:e2e": "pnpm --filter @ipollowork/app test:e2e",
     "audit:template-fidelity": "node scripts/audit-template-preview-fidelity.mjs",
+    "export:deepseek-design": "node scripts/export-deepseek-design-repository.mjs",
     "evals": "node evals/runner/run.mjs",
     "fraimz": "node evals/runner/run.mjs",
     "gsap:generate": "bun vendor/hyperframes/scripts/gsap-catalog.ts generate",

--- a/scripts/export-deepseek-design-repository.mjs
+++ b/scripts/export-deepseek-design-repository.mjs
@@ -1,0 +1,174 @@
+import { execFile } from "node:child_process";
+import {
+  access,
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const publicRepository = "https://github.com/Devin-AXIS/deepseek-design";
+const sourceRepository = "https://github.com/Devin-AXIS/iPolloWork";
+
+function usage() {
+  return `Usage: pnpm export:deepseek-design -- --output <directory> --idesign <tarball> --ippt <tarball>`;
+}
+
+function parseArguments(argv) {
+  if (argv[0] === "--") argv = argv.slice(1);
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || !value || value.startsWith("--")) {
+      throw new Error(usage());
+    }
+    values.set(key.slice(2), value);
+  }
+  for (const required of ["output", "idesign", "ippt"]) {
+    if (!values.has(required)) throw new Error(usage());
+  }
+  return {
+    output: resolve(values.get("output")),
+    packages: [
+      { name: "deepseek-idesign", tarball: resolve(values.get("idesign")) },
+      { name: "deepseek-ippt", tarball: resolve(values.get("ippt")) },
+    ],
+  };
+}
+
+async function assertSafeOutput(output) {
+  await mkdir(dirname(output), { recursive: true });
+  const resolvedHome = await realpath(homedir());
+  const resolvedRoot = resolve("/");
+  const resolvedRepository = await realpath(repositoryRoot);
+  const candidateParent = await realpath(dirname(output));
+  const candidate = join(candidateParent, basename(output));
+  const repositoryRelative = relative(resolvedRepository, candidate);
+
+  if (
+    candidate === resolvedRoot ||
+    candidate === resolvedHome ||
+    candidate === resolvedRepository ||
+    (repositoryRelative !== ".." && !repositoryRelative.startsWith(`..${sep}`))
+  ) {
+    throw new Error(`Refusing to replace unsafe output directory: ${candidate}`);
+  }
+}
+
+async function resetOutput(output) {
+  await assertSafeOutput(output);
+  await mkdir(output, { recursive: true });
+  for (const entry of await readdir(output)) {
+    if (entry === ".git") continue;
+    await rm(join(output, entry), { recursive: true, force: true });
+  }
+}
+
+async function copyFile(source, destination) {
+  await mkdir(dirname(destination), { recursive: true });
+  await cp(source, destination);
+}
+
+async function copySourceDirectory(source, destination) {
+  await cp(source, destination, {
+    recursive: true,
+    filter(path) {
+      const suffix = relative(source, path).split(sep);
+      return !suffix.some((part) => part === "node_modules" || part === "lib" || part === "dist");
+    },
+  });
+}
+
+async function extractPackage({ name, tarball }, output) {
+  await access(tarball);
+  const staging = await mkdtemp(join(tmpdir(), `deepseek-design-${name}-`));
+  try {
+    await run("tar", ["-xzf", tarball, "-C", staging]);
+    const extracted = join(staging, "package");
+    const metadata = JSON.parse(await readFile(join(extracted, "package.json"), "utf8"));
+    if (metadata.name !== name) {
+      throw new Error(`Expected ${name} tarball, received ${metadata.name ?? "an unnamed package"}.`);
+    }
+    await cp(extracted, join(output, "packages", name), { recursive: true });
+    return { name, version: metadata.version };
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+async function assertRunnablePackage(output, name) {
+  for (const path of ["package.json", "lib/index.js", "studio/dist/index.html", "cordis.patch.yml", "LICENSE"]) {
+    const target = join(output, "packages", name, path);
+    const details = await stat(target).catch(() => null);
+    if (!details?.isFile()) throw new Error(`Generated package is missing ${name}/${path}.`);
+  }
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  await resetOutput(options.output);
+
+  const { stdout } = await run("git", ["rev-parse", "HEAD"], { cwd: repositoryRoot });
+  const sourceCommit = stdout.trim();
+
+  for (const [source, destination] of [
+    ["external-plugins/deepseek-harness/README.md", "README.md"],
+    ["CONTRIBUTING.md", "CONTRIBUTING.md"],
+    ["LICENSE", "LICENSE"],
+    ["LICENSES/MIT-legacy.txt", "LICENSES/MIT-legacy.txt"],
+    ["CODE_OF_CONDUCT.md", "CODE_OF_CONDUCT.md"],
+    ["SECURITY.md", "SECURITY.md"],
+  ]) {
+    await copyFile(join(repositoryRoot, source), join(options.output, destination));
+  }
+
+  const packages = [];
+  for (const packageEntry of options.packages) {
+    packages.push(await extractPackage(packageEntry, options.output));
+    await assertRunnablePackage(options.output, packageEntry.name);
+  }
+
+  await copySourceDirectory(
+    join(repositoryRoot, "external-plugins/deepseek-harness/design-studio"),
+    join(options.output, "source/plugins/deepseek-idesign"),
+  );
+  await copySourceDirectory(
+    join(repositoryRoot, "external-plugins/deepseek-harness/ppt-studio"),
+    join(options.output, "source/plugins/deepseek-ippt"),
+  );
+  await copySourceDirectory(
+    join(repositoryRoot, "packages/design-studio"),
+    join(options.output, "source/shared/design-studio"),
+  );
+  await copyFile(
+    join(repositoryRoot, "packages/types/src/templates.ts"),
+    join(options.output, "source/shared/types/templates.ts"),
+  );
+
+  await writeFile(
+    join(options.output, "source/README.md"),
+    `# Source map\n\nThis directory mirrors the thin DeepSeek Harness adapters and shared Studio contract from [iPolloWork](${sourceRepository}/tree/${sourceCommit}). The complete, directly installable runtime is in \`packages/\`.\n\nThe Design and PPT interface remains single-sourced in [iPolloWork Design Studio](${sourceRepository}/tree/${sourceCommit}/apps/app/src/react-app/domains/session/design), and the curated templates remain in [bundled-templates](${sourceRepository}/tree/${sourceCommit}/apps/server/bundled-templates). Changes should be proposed in the main repository and are synchronized here after merge.\n`,
+  );
+  await writeFile(join(options.output, ".gitignore"), "node_modules/\n*.tgz\n.DS_Store\n");
+  await writeFile(join(options.output, "SOURCE_COMMIT"), `${sourceCommit}\n`);
+  await writeFile(
+    join(options.output, "repository.json"),
+    `${JSON.stringify({ schemaVersion: 1, repository: publicRepository, source: { repository: sourceRepository, commit: sourceCommit }, packages }, null, 2)}\n`,
+  );
+
+  console.log(`Exported ${packages.map(({ name, version }) => `${name}@${version}`).join(" and ")} from ${sourceCommit}.`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
- publish iDesign and iPPT from one main-repository source of truth
- export complete runnable packages to the public deepseek-design repository
- use the same iPolloWork license and contribution policies
- add one-way automatic synchronization and future npm release checks

## Verification
- both plugin typechecks passed
- both production Studio builds and package archives passed
- generated repository snapshot installed both local packages successfully
- exporter rejects unsafe in-repository output paths
- workflow YAML parsed successfully
- git diff --check passed

Public mirror: https://github.com/Devin-AXIS/deepseek-design