### PR TITLE
docs: present DeepSeek Design as a core Harness capability

### DIFF
--- a/external-plugins/deepseek-harness/README.md
+++ b/external-plugins/deepseek-harness/README.md
@@ -1,51 +1,283 @@
-# DeepSeek Design
+<h1 align="center">DeepSeek Design</h1>
 
-Native iPolloWork Design and PPT Studios for DeepSeek Harness.
+<p align="center">
+  <strong>由 iPolloWork 推出的 DeepSeek Harness 核心设计系统</strong><br />
+  让 DeepSeek Harness 不只回答问题，也能生成、理解并持续修改真正可编辑的设计作品。
+</p>
 
-This directory is the source of two independently installed plugins:
+<p align="center">
+  <a href="#简体中文">简体中文</a> · <a href="#english">English</a>
+</p>
 
-- [`deepseek-idesign`](https://www.npmjs.com/package/deepseek-idesign) — websites, app prototypes, posters,
-  information cards, reports, magazines, and other non-slide designs.
-- [`deepseek-ippt`](https://www.npmjs.com/package/deepseek-ippt) — presentations and slide templates only.
-
-## Install
-
-```sh
-dsh plugin --profile web add deepseek-idesign
-dsh plugin --profile web add deepseek-ippt
-dsh --profile web
-```
-
-Install either package or both. Each one contains its browser assets and does
-not install the iPolloWork desktop app.
-
-## One source, two entry points
-
-The iPolloWork repository is the only source of truth for product code. Every
-change to the shared Design Studio is built once and flows to both DeepSeek
-plugins. The public
-[`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) repository is
-an automatically generated distribution and contribution mirror: it provides
-complete runnable packages, source references, issues, and a focused discovery
-page without creating a second implementation to maintain.
-
-## Contributing code
-
-Open source pull requests in `deepseek-design` against `source/` or the root
-README. Do not edit generated runtime files under `packages/` directly. After a
-source change is merged there, iPolloWork imports it as a reviewable upstream
-pull request. Merging the upstream pull request rebuilds both plugins and
-synchronizes the result back to `deepseek-design`.
-
-## License
-
-These plugins use the same iPolloWork Source Available License as the main
-repository. Third-party components and previously licensed portions retain
-their respective licenses.
+<p align="center">
+  <a href="https://www.npmjs.com/package/deepseek-idesign"><img alt="deepseek-idesign" src="https://img.shields.io/npm/v/deepseek-idesign?label=deepseek-idesign&color=3b82f6" /></a>
+  <a href="https://www.npmjs.com/package/deepseek-ippt"><img alt="deepseek-ippt" src="https://img.shields.io/npm/v/deepseek-ippt?label=deepseek-ippt&color=8b5cf6" /></a>
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img alt="DeepSeek Harness plugin" src="https://img.shields.io/badge/DeepSeek%20Harness-plugin-111827" /></a>
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-iPolloWork%20Source%20Available-0f766e" /></a>
+</p>
 
 ---
 
-DeepSeek Design 将 iPolloWork 的 Design Studio 与 PPT Studio 作为两个可独立安装
-的 DeepSeek Harness 插件提供。大家可以在 `deepseek-design` 的 `source/` 目录
-提交代码；合并后会自动生成 iPolloWork 主库 PR。主库合并后再重新构建并同步
-回来，因此始终只有一套官方源码。
+<a id="简体中文"></a>
+
+## DeepSeek Harness 的核心设计能力
+
+**DeepSeek Design** 是由 [iPolloWork](https://github.com/Devin-AXIS/iPolloWork) 推出、专为 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 构建的原生可视化设计系统。
+
+它把 DeepSeek Harness 作为理解需求、生成内容和修改文件的 AI 引擎，把 iPolloWork Design Studio 作为可视化创作与精调界面。你可以在对话中提出完整需求，也可以选中画布里的一个标题、一张图片或一个组件，让 AI 只修改当前对象；需要更精确时，则直接在 Studio 中调整文字、字体、颜色、尺寸、间距、背景、链接与图片。
+
+你可以把它理解为 DeepSeek Harness 中类似 Claude Design 的开放设计工作流：**AI 负责从意图到作品，Studio 负责从作品到细节，最终结果仍是工作区中真实、可保存、可继续编辑的文件。**
+
+DeepSeek Design 不是另一个聊天机器人，也不会替换 DeepSeek Harness。它以原生插件方式进入 Harness 的对话界面，复用当前会话、模型、工作区与权限体系，为 Harness 增加一套专门的 Design 能力。
+
+## 从一句话到可交付设计
+
+1. 在 DeepSeek Harness 中描述你想要的网站、App 原型、海报、信息卡、报告或演示文稿。
+2. Harness 在当前工作区生成或修改 HTML、CSS、设计令牌和项目说明文件。
+3. 打开对话旁的 **Design** 或 **PPT** 视图，实时查看结果。
+4. 直接编辑画布，或选中具体元素后使用 **Ask AI** 继续修改。
+5. 继续对话、切换模板或撤销修改；PPT 作品还可导出为 PDF 或 PPTX。
+
+这是一条持续循环的创作流程，而不是一次性的图片生成：
+
+```text
+描述需求 → AI 生成 → Studio 预览 → 手动精调 / Ask AI → 保存到工作区 → 继续迭代
+```
+
+## 两个独立插件，一套设计系统
+
+| 插件 | 面向场景 | 核心能力 |
+| --- | --- | --- |
+| [`deepseek-idesign`](https://www.npmjs.com/package/deepseek-idesign) | 网站、App 原型、海报、信息卡、数据报告、杂志与其他非幻灯片设计 | Design 模板市场、桌面/移动预览、可视化元素编辑、主题与设计令牌、选区 Ask AI |
+| [`deepseek-ippt`](https://www.npmjs.com/package/deepseek-ippt) | 演示文稿与幻灯片 | 独立 PPT 模板市场、逐页编辑、可视化精调、选区 Ask AI、PDF/PPTX 导出 |
+
+两个插件可以单独安装，也可以一起使用。它们共享同一套 iPolloWork Design Studio 与模板协议，但项目目录彼此隔离，因此不会相互覆盖。
+
+Video Studio 不包含在本项目中，也不会因为安装 DeepSeek Design 而被下载或启动。
+
+## 核心特性
+
+- **Harness 原生界面**：Design 与 PPT 作为独立视图出现在 DeepSeek Harness 对话中，不需要启动 iPolloWork 桌面端。
+- **AI 与手动编辑并存**：既能让 AI 完整生成或重构，也能在画布中直接修改单个元素和全局主题。
+- **选区级 Ask AI**：选中元素后，插件把明确的文件、定位信息和当前样式整理为对话草稿；由用户确认后再发送，不会自动提交。
+- **真实项目文件**：作品保存在 Harness 工作区，而不是封闭的云端画布或不可编辑截图。
+- **模板市场**：Design 与 PPT 拥有各自的精选模板入口；网站和海报不会混入 PPT，幻灯片也不会混入 Design。
+- **可逆编辑**：支持保存、撤销和文件变更冲突检测，降低 AI 与手动编辑同时发生时的覆盖风险。
+- **设计系统能力**：通过设计令牌统一管理颜色、字体、背景、圆角、阴影、间距和组件视觉语言。
+- **独立安装**：每个 npm 包都包含所需的浏览器资源，只安装选择的能力，不把完整 iPolloWork 主项目带入 Harness。
+
+## 快速开始
+
+### 环境要求
+
+- Node.js `^22.19.0` 或 `>=24.0.0`
+- DeepSeek Harness 当前版本及其插件管理所需的 pnpm
+
+DeepSeek Harness 仍处于开发者预览阶段，可能出现兼容性变更。请优先使用最新版本，详见其[官方项目](https://github.com/deepseek-ai/deepseek-harness)。
+
+### 只安装 Design
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign
+npx @deepseek-ai/dsh web
+```
+
+### 同时安装 Design 与 PPT
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt
+npx @deepseek-ai/dsh web
+```
+
+如果已经安装了 `dsh` 命令，可以把上面的 `npx @deepseek-ai/dsh` 直接替换为 `dsh`。Web 界面默认运行在 [http://127.0.0.1:3080](http://127.0.0.1:3080)。
+
+### 更新或卸载
+
+```sh
+# 更新
+npx @deepseek-ai/dsh plugin --profile web update deepseek-idesign deepseek-ippt
+
+# 卸载
+npx @deepseek-ai/dsh plugin --profile web remove deepseek-idesign deepseek-ippt
+```
+
+## 如何使用
+
+1. 在要作为工作区的项目目录中启动 DeepSeek Harness。
+2. 新建或打开一个对话，在对话视图中选择 **Design** 或 **PPT**。
+3. 点击编辑开关旁的 `+` 打开对应模板市场，或直接让 AI 从当前空白项目开始创作。
+4. 点击画布中的元素进行精调；需要 AI 帮助时，点击 **Ask AI**，检查自动填入的修改要求后再发送。
+5. 所有修改都会回到当前工作区，后续对话仍可继续读取和编辑。
+
+Design 项目保存在：
+
+```text
+design/<sessionId>/
+```
+
+PPT 项目保存在：
+
+```text
+design/<sessionId>-ippt/
+```
+
+## 安全与数据边界
+
+- 插件只接受 DeepSeek Harness 已注册的工作区，并将读写限制在工作区的 `design/` 目录内。
+- Studio iframe 使用进程级随机令牌访问宿主接口，并校验同源消息。
+- 文本写入带版本冲突检查并采用原子替换，避免静默覆盖较新的文件。
+- 模板应用先在隔离目录中完成校验，再原子替换当前项目；失败时恢复原项目。
+- **Ask AI** 只填写当前对话的草稿，不会代替用户发送消息。
+- 安装插件不会安装或启动 iPolloWork 桌面应用，也不会载入 Video Studio。
+
+## 项目结构与同步方式
+
+```text
+packages/
+  deepseek-idesign/       可直接安装的完整 Design 插件
+  deepseek-ippt/          可直接安装的完整 PPT 插件
+source/
+  plugins/                DeepSeek Harness 适配器源码
+  shared/                 两个插件共用的 Studio 协议与类型
+SOURCE_COMMIT             对应的 iPolloWork 主库提交
+repository.json           包版本与源码来源清单
+```
+
+[iPolloWork](https://github.com/Devin-AXIS/iPolloWork) 是产品源码的唯一事实来源；[`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) 是面向 DeepSeek Harness 用户的独立发布与贡献入口。
+
+社区可以在本仓库修改 `source/` 或根目录 README。合并后，自动流程会在 iPolloWork 主库创建可审查的上游 PR；上游合并后再统一构建两个插件，并把结果同步回本仓库。这样，iPolloWork、DeepSeek Design 和两个 npm 包始终由同一套 Studio 能力升级，不需要分别维护功能分叉。
+
+请不要直接修改 `packages/` 下的生成产物。
+
+## 参与贡献
+
+- 功能建议与问题反馈：[GitHub Issues](https://github.com/Devin-AXIS/deepseek-design/issues)
+- 源码贡献：修改 [`source/`](https://github.com/Devin-AXIS/deepseek-design/tree/main/source) 并提交 Pull Request
+- iPolloWork 核心 Studio 与模板贡献：[iPolloWork](https://github.com/Devin-AXIS/iPolloWork)
+
+## 许可
+
+本项目使用与 iPolloWork 主仓库一致的 [iPolloWork Source Available License](LICENSE)。第三方组件及历史许可部分继续保留各自的许可条款。
+
+---
+
+<a id="english"></a>
+
+## The core design capability for DeepSeek Harness
+
+**DeepSeek Design** is a native visual design system created by [iPolloWork](https://github.com/Devin-AXIS/iPolloWork) for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness).
+
+It uses DeepSeek Harness as the AI engine that understands a brief, creates content, and edits workspace files, while iPolloWork Design Studio provides the visual surface for previewing and refining the result. Ask for a complete design in conversation, select one heading, image, or component for a focused AI change, or directly adjust text, typography, color, size, spacing, backgrounds, links, and media in Studio.
+
+Think of it as an open, source-available Claude Design-style workflow inside DeepSeek Harness: **AI moves from intent to artifact, Studio moves from artifact to detail, and the result remains a real, editable project in your workspace.**
+
+DeepSeek Design is not a separate chatbot and does not replace Harness. It installs as a native Harness bundle and reuses the active conversation, model, workspace, and permission system to give Harness a dedicated Design capability.
+
+## One continuous design loop
+
+```text
+Brief → AI generation → Studio preview → Visual edit / Ask AI → Workspace files → Iterate
+```
+
+1. Describe a website, app prototype, poster, information card, report, or presentation.
+2. Harness creates or updates the HTML, CSS, design tokens, and project metadata in the current workspace.
+3. Open the **Design** or **PPT** conversation view to see the result immediately.
+4. Edit directly on the canvas or select an element and use **Ask AI** for a focused change.
+5. Continue the conversation, switch templates, or undo changes; presentations can also be exported to PDF or PPTX.
+
+## Two plugins, one design system
+
+| Plugin | Best for | Main capabilities |
+| --- | --- | --- |
+| [`deepseek-idesign`](https://www.npmjs.com/package/deepseek-idesign) | Websites, app prototypes, posters, cards, data reports, magazines, and other non-slide designs | Curated Design templates, desktop/mobile preview, direct element editing, themes and design tokens, selection-aware Ask AI |
+| [`deepseek-ippt`](https://www.npmjs.com/package/deepseek-ippt) | Presentations and slide decks | Dedicated slide templates, page-by-page editing, visual refinement, selection-aware Ask AI, PDF/PPTX export |
+
+Install either plugin or both. They share the same iPolloWork Design Studio and template contract, while keeping their project directories isolated. Video Studio is intentionally not part of this repository or either package.
+
+## Highlights
+
+- **Native Harness surface** — Design and PPT appear as dedicated conversation views; the iPolloWork desktop app is not required.
+- **AI plus direct manipulation** — generate or restructure with AI, then refine individual elements and the global theme visually.
+- **Selection-aware Ask AI** — the selected element, file location, and styles are prepared as a reviewable conversation draft and are never submitted automatically.
+- **Real workspace files** — designs remain editable HTML, CSS, tokens, and metadata instead of a closed canvas or flattened screenshot.
+- **Curated template catalogs** — Design and PPT have separate template entry points, so slide templates never pollute the general design catalog.
+- **Reversible editing** — save, undo, and write-conflict detection protect mixed AI and manual workflows.
+- **Design-system controls** — colors, typography, backgrounds, radii, shadows, spacing, and component language stay coordinated through design tokens.
+- **Independent installation** — each npm package includes its browser assets and installs only the selected capability.
+
+## Quick start
+
+### Requirements
+
+- Node.js `^22.19.0` or `>=24.0.0`
+- A current DeepSeek Harness release and pnpm for its plugin manager
+
+DeepSeek Harness is currently a developer preview and may introduce compatibility-breaking changes. Follow its [official repository](https://github.com/deepseek-ai/deepseek-harness) for current requirements.
+
+### Install Design only
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign
+npx @deepseek-ai/dsh web
+```
+
+### Install Design and PPT
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt
+npx @deepseek-ai/dsh web
+```
+
+If `dsh` is already installed, replace `npx @deepseek-ai/dsh` with `dsh`. The Web UI is served at [http://127.0.0.1:3080](http://127.0.0.1:3080) by default.
+
+### Update or remove
+
+```sh
+# Update
+npx @deepseek-ai/dsh plugin --profile web update deepseek-idesign deepseek-ippt
+
+# Remove
+npx @deepseek-ai/dsh plugin --profile web remove deepseek-idesign deepseek-ippt
+```
+
+## Using the Studio
+
+1. Start DeepSeek Harness from the directory you want to use as the workspace.
+2. Create or open a conversation and choose the **Design** or **PPT** view.
+3. Use the `+` beside Edit to open the matching template catalog, or ask the AI to start from the blank project.
+4. Select elements for direct editing. Use **Ask AI** when you want Harness to make the next change, then review the prepared draft before sending it.
+5. Every change remains in the current workspace and can be read or edited by later turns.
+
+Design projects use `design/<sessionId>/`; PPT projects use `design/<sessionId>-ippt/`.
+
+## Security and data boundaries
+
+- Access is limited to workspaces registered by DeepSeek Harness and paths below their `design/` directory.
+- The Studio iframe uses a random per-process token and same-origin message checks.
+- Writes use conflict checks and atomic replacement; template changes are staged and validated before replacing a project.
+- **Ask AI** only prepares a draft in the current conversation and never submits it for the user.
+- Installing these packages does not install or launch the iPolloWork desktop app or Video Studio.
+
+## Repository model
+
+```text
+packages/               Complete, installable plugin builds
+source/plugins/         DeepSeek Harness adapter sources
+source/shared/          Shared Studio protocol and types
+SOURCE_COMMIT           Matching iPolloWork source commit
+repository.json         Package and provenance manifest
+```
+
+[iPolloWork](https://github.com/Devin-AXIS/iPolloWork) is the single source of truth for product code. [`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) is the focused distribution and contribution entry point for Harness users.
+
+Pull requests may update `source/` or this README. Accepted changes are imported into iPolloWork as a reviewable upstream pull request. After that pull request is merged, both plugins are rebuilt from the same Studio source and synchronized back here. Do not edit generated runtime files under `packages/` directly.
+
+## Contributing
+
+- Ideas and bug reports: [GitHub Issues](https://github.com/Devin-AXIS/deepseek-design/issues)
+- Adapter contributions: open a pull request against [`source/`](https://github.com/Devin-AXIS/deepseek-design/tree/main/source)
+- Core Studio and template contributions: [iPolloWork](https://github.com/Devin-AXIS/iPolloWork)
+
+## License
+
+This project uses the same [iPolloWork Source Available License](LICENSE) as the main iPolloWork repository. Third-party components and previously licensed portions retain their respective licenses.

--- a/external-plugins/deepseek-harness/design-studio/README.md
+++ b/external-plugins/deepseek-harness/design-studio/README.md
@@ -1,44 +1,139 @@
 # DeepSeek iDesign
 
-This bundle adds the existing iPolloWork Design Studio as a native `Design`
-conversation view in the DeepSeek Harness web app. Design files stay in the
-active Harness workspace under `design/<sessionId>/`; selected elements can be
-sent into the current conversation draft without automatically submitting it.
+> 由 iPolloWork 为 DeepSeek Harness 打造的原生可视化 Design Studio。
+>
+> Native visual Design Studio for DeepSeek Harness, created by iPolloWork.
 
-The `+` beside Edit opens the curated iPolloWork catalog for websites, app
-prototypes, posters, cards, reports, articles, and other non-slide designs.
-Video and slide templates are intentionally excluded; slides are provided by
-the separate `deepseek-ippt` package.
+[简体中文](#简体中文) · [English](#english) · [DeepSeek Design 项目](https://github.com/Devin-AXIS/deepseek-design)
 
-## Install
+---
 
-Install the published package into the web profile and start Harness normally:
+<a id="简体中文"></a>
+
+## 让 DeepSeek Harness 真正拥有设计能力
+
+`deepseek-idesign` 将 iPolloWork Design Studio 作为原生 **Design** 视图加入 DeepSeek Harness。AI 可以根据对话创建和修改设计文件，你也可以在同一个界面里直接选中元素，精调文字、字体、颜色、尺寸、间距、背景、链接与图片。
+
+它适合网站、App 原型、海报、信息卡、数据报告、杂志文章等非幻灯片设计。编辑开关旁的 `+` 会打开专属 Design 模板市场；PPT 模板由独立的 [`deepseek-ippt`](https://www.npmjs.com/package/deepseek-ippt) 提供，Video Studio 不包含在本包中。
+
+### 核心能力
+
+- 作为 DeepSeek Harness 对话中的原生 **Design** 视图运行
+- AI 对话生成、全局修改与选区级 **Ask AI**
+- 画布内文字、排版、颜色、尺寸、间距、背景、链接和图片编辑
+- 桌面与移动端预览
+- 主题与设计令牌统一控制
+- Design 模板市场
+- 保存、撤销与文件冲突检测
+- 真实 HTML、CSS 和项目文件保存在当前 Harness 工作区
+
+## 安装并启动
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign
+npx @deepseek-ai/dsh web
+```
+
+如果已经安装 `dsh`，可使用：
 
 ```sh
 dsh plugin --profile web add deepseek-idesign
-dsh --profile web
+dsh web
 ```
 
-For a local release artifact:
+DeepSeek Harness Web 界面默认运行在 [http://127.0.0.1:3080](http://127.0.0.1:3080)。打开对话后选择 **Design**，即可进入 Studio。
+
+### 本地发布包
 
 ```sh
 pnpm pack
 dsh plugin --profile web add ./deepseek-idesign-0.2.1.tgz
+dsh web
 ```
 
-The plugin contains its own browser assets. It does not install or start the
-iPolloWork desktop application, and it does not load Video Studio.
+## 使用方式
+
+1. 在项目目录中启动 DeepSeek Harness。
+2. 创建对话并打开 **Design** 视图。
+3. 点击 `+` 选择模板，或直接让 AI 创建设计。
+4. 打开编辑模式并选择画布元素进行精调。
+5. 点击 **Ask AI** 时，插件会把当前元素和文件信息填入对话草稿；确认后再由你发送。
+
+项目保存在 `design/<sessionId>/`。插件自带浏览器资源，不会安装或启动 iPolloWork 桌面端，也不会载入 PPT 或 Video Studio。
+
+## 数据边界
+
+- 只访问 DeepSeek Harness 已注册工作区中的 `design/` 目录。
+- Studio iframe 使用进程级随机令牌并校验同源消息。
+- 写入带冲突检查并采用原子替换。
+- **Ask AI** 只准备草稿，不会自动发送消息。
+
+## 参与贡献
+
+请在 [`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) 仓库的 `source/plugins/deepseek-idesign` 下提交适配器改动。合并后的修改会作为可审查 PR 回到 iPolloWork 主库，并在上游合并后重新构建、同步和发布。
+
+---
+
+<a id="english"></a>
+
+## Give DeepSeek Harness a native design capability
+
+`deepseek-idesign` adds iPolloWork Design Studio to DeepSeek Harness as a native **Design** conversation view. Harness can create and edit the project through conversation, while you can select elements in the same surface and refine text, typography, color, size, spacing, backgrounds, links, and images directly.
+
+It is designed for websites, app prototypes, posters, information cards, data reports, magazines, and other non-slide work. The `+` beside Edit opens the dedicated Design template catalog. Slides are provided by [`deepseek-ippt`](https://www.npmjs.com/package/deepseek-ippt); Video Studio is not part of this package.
+
+### Highlights
+
+- Native **Design** view inside DeepSeek Harness conversations
+- Conversational generation, broad AI changes, and selection-aware **Ask AI**
+- Direct canvas editing for content, layout, media, and visual styles
+- Desktop and mobile preview
+- Shared themes and design-token controls
+- Curated non-slide template catalog
+- Save, undo, and write-conflict detection
+- Real HTML, CSS, and project files in the active Harness workspace
+
+## Install and run
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign
+npx @deepseek-ai/dsh web
+```
+
+If `dsh` is already installed:
+
+```sh
+dsh plugin --profile web add deepseek-idesign
+dsh web
+```
+
+The Web UI is served at [http://127.0.0.1:3080](http://127.0.0.1:3080) by default. Open a conversation and choose **Design** to enter the Studio.
+
+### Local release artifact
+
+```sh
+pnpm pack
+dsh plugin --profile web add ./deepseek-idesign-0.2.1.tgz
+dsh web
+```
+
+## Workflow
+
+1. Start DeepSeek Harness in the directory you want to use as the workspace.
+2. Create a conversation and open the **Design** view.
+3. Choose a template with `+`, or ask the AI to create a design from the blank project.
+4. Enable Edit and select canvas elements for direct refinement.
+5. Use **Ask AI** to prepare a focused change as a conversation draft, then review and send it yourself.
+
+Projects stay under `design/<sessionId>/`. The package includes its browser assets and does not install or launch the iPolloWork desktop app, PPT Studio, or Video Studio.
 
 ## Data boundary
 
-The host bridge accepts only the workspace registered by DeepSeek Harness and
-only paths below its `design/` directory. Writes use conflict checks and atomic
-replacement. The Studio iframe receives a per-process token; selecting
-`Ask AI` stages a draft for the user to review and never submits it itself.
+- Access is limited to the `design/` directory of workspaces registered by DeepSeek Harness.
+- The Studio iframe uses a random per-process token and same-origin message checks.
+- Writes use conflict detection and atomic replacement.
+- **Ask AI** prepares a draft and never submits a message automatically.
 
 ## Contributing
 
-Propose Design adapter changes in this repository under
-`source/plugins/deepseek-idesign`. Accepted changes are sent to iPolloWork as a
-reviewable upstream pull request and return here through the normal release
-sync after they are merged upstream.
+Propose adapter changes under `source/plugins/deepseek-idesign` in the [`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) repository. Accepted changes return to iPolloWork as a reviewable pull request, then are rebuilt, synchronized, and released after the upstream change is merged.

--- a/external-plugins/deepseek-harness/ppt-studio/README.md
+++ b/external-plugins/deepseek-harness/ppt-studio/README.md
@@ -1,24 +1,143 @@
 # DeepSeek iPPT
 
-This bundle adds iPolloWork PPT Studio as a native `PPT` conversation view in
-the DeepSeek Harness web app. The `+` beside Edit opens only the curated
-iPolloWork slide catalog; websites, app prototypes, posters, reports, and Video
-templates remain outside this package.
+> 由 iPolloWork 为 DeepSeek Harness 打造的原生可视化 PPT Studio。
+>
+> Native visual PPT Studio for DeepSeek Harness, created by iPolloWork.
 
-PPT projects stay isolated under `design/<sessionId>-ippt/`, so iPPT and
-`deepseek-idesign` can be installed together without replacing each other's
-files. Both packages use the same Studio implementation and template contract.
+[简体中文](#简体中文) · [English](#english) · [DeepSeek Design 项目](https://github.com/Devin-AXIS/deepseek-design)
 
-## Install
+---
+
+<a id="简体中文"></a>
+
+## 在 DeepSeek Harness 中完成整套演示文稿
+
+`deepseek-ippt` 将 iPolloWork PPT Studio 作为原生 **PPT** 视图加入 DeepSeek Harness。AI 可以在对话中梳理叙事、生成页面和修改内容，你也可以逐页预览并直接调整文字、图片、排版、颜色、位置与视觉样式。
+
+编辑开关旁的 `+` 只显示精选幻灯片模板，网站、App 原型、海报和报告模板不会混入其中。通用 Design 能力由独立的 [`deepseek-idesign`](https://www.npmjs.com/package/deepseek-idesign) 提供；两个插件可以同时安装。
+
+### 核心能力
+
+- DeepSeek Harness 对话中的原生 **PPT** 视图
+- AI 生成叙事、页面与内容，支持选区级 **Ask AI**
+- 逐页预览与可视化元素编辑
+- 独立 PPT 模板市场
+- 主题与设计令牌统一控制
+- 保存、撤销与文件冲突检测
+- 导出 PDF 与 PPTX
+- 与 iDesign 分目录存储，互不覆盖
+
+## 安装并启动
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-ippt
+npx @deepseek-ai/dsh web
+```
+
+如果已经安装 `dsh`，可使用：
 
 ```sh
 dsh plugin --profile web add deepseek-ippt
-dsh --profile web
+dsh web
 ```
 
-For a local release artifact:
+DeepSeek Harness Web 界面默认运行在 [http://127.0.0.1:3080](http://127.0.0.1:3080)。打开对话后选择 **PPT**，即可进入 Studio。
+
+### 本地发布包
 
 ```sh
 pnpm pack
 dsh plugin --profile web add ./deepseek-ippt-0.1.1.tgz
+dsh web
 ```
+
+## 使用方式
+
+1. 在项目目录中启动 DeepSeek Harness。
+2. 创建对话并打开 **PPT** 视图。
+3. 点击 `+` 选择幻灯片模板，或让 AI 从空白演示文稿开始创作。
+4. 逐页查看结果，打开编辑模式精调元素。
+5. 使用 **Ask AI** 继续修改叙事、页面或选中元素。
+6. 完成后下载 PDF 或 PPTX。
+
+项目保存在 `design/<sessionId>-ippt/`，可与 `deepseek-idesign` 同时使用。插件自带浏览器资源，不会安装或启动 iPolloWork 桌面端，也不会载入 Video Studio。
+
+## 数据边界
+
+- 只访问 DeepSeek Harness 已注册工作区中的 `design/` 目录。
+- iPPT 使用独立的 `-ippt` 项目后缀，不覆盖 iDesign 文件。
+- Studio iframe 使用进程级随机令牌并校验同源消息。
+- 写入带冲突检查并采用原子替换。
+- **Ask AI** 只准备草稿，不会自动发送消息。
+
+## 参与贡献
+
+请在 [`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) 仓库的 `source/plugins/deepseek-ippt` 下提交适配器改动。iPPT 与 iDesign 共用同一套 iPolloWork Design Studio，核心能力会从主库统一升级，不需要维护第二套编辑器。
+
+---
+
+<a id="english"></a>
+
+## Build complete presentations inside DeepSeek Harness
+
+`deepseek-ippt` adds iPolloWork PPT Studio to DeepSeek Harness as a native **PPT** conversation view. The AI can shape the narrative, create slides, and revise content through conversation, while you can preview every page and directly refine text, images, layout, color, position, and visual styles.
+
+The `+` beside Edit shows only curated slide templates; websites, app prototypes, posters, and reports stay out of this catalog. General Design work is provided by the separate [`deepseek-idesign`](https://www.npmjs.com/package/deepseek-idesign) package, and both plugins can be installed together.
+
+### Highlights
+
+- Native **PPT** view inside DeepSeek Harness conversations
+- AI-generated narratives, pages, and content with selection-aware **Ask AI**
+- Page-by-page preview and direct element editing
+- Dedicated presentation template catalog
+- Shared themes and design-token controls
+- Save, undo, and write-conflict detection
+- PDF and PPTX export
+- Isolated project path that never overwrites iDesign work
+
+## Install and run
+
+```sh
+npx @deepseek-ai/dsh plugin --profile web add deepseek-ippt
+npx @deepseek-ai/dsh web
+```
+
+If `dsh` is already installed:
+
+```sh
+dsh plugin --profile web add deepseek-ippt
+dsh web
+```
+
+The Web UI is served at [http://127.0.0.1:3080](http://127.0.0.1:3080) by default. Open a conversation and choose **PPT** to enter the Studio.
+
+### Local release artifact
+
+```sh
+pnpm pack
+dsh plugin --profile web add ./deepseek-ippt-0.1.1.tgz
+dsh web
+```
+
+## Workflow
+
+1. Start DeepSeek Harness in the directory you want to use as the workspace.
+2. Create a conversation and open the **PPT** view.
+3. Choose a slide template with `+`, or ask the AI to start from the blank deck.
+4. Review each page and enable Edit for direct refinement.
+5. Use **Ask AI** to revise the narrative, page, or selected element.
+6. Download the finished presentation as PDF or PPTX.
+
+Projects stay under `design/<sessionId>-ippt/`, so the package can run beside `deepseek-idesign`. It includes its browser assets and does not install or launch the iPolloWork desktop app or Video Studio.
+
+## Data boundary
+
+- Access is limited to the `design/` directory of workspaces registered by DeepSeek Harness.
+- The `-ippt` project suffix keeps presentation files separate from iDesign.
+- The Studio iframe uses a random per-process token and same-origin message checks.
+- Writes use conflict detection and atomic replacement.
+- **Ask AI** prepares a draft and never submits a message automatically.
+
+## Contributing
+
+Propose adapter changes under `source/plugins/deepseek-ippt` in the [`deepseek-design`](https://github.com/Devin-AXIS/deepseek-design) repository. iPPT and iDesign share one iPolloWork Design Studio, so core capability upgrades flow from the main repository without maintaining a second editor.


### PR DESCRIPTION
## Summary

- reposition DeepSeek Design as the iPolloWork-built core design capability for DeepSeek Harness
- make Simplified Chinese the primary README language with a complete English edition
- document the Design/PPT split, AI plus visual editing loop, installation, startup, data boundaries, repository sync, and contribution path
- expand the npm package READMEs for deepseek-idesign and deepseek-ippt with bilingual quick starts

## Verification

- `node --test scripts/import-deepseek-design-repository.test.mjs`
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`
- `git diff --check`
- GitHub Markdown API render check for the public repository context
- `npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --version` and `--help`

Docs-only change; no runtime behavior changed, so observable-runtime fraimz verification is not applicable.