### PR TITLE
fix: install shared DeepSeek plugin workspace in CI

### DIFF
--- a/.github/workflows/ci-dsh-design-studio.yml
+++ b/.github/workflows/ci-dsh-design-studio.yml
@@ -55,8 +55,10 @@ jobs:
       - name: Install iPolloWork workspace
         run: pnpm install --frozen-lockfile
 
-      - name: Install plugin workspace
-        run: pnpm --dir external-plugins/deepseek-harness/${{ matrix.package }} install --frozen-lockfile
+      - name: Install plugin workspaces
+        run: |
+          pnpm --dir external-plugins/deepseek-harness/design-studio install --frozen-lockfile
+          pnpm --dir external-plugins/deepseek-harness/ppt-studio install --frozen-lockfile
 
       - name: Typecheck and package
         run: |


### PR DESCRIPTION
## Summary
- install both external plugin workspaces before matrix typechecks
- keeps iPPT's intentionally shared iDesign Studio config resolvable in clean CI

## Verification
- both packages already pass local typecheck, production build, pack, export, and local install
- failure cause confirmed from the clean CI log