### PR TITLE
feat: import DeepSeek Design contributions

### DIFF
--- a/.github/workflows/import-deepseek-design.yml
+++ b/.github/workflows/import-deepseek-design.yml
@@ -1,0 +1,72 @@
+name: Import DeepSeek Design contributions
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: import-deepseek-design
+  cancel-in-progress: false
+
+jobs:
+  import:
+    name: Create an upstream source pull request
+    if: github.repository == 'Devin-AXIS/iPolloWork'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout iPolloWork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Read public contribution mirror
+        id: mirror
+        run: |
+          git clone --depth 1 https://github.com/Devin-AXIS/deepseek-design.git "${RUNNER_TEMP}/deepseek-design"
+          mirror_sha="$(git -C "${RUNNER_TEMP}/deepseek-design" rev-parse HEAD)"
+          [[ "${mirror_sha}" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=${mirror_sha}" >> "${GITHUB_OUTPUT}"
+          node scripts/import-deepseek-design-repository.mjs --source "${RUNNER_TEMP}/deepseek-design"
+
+      - name: Create upstream pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MIRROR_SHA: ${{ steps.mirror.outputs.sha }}
+        run: |
+          if [[ -z "$(git status --porcelain -- external-plugins/deepseek-harness packages/design-studio packages/types/src/templates.ts)" ]]; then
+            echo "No incoming DeepSeek Design source changes."
+            exit 0
+          fi
+          branch="automation/deepseek-design-${MIRROR_SHA:0:12}"
+          existing_pr="$(gh pr list --state open --head "${branch}" --json url --jq '.[0].url')"
+          if [[ -n "${existing_pr}" ]]; then
+            echo "Incoming contribution already has an upstream pull request: ${existing_pr}"
+            exit 0
+          fi
+          git config user.name "iPolloWork Sync"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "${branch}"
+          git add -- \
+            external-plugins/deepseek-harness/README.md \
+            external-plugins/deepseek-harness/design-studio \
+            external-plugins/deepseek-harness/ppt-studio \
+            packages/design-studio \
+            packages/types/src/templates.ts
+          git commit -m "sync: import DeepSeek Design ${MIRROR_SHA:0:12}"
+          git push origin "${branch}"
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "sync: import DeepSeek Design contribution" \
+            --body "Imports approved source paths from [DeepSeek Design](https://github.com/Devin-AXIS/deepseek-design/commit/${MIRROR_SHA}). Generated packages and repository policy files are intentionally excluded. After this pull request is merged, the normal forward sync rebuilds both plugins and updates the public repository."

--- a/external-plugins/deepseek-harness/README.md
+++ b/external-plugins/deepseek-harness/README.md
@@ -25,9 +25,17 @@ The iPolloWork repository is the only source of truth for product code. Every
 change to the shared Design Studio is built once and flows to both DeepSeek
 plugins. The public
 [`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) repository is
-an automatically generated distribution mirror: it provides complete runnable
-packages, source references, issues, and a focused discovery page without
-creating a second implementation to maintain.
+an automatically generated distribution and contribution mirror: it provides
+complete runnable packages, source references, issues, and a focused discovery
+page without creating a second implementation to maintain.
+
+## Contributing code
+
+Open source pull requests in `deepseek-design` against `source/` or the root
+README. Do not edit generated runtime files under `packages/` directly. After a
+source change is merged there, iPolloWork imports it as a reviewable upstream
+pull request. Merging the upstream pull request rebuilds both plugins and
+synchronizes the result back to `deepseek-design`.
 
 ## License
 
@@ -38,5 +46,6 @@ their respective licenses.
 ---
 
 DeepSeek Design 将 iPolloWork 的 Design Studio 与 PPT Studio 作为两个可独立安装
-的 DeepSeek Harness 插件提供。产品代码只在 iPolloWork 主库维护；公开的
-`deepseek-design` 仓库由主库自动生成和同步，不会形成两套代码。
+的 DeepSeek Harness 插件提供。大家可以在 `deepseek-design` 的 `source/` 目录
+提交代码；合并后会自动生成 iPolloWork 主库 PR。主库合并后再重新构建并同步
+回来，因此始终只有一套官方源码。

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "test:e2e": "pnpm --filter @ipollowork/app test:e2e",
     "audit:template-fidelity": "node scripts/audit-template-preview-fidelity.mjs",
     "export:deepseek-design": "node scripts/export-deepseek-design-repository.mjs",
+    "import:deepseek-design": "node scripts/import-deepseek-design-repository.mjs",
+    "test:deepseek-design-import": "node --test scripts/import-deepseek-design-repository.test.mjs",
     "evals": "node evals/runner/run.mjs",
     "fraimz": "node evals/runner/run.mjs",
     "gsap:generate": "bun vendor/hyperframes/scripts/gsap-catalog.ts generate",

--- a/scripts/export-deepseek-design-repository.mjs
+++ b/scripts/export-deepseek-design-repository.mjs
@@ -21,6 +21,34 @@ const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 const publicRepository = "https://github.com/Devin-AXIS/deepseek-design";
 const sourceRepository = "https://github.com/Devin-AXIS/iPolloWork";
 
+export const deepSeekDesignSourceMappings = [
+  {
+    ipolloWorkPath: "external-plugins/deepseek-harness/README.md",
+    mirrorPath: "README.md",
+    type: "file",
+  },
+  {
+    ipolloWorkPath: "external-plugins/deepseek-harness/design-studio",
+    mirrorPath: "source/plugins/deepseek-idesign",
+    type: "directory",
+  },
+  {
+    ipolloWorkPath: "external-plugins/deepseek-harness/ppt-studio",
+    mirrorPath: "source/plugins/deepseek-ippt",
+    type: "directory",
+  },
+  {
+    ipolloWorkPath: "packages/design-studio",
+    mirrorPath: "source/shared/design-studio",
+    type: "directory",
+  },
+  {
+    ipolloWorkPath: "packages/types/src/templates.ts",
+    mirrorPath: "source/shared/types/templates.ts",
+    type: "file",
+  },
+];
+
 function usage() {
   return `Usage: pnpm export:deepseek-design -- --output <directory> --idesign <tarball> --ippt <tarball>`;
 }
@@ -124,7 +152,6 @@ async function main() {
   const sourceCommit = stdout.trim();
 
   for (const [source, destination] of [
-    ["external-plugins/deepseek-harness/README.md", "README.md"],
     ["CONTRIBUTING.md", "CONTRIBUTING.md"],
     ["LICENSE", "LICENSE"],
     ["LICENSES/MIT-legacy.txt", "LICENSES/MIT-legacy.txt"],
@@ -134,41 +161,31 @@ async function main() {
     await copyFile(join(repositoryRoot, source), join(options.output, destination));
   }
 
+  for (const mapping of deepSeekDesignSourceMappings) {
+    const source = join(repositoryRoot, mapping.ipolloWorkPath);
+    const destination = join(options.output, mapping.mirrorPath);
+    if (mapping.type === "directory") await copySourceDirectory(source, destination);
+    else await copyFile(source, destination);
+  }
+
   const packages = [];
   for (const packageEntry of options.packages) {
     packages.push(await extractPackage(packageEntry, options.output));
     await assertRunnablePackage(options.output, packageEntry.name);
   }
 
-  await copySourceDirectory(
-    join(repositoryRoot, "external-plugins/deepseek-harness/design-studio"),
-    join(options.output, "source/plugins/deepseek-idesign"),
-  );
-  await copySourceDirectory(
-    join(repositoryRoot, "external-plugins/deepseek-harness/ppt-studio"),
-    join(options.output, "source/plugins/deepseek-ippt"),
-  );
-  await copySourceDirectory(
-    join(repositoryRoot, "packages/design-studio"),
-    join(options.output, "source/shared/design-studio"),
-  );
-  await copyFile(
-    join(repositoryRoot, "packages/types/src/templates.ts"),
-    join(options.output, "source/shared/types/templates.ts"),
-  );
-
   await writeFile(
     join(options.output, "source/README.md"),
-    `# Source map\n\nThis directory mirrors the thin DeepSeek Harness adapters and shared Studio contract from [iPolloWork](${sourceRepository}/tree/${sourceCommit}). The complete, directly installable runtime is in \`packages/\`.\n\nThe Design and PPT interface remains single-sourced in [iPolloWork Design Studio](${sourceRepository}/tree/${sourceCommit}/apps/app/src/react-app/domains/session/design), and the curated templates remain in [bundled-templates](${sourceRepository}/tree/${sourceCommit}/apps/server/bundled-templates). Changes should be proposed in the main repository and are synchronized here after merge.\n`,
+    `# Source map\n\nThis directory mirrors the thin DeepSeek Harness adapters and shared Studio contract from [iPolloWork](${sourceRepository}/tree/${sourceCommit}). The complete, directly installable runtime is in \`packages/\`.\n\nSource pull requests are welcome in this repository. After a source change is merged here, iPolloWork imports it as a reviewable upstream pull request. When that upstream pull request is merged, the Studio and packages are rebuilt and synchronized back here. Do not edit generated files under \`packages/\` directly.\n\nThe Design and PPT interface remains single-sourced in [iPolloWork Design Studio](${sourceRepository}/tree/${sourceCommit}/apps/app/src/react-app/domains/session/design), and the curated templates remain in [bundled-templates](${sourceRepository}/tree/${sourceCommit}/apps/server/bundled-templates). Changes to those paths should be proposed directly in the main repository.\n`,
   );
   await writeFile(join(options.output, ".gitignore"), "node_modules/\n*.tgz\n.DS_Store\n");
   await writeFile(join(options.output, "SOURCE_COMMIT"), `${sourceCommit}\n`);
   await writeFile(
     join(options.output, "repository.json"),
-    `${JSON.stringify({ schemaVersion: 1, repository: publicRepository, source: { repository: sourceRepository, commit: sourceCommit }, packages }, null, 2)}\n`,
+    `${JSON.stringify({ schemaVersion: 1, repository: publicRepository, source: { repository: sourceRepository, commit: sourceCommit }, contributions: { mode: "upstream-pull-request", upstream: sourceRepository }, packages }, null, 2)}\n`,
   );
 
   console.log(`Exported ${packages.map(({ name, version }) => `${name}@${version}`).join(" and ")} from ${sourceCommit}.`);
 }
 
-await main();
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main();

--- a/scripts/import-deepseek-design-repository.mjs
+++ b/scripts/import-deepseek-design-repository.mjs
@@ -1,0 +1,109 @@
+import { cp, lstat, mkdir, readFile, readdir, rm } from "node:fs/promises";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { deepSeekDesignSourceMappings } from "./export-deepseek-design-repository.mjs";
+
+const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const publicRepository = "https://github.com/Devin-AXIS/deepseek-design";
+const sourceRepository = "https://github.com/Devin-AXIS/iPolloWork";
+const forbiddenDirectoryNames = new Set([".git", "dist", "lib", "node_modules"]);
+const maximumFilesPerMapping = 2048;
+const maximumFileBytes = 5 * 1024 * 1024;
+
+function usage() {
+  return "Usage: pnpm import:deepseek-design -- --source <deepseek-design-checkout>";
+}
+
+function parseArguments(argv) {
+  if (argv[0] === "--") argv = argv.slice(1);
+  if (argv.length !== 2 || argv[0] !== "--source" || !argv[1]) throw new Error(usage());
+  return { source: resolve(argv[1]) };
+}
+
+function pathWithin(root, path) {
+  const suffix = relative(root, path);
+  return suffix && suffix !== ".." && !suffix.startsWith(`..${sep}`) && !suffix.startsWith(sep);
+}
+
+function mappedPath(root, value) {
+  const path = resolve(root, value);
+  if (!pathWithin(root, path)) throw new Error(`Mapped path escapes its repository: ${value}`);
+  return path;
+}
+
+async function validateSource(path, label, type) {
+  let files = 0;
+  const visit = async (entryPath, relativePath) => {
+    const metadata = await lstat(entryPath);
+    if (metadata.isSymbolicLink()) throw new Error(`DeepSeek Design source may not contain symbolic links: ${label}/${relativePath}`);
+    if (metadata.isFile()) {
+      files += 1;
+      if (files > maximumFilesPerMapping) throw new Error(`DeepSeek Design source has too many files under ${label}.`);
+      if (metadata.size > maximumFileBytes) throw new Error(`DeepSeek Design source file is too large: ${label}/${relativePath}`);
+      return;
+    }
+    if (!metadata.isDirectory()) throw new Error(`DeepSeek Design source must contain only regular files and directories: ${label}/${relativePath}`);
+    for (const entry of await readdir(entryPath, { withFileTypes: true })) {
+      if (entry.isDirectory() && forbiddenDirectoryNames.has(entry.name)) {
+        throw new Error(`DeepSeek Design source contains a generated or unsafe directory: ${label}/${relativePath}${entry.name}`);
+      }
+      await visit(resolve(entryPath, entry.name), `${relativePath}${entry.name}${entry.isDirectory() ? "/" : ""}`);
+    }
+  };
+  const rootMetadata = await lstat(path);
+  if (rootMetadata.isSymbolicLink()) throw new Error(`DeepSeek Design source may not contain symbolic links: ${label}`);
+  if (type === "file" && !rootMetadata.isFile()) throw new Error(`DeepSeek Design source must be a regular file: ${label}`);
+  if (type === "directory" && !rootMetadata.isDirectory()) throw new Error(`DeepSeek Design source must be a directory: ${label}`);
+  await visit(path, "");
+  if (!files) throw new Error(`DeepSeek Design source is empty: ${label}`);
+}
+
+async function validateRepository(source) {
+  const metadataPath = mappedPath(source, "repository.json");
+  const metadataDetails = await lstat(metadataPath);
+  if (metadataDetails.isSymbolicLink() || !metadataDetails.isFile() || metadataDetails.size > maximumFileBytes) {
+    throw new Error("The DeepSeek Design repository metadata must be a regular file.");
+  }
+  const metadata = JSON.parse(await readFile(metadataPath, "utf8"));
+  if (
+    metadata.schemaVersion !== 1 ||
+    metadata.repository !== publicRepository ||
+    metadata.source?.repository !== sourceRepository ||
+    !/^[0-9a-f]{40}$/.test(metadata.source.commit)
+  ) {
+    throw new Error("The source directory is not a supported DeepSeek Design repository snapshot.");
+  }
+}
+
+export async function importDeepSeekDesignRepository({ source, destination = repositoryRoot }) {
+  const sourceRoot = resolve(source);
+  const destinationRoot = resolve(destination);
+  if (sourceRoot === destinationRoot || pathWithin(sourceRoot, destinationRoot) || pathWithin(destinationRoot, sourceRoot)) {
+    throw new Error("The DeepSeek Design checkout and iPolloWork checkout must be separate directories.");
+  }
+  await validateRepository(sourceRoot);
+
+  for (const mapping of deepSeekDesignSourceMappings) {
+    const sourcePath = mappedPath(sourceRoot, mapping.mirrorPath);
+    await validateSource(sourcePath, mapping.mirrorPath, mapping.type);
+  }
+
+  for (const mapping of deepSeekDesignSourceMappings) {
+    const sourcePath = mappedPath(sourceRoot, mapping.mirrorPath);
+    const destinationPath = mappedPath(destinationRoot, mapping.ipolloWorkPath);
+    await rm(destinationPath, { recursive: true, force: true });
+    await mkdir(dirname(destinationPath), { recursive: true });
+    await cp(sourcePath, destinationPath, { recursive: mapping.type === "directory", errorOnExist: true });
+  }
+
+  return deepSeekDesignSourceMappings.map(({ ipolloWorkPath }) => ipolloWorkPath);
+}
+
+async function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const imported = await importDeepSeekDesignRepository({ source: options.source });
+  console.log(`Imported ${imported.length} approved source mappings from DeepSeek Design.`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) await main();

--- a/scripts/import-deepseek-design-repository.test.mjs
+++ b/scripts/import-deepseek-design-repository.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { deepSeekDesignSourceMappings } from "./export-deepseek-design-repository.mjs";
+import { importDeepSeekDesignRepository } from "./import-deepseek-design-repository.mjs";
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "deepseek-design-import-test-"));
+  const source = join(root, "deepseek-design");
+  const destination = join(root, "ipollowork");
+  await mkdir(source, { recursive: true });
+  await mkdir(destination, { recursive: true });
+  await writeFile(join(source, "repository.json"), `${JSON.stringify({
+    schemaVersion: 1,
+    repository: "https://github.com/Devin-AXIS/deepseek-design",
+    source: {
+      repository: "https://github.com/Devin-AXIS/iPolloWork",
+      commit: "0123456789abcdef0123456789abcdef01234567",
+    },
+  })}\n`);
+  for (const mapping of deepSeekDesignSourceMappings) {
+    const target = join(source, mapping.mirrorPath);
+    if (mapping.type === "directory") {
+      await mkdir(target, { recursive: true });
+      await writeFile(join(target, "fixture.txt"), mapping.mirrorPath);
+    } else {
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, mapping.mirrorPath);
+    }
+  }
+  return { root, source, destination };
+}
+
+test("imports only the approved DeepSeek Design source mappings", async () => {
+  const current = await fixture();
+  try {
+    const imported = await importDeepSeekDesignRepository(current);
+    assert.deepEqual(imported, deepSeekDesignSourceMappings.map(({ ipolloWorkPath }) => ipolloWorkPath));
+    for (const mapping of deepSeekDesignSourceMappings) {
+      const target = join(current.destination, mapping.ipolloWorkPath);
+      const content = mapping.type === "directory"
+        ? await readFile(join(target, "fixture.txt"), "utf8")
+        : await readFile(target, "utf8");
+      assert.equal(content, mapping.mirrorPath);
+    }
+  } finally {
+    await rm(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects symbolic links from the public repository", async () => {
+  const current = await fixture();
+  try {
+    const directoryMapping = deepSeekDesignSourceMappings.find(({ type }) => type === "directory");
+    assert.ok(directoryMapping);
+    await symlink("fixture.txt", join(current.source, directoryMapping.mirrorPath, "linked.txt"));
+    await assert.rejects(
+      importDeepSeekDesignRepository(current),
+      /may not contain symbolic links/,
+    );
+  } finally {
+    await rm(current.root, { recursive: true, force: true });
+  }
+});
+
+test("rejects a mapped path with the wrong file type", async () => {
+  const current = await fixture();
+  try {
+    const fileMapping = deepSeekDesignSourceMappings.find(({ type }) => type === "file");
+    assert.ok(fileMapping);
+    await rm(join(current.source, fileMapping.mirrorPath));
+    await mkdir(join(current.source, fileMapping.mirrorPath));
+    await writeFile(join(current.source, fileMapping.mirrorPath, "unexpected.txt"), "unexpected");
+    await assert.rejects(
+      importDeepSeekDesignRepository(current),
+      /must be a regular file/,
+    );
+  } finally {
+    await rm(current.root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- import only approved DeepSeek Design source paths into reviewable iPolloWork pull requests
- poll the public repository every 30 minutes and support manual dispatch
- keep generated packages and repository policy files out of the reverse path
- document the single-source contribution loop

## Verification

- `pnpm test:deepseek-design-import`
- current public repository imports with no diff
- simulated Design source contribution changes only its mapped main-repository file
- maintainability audit passes with no warnings
- workflow YAML parses successfully
- Fraimz skipped: workflow/scripts/docs only; no app UI or runtime behavior changed