### PR TITLE
refactor: add plugin engine adapter registry

### DIFF
--- a/apps/server/src/plugin-engine-adapter.ts
+++ b/apps/server/src/plugin-engine-adapter.ts
@@ -45,6 +45,36 @@ export interface PluginEngineAdapter {
   }): Promise<void>;
 }
 
+export class PluginEngineAdapterRegistry {
+  readonly #adapters: ReadonlyMap<string, PluginEngineAdapter>;
+
+  constructor(adapters: readonly PluginEngineAdapter[]) {
+    const entries = new Map<string, PluginEngineAdapter>();
+    for (const adapter of adapters) {
+      const id = adapter.id.trim();
+      if (!id) throw new Error("Plugin engine adapter ID is required");
+      if (entries.has(id)) throw new Error(`Duplicate plugin engine adapter: ${id}`);
+      entries.set(id, adapter);
+    }
+    this.#adapters = entries;
+  }
+
+  get(id: string): PluginEngineAdapter {
+    const adapter = this.#adapters.get(id.trim());
+    if (!adapter) {
+      throw new ApiError(409, "plugin_engine_not_registered", `Plugin engine is not registered: ${id}`, {
+        engine: id,
+        registeredEngines: [...this.#adapters.keys()],
+      });
+    }
+    return adapter;
+  }
+
+  ids(): string[] {
+    return [...this.#adapters.keys()];
+  }
+}
+
 const OPENCODE_TARGETS = {
   skills: ".opencode/skills/",
   agents: ".opencode/agents/",
@@ -159,4 +189,6 @@ export const openCodePluginEngineAdapter: PluginEngineAdapter = {
   },
 };
 
-export const pluginEngineAdapter: PluginEngineAdapter = openCodePluginEngineAdapter;
+export const pluginEngineAdapters = new PluginEngineAdapterRegistry([
+  openCodePluginEngineAdapter,
+]);

--- a/apps/server/src/plugin-package-lifecycle.test.ts
+++ b/apps/server/src/plugin-package-lifecycle.test.ts
@@ -4,12 +4,18 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  openCodePluginEngineAdapter,
+  PluginEngineAdapterRegistry,
+  type PluginEngineAdapter,
+} from "./plugin-engine-adapter.js";
 import { readRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { pluginServiceDataDirectory } from "./plugin-service-runtime.js";
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
 
 const WORKSPACE_ID = "ws_plugin_package";
+const ENGINE_ID = "opencode";
 const roots: string[] = [];
 const previousRuntimeDb = process.env.IPOLLOWORK_RUNTIME_DB;
 
@@ -22,7 +28,7 @@ function serverConfig(root: string): ServerConfig {
     configPath: join(root, "server.json"),
     approval: { mode: "auto", timeoutMs: 0 },
     corsOrigins: [],
-    workspaces: [{ id: WORKSPACE_ID, name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    workspaces: [{ id: WORKSPACE_ID, name: "Test", path: root, preset: "starter", workspaceType: "local", engineId: ENGINE_ID }],
     authorizedRoots: [root],
     readOnly: false,
     startedAt: Date.now(),
@@ -158,12 +164,31 @@ afterEach(async () => {
 });
 
 describe("plugin package lifecycle", () => {
+  test("registers unique engine adapters and rejects duplicate IDs", () => {
+    const alternateAdapter: PluginEngineAdapter = {
+      id: "deepseek-harness",
+      compatibility: () => [],
+      workspaceFiles: () => [],
+      skillTargetPath: () => null,
+      syncRuntime: async () => undefined,
+    };
+    const registry = new PluginEngineAdapterRegistry([openCodePluginEngineAdapter, alternateAdapter]);
+
+    expect(registry.ids()).toEqual([ENGINE_ID, "deepseek-harness"]);
+    expect(registry.get(ENGINE_ID)).toBe(openCodePluginEngineAdapter);
+    expect(registry.get("deepseek-harness")).toBe(alternateAdapter);
+    expect(() => new PluginEngineAdapterRegistry([
+      openCodePluginEngineAdapter,
+      openCodePluginEngineAdapter,
+    ])).toThrow("Duplicate plugin engine adapter: opencode");
+  });
+
   test("previews the complete Figma package and every bundled workflow file", async () => {
     const lifecycle = await import("./plugin-package-lifecycle.js");
     const workspaceRoot = await createRoot("ipollowork-figma-preview-workspace-");
     const packageRoot = fileURLToPath(new URL("../../../examples/plugin-packages/figma", import.meta.url));
 
-    const preview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const preview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
 
     expect(preview.manifest.id).toBe("figma");
     expect(preview.files.length).toBeGreaterThan(100);
@@ -194,7 +219,7 @@ describe("plugin package lifecycle", () => {
       ],
     }), "utf8");
 
-    const preview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const preview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
 
     expect(preview.writes.map((entry) => entry.path)).toEqual([
       ".opencode/skills/figma/SKILL.md",
@@ -211,7 +236,7 @@ describe("plugin package lifecycle", () => {
     await writeFile(join(workspaceRoot, "unrelated.txt"), "keep me", "utf8");
     const config = serverConfig(workspaceRoot);
 
-    const preview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const preview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
     expect(preview.writes.map((entry) => entry.path).sort()).toEqual([
       ".opencode/skills/acme-research/SKILL.md",
     ]);
@@ -341,7 +366,7 @@ describe("plugin package lifecycle", () => {
     const packageRoot = await createRoot("ipollowork-plugin-integrity-package-");
     await writePackage(packageRoot, "1.0.0", "export default async () => ({})\n", "# Acme Research\n");
 
-    const unsigned = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const unsigned = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
     expect(unsigned.integrity.status).toBe("unsigned");
     expect(unsigned.integrity.sha256).toMatch(/^[a-f0-9]{64}$/);
 
@@ -349,20 +374,20 @@ describe("plugin package lifecycle", () => {
     const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
     manifest.description = "Changed package metadata";
     await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
-    const changed = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const changed = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
     expect(changed.integrity.sha256).not.toBe(unsigned.integrity.sha256);
 
     manifest.package.checksum = { algorithm: "sha256", value: "0".repeat(64) };
     await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
 
-    await expect(lifecycle.previewPluginPackage({ packageRoot, workspaceRoot })).rejects.toMatchObject({
+    await expect(lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID })).rejects.toMatchObject({
       code: "plugin_package_checksum_mismatch",
     });
 
     delete manifest.package.checksum;
     manifest.package.compatibility = { ipollowork: ">=99.0.0" };
     await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
-    await expect(lifecycle.previewPluginPackage({ packageRoot, workspaceRoot })).rejects.toMatchObject({
+    await expect(lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID })).rejects.toMatchObject({
       code: "plugin_package_incompatible",
     });
   });
@@ -377,9 +402,30 @@ describe("plugin package lifecycle", () => {
     manifest.package.engines = ["deepseek-harness"];
     await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
 
-    await expect(lifecycle.previewPluginPackage({ packageRoot, workspaceRoot })).rejects.toMatchObject({
+    await expect(lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID })).rejects.toMatchObject({
       code: "plugin_package_incompatible",
       details: { engine: "opencode", supportedEngines: ["deepseek-harness"] },
+    });
+  });
+
+  test("selects the workspace engine and rejects an unregistered adapter", async () => {
+    const lifecycle = await import("./plugin-package-lifecycle.js");
+    const workspaceRoot = await createRoot("ipollowork-plugin-engine-selection-workspace-");
+    const packageRoot = await createRoot("ipollowork-plugin-engine-selection-package-");
+    await writeDeclarativePackage(packageRoot);
+    const config = serverConfig(workspaceRoot);
+    const workspace = config.workspaces[0];
+    if (!workspace) throw new Error("Test workspace is missing");
+    workspace.engineId = "deepseek-harness";
+
+    await expect(lifecycle.installPluginPackage({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      packageRoot,
+      workspaceRoot,
+    })).rejects.toMatchObject({
+      code: "plugin_engine_not_registered",
+      details: { engine: "deepseek-harness", registeredEngines: [ENGINE_ID] },
     });
   });
 
@@ -395,7 +441,7 @@ describe("plugin package lifecycle", () => {
     delete manifest.authorization;
     await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
 
-    const remotePreview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const remotePreview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
     expect(await lifecycle.assertPluginPackageSafeForImport({ packageRoot, preview: remotePreview }))
       .toMatchObject({ level: "declarative", localCode: false });
 
@@ -404,7 +450,7 @@ describe("plugin package lifecycle", () => {
       JSON.stringify({ type: "local", command: ["node", "malicious.mjs"] }),
       "utf8",
     );
-    const localPreview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot });
+    const localPreview = await lifecycle.previewPluginPackage({ packageRoot, workspaceRoot, engineId: ENGINE_ID });
     await expect(lifecycle.assertPluginPackageSafeForImport({ packageRoot, preview: localPreview })).rejects.toMatchObject({
       code: "plugin_package_import_unsafe",
     });

--- a/apps/server/src/plugin-package-lifecycle.ts
+++ b/apps/server/src/plugin-package-lifecycle.ts
@@ -6,13 +6,14 @@ import { z } from "zod";
 import { ApiError } from "./errors.js";
 import {
   parsePluginMcpEntries,
-  pluginEngineAdapter,
+  pluginEngineAdapters,
+  type PluginEngineAdapter,
   type PluginEngineVersion,
   type PluginWorkspaceFile,
 } from "./plugin-engine-adapter.js";
 import { parsePluginPackageManifest, type PluginPackageManifest } from "./plugin-package-manifest.js";
 import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
-import type { ServerConfig } from "./types.js";
+import { DEFAULT_ENGINE_ID, type ServerConfig } from "./types.js";
 import serverPackage from "../package.json" with { type: "json" };
 
 const MANIFEST_FILE = "ipollowork.plugin.json";
@@ -23,6 +24,12 @@ const TRUSTED_IMPORT_PUBLISHER_KEYS = new Map([
     "MCowBQYDK2VwAyEARwKWW0VeQqnxh1WiOi8+kAutSITD476eRaRguDZkxYk=",
   ],
 ]);
+
+function workspaceEngineAdapter(config: ServerConfig, workspaceId: string): PluginEngineAdapter {
+  const workspace = config.workspaces.find((entry) => entry.id === workspaceId);
+  if (!workspace) throw new ApiError(404, "workspace_not_found", "Workspace not found");
+  return pluginEngineAdapters.get(workspace.engineId?.trim() || DEFAULT_ENGINE_ID);
+}
 
 const ownedFileSchema = z.object({ path: z.string(), sha256: z.string() });
 const installedVersionSchema = z.object({
@@ -273,18 +280,18 @@ function satisfiesRange(version: string, range: string): boolean {
   return satisfiesPredicate(tuple, range);
 }
 
-function assertRuntimeCompatibility(manifest: PluginPackageManifest): void {
+function assertRuntimeCompatibility(manifest: PluginPackageManifest, engineAdapter: PluginEngineAdapter): void {
   const compatibility = manifest.package?.compatibility;
   const supportedEngines = manifest.package?.engines;
-  if (supportedEngines && !supportedEngines.includes(pluginEngineAdapter.id)) {
-    throw new ApiError(409, "plugin_package_incompatible", `Plugin does not support ${pluginEngineAdapter.id}`, {
-      engine: pluginEngineAdapter.id,
+  if (supportedEngines && !supportedEngines.includes(engineAdapter.id)) {
+    throw new ApiError(409, "plugin_package_incompatible", `Plugin does not support ${engineAdapter.id}`, {
+      engine: engineAdapter.id,
       supportedEngines,
     });
   }
   const checks = [
     { name: "iPolloWork", version: serverPackage.version, range: compatibility?.ipollowork },
-    ...pluginEngineAdapter.compatibility(manifest),
+    ...engineAdapter.compatibility(manifest),
   ];
   for (const check of checks) {
     if (check.range && !satisfiesRange(check.version, check.range)) {
@@ -360,7 +367,7 @@ function workspaceActivationFiles(
   pluginId: string,
   version: InstalledVersion,
 ): PluginWorkspaceFile[] {
-  return pluginEngineAdapter.workspaceFiles(engineVersion(config, workspaceId, pluginId, version));
+  return workspaceEngineAdapter(config, workspaceId).workspaceFiles(engineVersion(config, workspaceId, pluginId, version));
 }
 
 function workspaceActivationPaths(
@@ -380,8 +387,9 @@ function skillActivationPaths(
   resourceIds: ReadonlySet<string>,
 ): Set<string> {
   const projected = engineVersion(config, workspaceId, pluginId, version);
+  const engineAdapter = workspaceEngineAdapter(config, workspaceId);
   return new Set([...resourceIds].flatMap((resourceId) => {
-    const targetPath = pluginEngineAdapter.skillTargetPath(projected, resourceId);
+    const targetPath = engineAdapter.skillTargetPath(projected, resourceId);
     return targetPath ? [targetPath] : [];
   }));
 }
@@ -497,6 +505,7 @@ async function applyVersion(
   }
 
   const enabled = installed?.enabled !== false;
+  const engineAdapter = workspaceEngineAdapter(config, workspaceId);
   try {
     for (const file of nextActivationFiles) {
       const source = resolveWithin(nextEngineVersion.artifactRoot, file.sourcePath);
@@ -514,7 +523,7 @@ async function applyVersion(
     for (const file of currentActivationFiles) {
       if (!nextPaths.has(file.targetPath)) await rm(resolveWithin(workspaceRoot, file.targetPath), { force: true });
     }
-    await pluginEngineAdapter.syncRuntime({
+    await engineAdapter.syncRuntime({
       config,
       workspaceId,
       resolvePath: resolveWithin,
@@ -523,7 +532,7 @@ async function applyVersion(
       enabled,
     });
   } catch (error) {
-    await pluginEngineAdapter.syncRuntime({
+    await engineAdapter.syncRuntime({
       config,
       workspaceId,
       resolvePath: resolveWithin,
@@ -552,7 +561,7 @@ async function applyVersion(
   }
 }
 
-export async function previewPluginPackage(input: { packageRoot: string; workspaceRoot: string }): Promise<PluginPackagePreview> {
+export async function previewPluginPackage(input: { packageRoot: string; workspaceRoot: string; engineId: string }): Promise<PluginPackagePreview> {
   const manifestPath = resolveWithin(input.packageRoot, MANIFEST_FILE);
   let sourceManifest: unknown;
   let manifest: PluginPackageManifest;
@@ -564,7 +573,8 @@ export async function previewPluginPackage(input: { packageRoot: string; workspa
     throw error;
   }
   if (!manifest.package) throw new ApiError(400, "plugin_package_metadata_required", "Package metadata is required for installation");
-  assertRuntimeCompatibility(manifest);
+  const engineAdapter = pluginEngineAdapters.get(input.engineId);
+  assertRuntimeCompatibility(manifest, engineAdapter);
   const resourcePaths = [...new Set([
     ...manifest.resources.flatMap((resource) => resource.path ? [resource.path] : []),
     ...manifest.engineBindings?.flatMap((binding) => binding.capabilities.flatMap((capability) => capability.path ? [capability.path] : [])) ?? [],
@@ -575,7 +585,7 @@ export async function previewPluginPackage(input: { packageRoot: string; workspa
   }
   const files: OwnedFile[] = [];
   for (const path of [...paths].sort()) files.push({ path, sha256: await sha256(resolveWithin(input.packageRoot, path)) });
-  const writes = pluginEngineAdapter.workspaceFiles({ manifest, artifactRoot: input.packageRoot, files })
+  const writes = engineAdapter.workspaceFiles({ manifest, artifactRoot: input.packageRoot, files })
     .map((file) => ({ path: file.targetPath, sha256: file.sha256 }));
   return { manifest, files, writes, integrity: integrityForManifest(manifest, files, sourceManifest) };
 }
@@ -758,7 +768,11 @@ export async function installPluginPackage(input: {
   packageRoot: string;
   workspaceRoot: string;
 }): Promise<PluginPackageInstallResult> {
-  const preview = await previewPluginPackage(input);
+  const preview = await previewPluginPackage({
+    packageRoot: input.packageRoot,
+    workspaceRoot: input.workspaceRoot,
+    engineId: workspaceEngineAdapter(input.serverConfig, input.workspaceId).id,
+  });
   if (!preview.manifest.package) throw new ApiError(400, "plugin_package_metadata_required", "Package metadata is required for installation");
   const state = await readState(input.serverConfig, input.workspaceId);
   const existing = state.packages[preview.manifest.id];
@@ -798,7 +812,11 @@ export async function updatePluginPackage(input: {
   packageRoot: string;
   workspaceRoot: string;
 }): Promise<PluginPackageUpdateResult> {
-  const preview = await previewPluginPackage(input);
+  const preview = await previewPluginPackage({
+    packageRoot: input.packageRoot,
+    workspaceRoot: input.workspaceRoot,
+    engineId: workspaceEngineAdapter(input.serverConfig, input.workspaceId).id,
+  });
   if (!preview.manifest.package) throw new ApiError(400, "plugin_package_metadata_required", "Package metadata is required for installation");
   const state = await readState(input.serverConfig, input.workspaceId);
   const installed = state.packages[preview.manifest.id];
@@ -875,6 +893,7 @@ export async function setPluginPackageEnabled(input: {
     inactiveActivationPaths(input.serverConfig, input.workspaceId, installed, current),
   );
   const currentEngineVersion = engineVersion(input.serverConfig, input.workspaceId, installed.pluginId, current);
+  const engineAdapter = workspaceEngineAdapter(input.serverConfig, input.workspaceId);
   const activationFiles = workspaceActivationFiles(input.serverConfig, input.workspaceId, installed.pluginId, current);
   const allActivationPaths = new Set(activationFiles.map((file) => file.targetPath));
   const disabledSkillPaths = skillActivationPaths(
@@ -894,7 +913,7 @@ export async function setPluginPackageEnabled(input: {
       throw new ApiError(409, "plugin_package_conflict", "Plugin skill targets already exist", { paths: conflicts });
     }
   }
-  await pluginEngineAdapter.syncRuntime({
+  await engineAdapter.syncRuntime({
     config: input.serverConfig,
     workspaceId: input.workspaceId,
     resolvePath: resolveWithin,
@@ -991,6 +1010,7 @@ export async function uninstallPluginPackage(input: {
   if (!installed) throw new ApiError(404, "plugin_package_not_installed", "Plugin package is not installed");
   const current = installed.versions[installed.currentVersion];
   if (!current) throw new ApiError(500, "plugin_package_state_invalid", "Installed package version is missing");
+  const engineAdapter = workspaceEngineAdapter(input.serverConfig, input.workspaceId);
   await assertOwnedFilesUnchanged(
     input.serverConfig,
     input.workspaceId,
@@ -999,7 +1019,7 @@ export async function uninstallPluginPackage(input: {
     current,
     inactiveActivationPaths(input.serverConfig, input.workspaceId, installed, current),
   );
-  await pluginEngineAdapter.syncRuntime({
+  await engineAdapter.syncRuntime({
     config: input.serverConfig,
     workspaceId: input.workspaceId,
     resolvePath: resolveWithin,

--- a/apps/server/src/routes/workspaces.ts
+++ b/apps/server/src/routes/workspaces.ts
@@ -3,7 +3,7 @@ import { basename, dirname, resolve } from "node:path";
 import { recordAudit } from "../audit.js";
 import { ApiError } from "../errors.js";
 import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection } from "../opencode-connection.js";
-import type { ServerConfig, WorkspaceInfo } from "../types.js";
+import { DEFAULT_ENGINE_ID, type ServerConfig, type WorkspaceInfo } from "../types.js";
 import { ensureDir, exists, shortId } from "../utils.js";
 import { defaultWorkspaceiPolloWorkConfig, ensureWorkspaceFiles } from "../workspace-init.js";
 import { seediPolloWorkWorkspaceConfigIfEmpty } from "../ipollowork-workspace-config-store.js";
@@ -201,6 +201,7 @@ function serializeWorkspaceConfigEntry(workspace: WorkspaceInfo): Record<string,
     preset: workspace.preset,
     ...(workspace.workContextId ? { workContextId: workspace.workContextId } : {}),
     workspaceType: workspace.workspaceType,
+    engineId: workspace.engineId?.trim() || DEFAULT_ENGINE_ID,
     ...(workspace.remoteType ? { remoteType: workspace.remoteType } : {}),
     ...(!isLocalWorkspace && workspace.baseUrl ? { baseUrl: workspace.baseUrl } : {}),
     ...(!isLocalWorkspace && workspace.directory ? { directory: workspace.directory } : {}),
@@ -305,6 +306,7 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
       preset,
       ...(workContextId ? { workContextId } : {}),
       workspaceType: "local",
+      engineId: DEFAULT_ENGINE_ID,
       ...inheritWorkspaceOpencodeConnection(config),
     };
 
@@ -392,6 +394,7 @@ export function registerWorkspaceRoutes(options: RegisterWorkspaceRoutesOptions)
       preset: "remote",
       ...(workContextId ? { workContextId } : {}),
       workspaceType: "remote",
+      engineId: DEFAULT_ENGINE_ID,
       remoteType,
       baseUrl: remoteType === "ipollowork" ? (ipolloworkHostUrl ?? baseUrl) : baseUrl,
       ...(directory ? { directory } : {}),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -4,7 +4,7 @@ import { homedir, hostname } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import { IPOLLOWORK_PACKAGE_EXTENSION, IPOLLOWORK_PACKAGE_MEDIA_TYPE, templateCategorySchema } from "@ipollowork/types/templates";
-import type { ApprovalRequest, Capabilities, ServerConfig, WorkspaceInfo, Actor, ReloadReason, ReloadTrigger, TokenScope } from "./types.js";
+import { DEFAULT_ENGINE_ID, type ApprovalRequest, type Capabilities, type ServerConfig, type WorkspaceInfo, type Actor, type ReloadReason, type ReloadTrigger, type TokenScope } from "./types.js";
 import { ApprovalService } from "./approvals.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
@@ -1843,7 +1843,7 @@ function createRoutes(
     const installedById = new Map(installed.map((item) => [item.pluginId, item]));
     const items = await Promise.all(bundledPluginPackageIds.map(async (pluginId) => {
       const packageRoot = await resolveBundledPluginPackageRoot(pluginId);
-      const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+      const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
       const current = installedById.get(pluginId);
       return {
         pluginId,
@@ -1864,7 +1864,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const pluginId = ctx.params.pluginId ?? "";
     const packageRoot = await resolveBundledPluginPackageRoot(pluginId);
-    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
     await requireApproval(ctx, {
       workspaceId: workspace.id,
       action: "plugin_packages.install",
@@ -1902,7 +1902,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readPluginPackageUploadBody(ctx.request);
     return withMaterializedPluginPackageUpload(body, async ({ packageRoot }) => {
-      const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+      const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
       const safety = await assertPluginPackageSafeForImport({ packageRoot, preview });
       return jsonResponse({ preview: { ...preview, safety } });
     });
@@ -1914,7 +1914,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readPluginPackageUploadBody(ctx.request);
     return withMaterializedPluginPackageUpload(body, async ({ archiveName, packageRoot }) => {
-      const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+      const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
       const safety = await assertPluginPackageSafeForImport({ packageRoot, preview });
       await requireApproval(ctx, {
         workspaceId: workspace.id,
@@ -1951,7 +1951,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const packageRoot = resolveLocalPluginPackageRoot(workspace.path, body.packageRoot);
-    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
     const safety = await assertPluginPackageSafeForImport({ packageRoot, preview });
     return jsonResponse({ preview: { ...preview, safety } });
   });
@@ -1962,7 +1962,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const packageRoot = resolveLocalPluginPackageRoot(workspace.path, body.packageRoot);
-    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
     await assertPluginPackageSafeForImport({ packageRoot, preview });
     await requireApproval(ctx, {
       workspaceId: workspace.id,
@@ -1991,7 +1991,7 @@ function createRoutes(
     const workspace = await resolveWorkspace(config, ctx.params.id);
     const body = await readJsonBody(ctx.request);
     const packageRoot = resolveLocalPluginPackageRoot(workspace.path, body.packageRoot);
-    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path });
+    const preview = await previewPluginPackage({ packageRoot, workspaceRoot: workspace.path, engineId: workspace.engineId ?? DEFAULT_ENGINE_ID });
     await assertPluginPackageSafeForImport({ packageRoot, preview });
     if (preview.manifest.id !== ctx.params.pluginId) throw new ApiError(400, "plugin_package_id_mismatch", "Update package ID does not match the installed plugin");
     await requireApproval(ctx, {

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -14,6 +14,8 @@ export type ProviderPlacement = "in-sandbox" | "host-machine" | "client-machine"
 
 export type LogFormat = "pretty" | "json";
 
+export const DEFAULT_ENGINE_ID = "opencode";
+
 export interface WorkspaceConfig {
   id?: string;
   path: string;
@@ -21,6 +23,7 @@ export interface WorkspaceConfig {
   preset?: string;
   workContextId?: `enterprise:${string}`;
   workspaceType?: WorkspaceType;
+  engineId?: string;
   remoteType?: RemoteType;
   baseUrl?: string;
   directory?: string;
@@ -43,6 +46,7 @@ export interface WorkspaceInfo {
   preset: string;
   workContextId?: `enterprise:${string}`;
   workspaceType: WorkspaceType;
+  engineId?: string;
   remoteType?: RemoteType;
   baseUrl?: string;
   directory?: string;

--- a/apps/server/src/workspaces.test.ts
+++ b/apps/server/src/workspaces.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { findManagedEngineWorkspace } from "./workspaces.js";
-import type { WorkspaceInfo } from "./types.js";
+import { buildWorkspaceInfos, findManagedEngineWorkspace } from "./workspaces.js";
+import { DEFAULT_ENGINE_ID, type WorkspaceInfo } from "./types.js";
 
 function ws(fields: {
   id?: string;
@@ -18,6 +18,18 @@ function ws(fields: {
     workspaceType: fields.workspaceType,
   };
 }
+
+describe("workspace engine selection", () => {
+  test("defaults existing workspace configs to OpenCode", () => {
+    const [workspace] = buildWorkspaceInfos([{ path: "./workspace" }], "/tmp");
+    expect(workspace?.engineId).toBe(DEFAULT_ENGINE_ID);
+  });
+
+  test("preserves an explicitly selected engine", () => {
+    const [workspace] = buildWorkspaceInfos([{ path: "./workspace", engineId: "deepseek-harness" }], "/tmp");
+    expect(workspace?.engineId).toBe("deepseek-harness");
+  });
+});
 
 describe("findManagedEngineWorkspace", () => {
   test("selects the local workspace in a typical local + remote config", () => {

--- a/apps/server/src/workspaces.ts
+++ b/apps/server/src/workspaces.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { basename, resolve } from "node:path";
-import type { WorkspaceConfig, WorkspaceInfo } from "./types.js";
+import { DEFAULT_ENGINE_ID, type WorkspaceConfig, type WorkspaceInfo } from "./types.js";
 
 function workspaceIdForKey(key: string): string {
   const hash = createHash("sha256").update(key).digest("hex");
@@ -55,6 +55,7 @@ export function buildWorkspaceInfos(
       preset: workspace.preset?.trim() || (workspaceType === "remote" ? "remote" : "starter"),
       workContextId: workspace.workContextId,
       workspaceType,
+      engineId: workspace.engineId?.trim() || DEFAULT_ENGINE_ID,
       remoteType,
       baseUrl: workspace.baseUrl,
       directory: workspace.directory,

--- a/docs/scenario/plugin-package-lifecycle.md
+++ b/docs/scenario/plugin-package-lifecycle.md
@@ -1,7 +1,7 @@
 # Scenario: Lightweight lifecycle over an engine adapter
 - Given: A validated package contains portable resources and optional native engine capabilities.
 - When: The user previews, installs, disables, enables, updates, rolls back, or uninstalls the package.
-- Then: iPolloWork records file ownership and versions while the active engine adapter projects runtime files and configuration without leaking engine details into the lifecycle.
+- Then: iPolloWork selects the workspace engine from the adapter registry, records file ownership and versions, and projects runtime files and configuration without leaking engine details into the lifecycle.
 
 ## Test Steps
 
@@ -12,6 +12,7 @@
 - Case 5 (rollback): Restore the prior immutable version and its owned files after an update.
 - Case 6 (uninstall): Remove only owned files, plugin configuration, package state, and authorization records.
 - Case 7 (runtime lifecycle): Reuse one lazy service instance during normal calls and dispose it on update, disable, authorization changes, uninstall, and server shutdown.
+- Case 8 (engine selection): Resolve the workspace engine through the registry, reject unknown engines, and keep OpenCode as the unchanged default.
 
 ## Status
 - [x] Write scenario document

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -24,6 +24,7 @@ export type WorkspaceWire = {
   /** The owning application context. Missing/null records belong to Personal. */
   workContextId?: `enterprise:${string}` | null;
   workspaceType: WorkspaceKind;
+  engineId?: string | null;
   remoteType?: WorkspaceRemoteKind | null;
   baseUrl?: string | null;
   directory?: string | null;


### PR DESCRIPTION
## What changed

- Replace the fixed OpenCode plugin adapter singleton with an immutable engine adapter registry.
- Select the plugin adapter from each workspace's `engineId`, keeping OpenCode as the default.
- Route preview, install, update, enable/disable, rollback, and uninstall operations through the selected adapter.
- Remove the old fixed-adapter symbol and add registry, selection, defaulting, and unknown-engine coverage.

## Why

This creates the smallest clean boundary for future plugin support across multiple agent engines without changing today's OpenCode behavior or adding a user-visible switch.

## Validation

- Server typecheck: passed
- App typecheck: passed
- Server build: passed
- Engine registry tests: 2 passed
- Workspace tests: 8 passed
- Maintainability audit: passed with no warnings
- `git diff --check`: passed
- Full server suite: 449 passed, 7 skipped, 1 failed
  - The single catalog assertion failure is also reproducible unchanged on `main`: it expects GitHub category `开发者工具`, while the bundled manifest now returns `开发与运维`.
- GitHub Actions macOS app tests currently report two stale Video Studio source assertions.
  - Both failures reproduce unchanged on `main`, and this PR does not modify `apps/app` implementation or tests.
- No UI surface changed, so visual/Fraimz validation is not applicable.