### PR TITLE
Unify DeepSeek Studio into one glass toolbar

### DIFF
--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import * as React from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Check, ChevronLeft, ChevronRight, Code2, Focus, Loader2, Minus, Monitor, MousePointer2, Palette, Plus, Save, Share2, SlidersHorizontal, Smartphone, Undo2 } from "lucide-react";
+import { ArrowLeft, Check, ChevronLeft, ChevronRight, Code2, Focus, Github, Layers3, Loader2, Minus, Monitor, MousePointer2, Palette, Plus, Presentation, Save, Share2, SlidersHorizontal, Smartphone, Sparkles, Undo2 } from "lucide-react";
 
 import {
   IPOLLOWORK_DESIGN_STUDIO_FEATURES,
@@ -129,6 +129,14 @@ type DesignPanelProps = {
   initialPath?: string;
   expanded?: boolean;
   features?: DesignStudioFeatures;
+  branding?: {
+    kind: "design" | "slides";
+    title: string;
+    byline: string;
+    bylineUrl: string;
+    repositoryUrl: string;
+    onAskAi: () => void;
+  };
   onAskAi: (context: DesignAiSelectionContext) => void;
   onSaveAsTemplate?: () => void;
 };
@@ -536,6 +544,7 @@ export function DesignPanel({
   initialPath,
   expanded = false,
   features = IPOLLOWORK_DESIGN_STUDIO_FEATURES,
+  branding,
   onAskAi,
   onSaveAsTemplate,
 }: DesignPanelProps) {
@@ -1997,6 +2006,36 @@ export function DesignPanel({
   const viewedVersionLabel = viewedVersionPath === "current"
     ? currentVersionLabel
     : `V${versionTargets.length - versionTargets.findIndex((version) => version.path === viewedVersionPath)}`;
+  const editControl = (
+    <Label className={cn("flex shrink-0 items-center gap-2 text-xs", !branding && "order-1")}>
+      <Switch
+        size="sm"
+        className="border-[#AEB2B9] bg-transparent shadow-none data-checked:!border-[#0A84FF] data-checked:!bg-[#0A84FF] data-unchecked:!border-[#AEB2B9] data-unchecked:!bg-transparent [&_[data-slot=switch-thumb]]:!shadow-none [&_[data-slot=switch-thumb][data-checked]]:!bg-white [&_[data-slot=switch-thumb][data-unchecked]]:!bg-[#62666D]"
+        checked={editing}
+        onCheckedChange={(checked) => {
+          setEditing(checked);
+          setSelectionState(null);
+          setQuickEdit(null);
+          setAdvancedOpen(false);
+        }}
+        aria-label="Edit"
+      />
+      Edit
+    </Label>
+  );
+  const templateControl = templateCatalog ? (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      className={cn(DESIGN_ACTION_BUTTON_CLASS, !branding && "order-1")}
+      onClick={() => setTemplateDialogOpen(true)}
+      aria-label={templateCatalog.title}
+      title={templateCatalog.title}
+      data-testid="design-template-market-button"
+    >
+      <Plus />
+    </Button>
+  ) : null;
 
   return (
     <div ref={panelRef} className="flex h-full min-h-0 flex-col bg-background" data-testid="design-panel">
@@ -2030,9 +2069,30 @@ export function DesignPanel({
       ) : (
         <>
           <div className={cn(
-            "flex min-w-0 shrink-0 flex-wrap items-center border-b border-border px-3 py-2 [border-bottom-width:0.5px]",
+            "flex min-w-0 shrink-0 items-center border-b border-border px-3 py-2 [border-bottom-width:0.5px]",
+            branding
+              ? "relative z-30 h-14 flex-nowrap overflow-hidden border-white/60 bg-background/80 shadow-[0_10px_30px_-22px_rgba(15,23,42,0.55),inset_0_1px_0_rgba(255,255,255,0.72)] backdrop-blur-xl backdrop-saturate-150 before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-gradient-to-r before:from-transparent before:via-white/90 before:to-transparent dark:border-white/10 dark:bg-background/72 dark:shadow-[0_10px_30px_-22px_rgba(0,0,0,0.9),inset_0_1px_0_rgba(255,255,255,0.12)] dark:before:via-white/20"
+              : "flex-wrap",
             compactToolbar ? "gap-1" : "gap-2",
           )}>
+            {branding ? (
+              <div className="order-0 flex min-w-0 shrink-0 items-center gap-2.5 border-r border-border/70 pr-3">
+                <span className="grid size-8 shrink-0 place-items-center rounded-xl border border-white/70 bg-white/70 text-foreground shadow-[0_6px_18px_-12px_rgba(15,23,42,0.8),inset_0_1px_0_rgba(255,255,255,0.9)] dark:border-white/10 dark:bg-white/8 dark:shadow-none" aria-hidden="true">
+                  {branding.kind === "slides" ? <Presentation className="size-4" /> : <Layers3 className="size-4" />}
+                </span>
+                <div className="flex min-w-0 flex-col justify-center leading-none">
+                  <strong className="truncate text-sm font-semibold tracking-[-0.02em]">{branding.title}</strong>
+                  <a
+                    href={branding.bylineUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-1 w-fit truncate text-[10px] font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    {branding.byline}
+                  </a>
+                </div>
+              </div>
+            ) : null}
             {hasSiteVersioning ? (
               <div className={cn("order-0 flex min-w-0 flex-1 items-center gap-2", veryCompactToolbar && "hidden")}>
                 <p className="min-w-0 truncate text-sm font-medium">{fileName(activePagePath)}</p>
@@ -2047,34 +2107,7 @@ export function DesignPanel({
                 ) : null}
               </div>
             ) : null}
-            <Label className="order-1 flex shrink-0 items-center gap-2 text-xs">
-              <Switch
-                size="sm"
-                className="border-[#AEB2B9] bg-transparent shadow-none data-checked:!border-[#0A84FF] data-checked:!bg-[#0A84FF] data-unchecked:!border-[#AEB2B9] data-unchecked:!bg-transparent [&_[data-slot=switch-thumb]]:!shadow-none [&_[data-slot=switch-thumb][data-checked]]:!bg-white [&_[data-slot=switch-thumb][data-unchecked]]:!bg-[#62666D]"
-                checked={editing}
-                onCheckedChange={(checked) => {
-                  setEditing(checked);
-                  setSelectionState(null);
-                  setQuickEdit(null);
-                  setAdvancedOpen(false);
-                }}
-                aria-label="Edit"
-              />
-              Edit
-            </Label>
-            {templateCatalog ? (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn("order-1", DESIGN_ACTION_BUTTON_CLASS)}
-                onClick={() => setTemplateDialogOpen(true)}
-                aria-label={templateCatalog.title}
-                title={templateCatalog.title}
-                data-testid="design-template-market-button"
-              >
-                <Plus />
-              </Button>
-            ) : null}
+            {!branding ? <>{editControl}{templateControl}</> : null}
             {deck ? (
               <div className="order-2 flex h-8 min-w-0 items-center rounded-lg border border-border bg-transparent p-0.5 shadow-none" data-testid="design-deck-navigation">
                 <Button variant="ghost" size="icon-sm" className="size-7 rounded-md text-foreground hover:bg-muted" onClick={() => navigateDeck("previous")} disabled={deck.index <= 0} aria-label="Previous slide" title="Previous slide">
@@ -2115,6 +2148,23 @@ export function DesignPanel({
               )
             ) : null}
             <div className={cn("ml-auto flex shrink-0 items-center", isPresentationTemplate ? "order-3" : "order-2", compactToolbar ? "gap-1" : "gap-2")}>
+              {branding ? (
+                <>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="h-8 shrink-0 gap-1.5 rounded-lg bg-foreground px-2.5 text-xs font-semibold text-background shadow-none hover:bg-foreground/90 hover:text-background"
+                    onClick={branding.onAskAi}
+                    aria-label="Ask AI about this document"
+                    title="Ask AI"
+                  >
+                    <Sparkles className="size-4" />
+                    <span className={cn(compactToolbar && "sr-only")}>Ask AI</span>
+                  </Button>
+                  {templateControl}
+                  {editControl}
+                </>
+              ) : null}
               {editing ? <Button
                 variant="ghost"
                 size="icon-sm"
@@ -2199,6 +2249,18 @@ export function DesignPanel({
                   onExportPptx={() => setPptxConfirmationOpen(true)}
                   onSaveAsTemplate={onSaveAsTemplate}
                 />
+              ) : null}
+              {branding ? (
+                <a
+                  href={branding.repositoryUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className={cn(DESIGN_ACTION_BUTTON_CLASS, "inline-flex items-center justify-center border border-border/70 bg-background/65 shadow-sm hover:border-foreground/20 hover:bg-background")}
+                  aria-label="View DeepSeek Design on GitHub"
+                  title="DeepSeek Design on GitHub"
+                >
+                  <Github className="size-[18px]" />
+                </a>
               ) : null}
             </div>
           </div>

--- a/apps/app/tests/design-studio-bridge.test.ts
+++ b/apps/app/tests/design-studio-bridge.test.ts
@@ -45,6 +45,10 @@ describe("Design Studio host bridge", () => {
       type: "ask-ai",
       request: designStudioAskAiRequest(context),
     })).toBe(true);
+    expect(isDesignStudioHostMessage({
+      channel: DESIGN_STUDIO_HOST_CHANNEL,
+      type: "ask-document-ai",
+    })).toBe(true);
     expect(isDesignStudioHostMessage({ channel: "other", type: "ask-ai", request: {} })).toBe(false);
   });
 

--- a/external-plugins/deepseek-harness/design-studio/package.json
+++ b/external-plugins/deepseek-harness/design-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-idesign",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "iPolloWork Design Studio and its curated design templates as a native DeepSeek Harness conversation view.",
   "type": "module",
   "main": "lib/index.js",

--- a/external-plugins/deepseek-harness/design-studio/src/client.tsx
+++ b/external-plugins/deepseek-harness/design-studio/src/client.tsx
@@ -23,16 +23,27 @@ export function createDeepSeekDesignStudioClient(options: DeepSeekDesignStudioCl
   function StudioView({ sessionId, useWorkspaces, inputActions }: ConvViewProps) {
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
     const workspace = useWorkspaces((state) => state.items.find((item) => item.sessionIds.includes(sessionId)));
+    const projectId = `${String(sessionId)}${options.projectSuffix ?? ""}`;
 
     React.useEffect(() => {
       const receive = (event: MessageEvent) => {
         if (event.origin !== window.location.origin || event.source !== iframeRef.current?.contentWindow) return;
         if (!isDesignStudioHostMessage(event.data)) return;
+        if (event.data.type === "ask-document-ai") {
+          inputActions.setDraft([
+            `Help me improve the current ${options.studioTitle} document.`,
+            `Project: design/${projectId}`,
+            "Read manifest.json, then read its entry file and linked design-tokens.css before editing.",
+            "Preserve the existing structure unless I request a redesign.",
+            "My requested change:",
+          ].join("\n"));
+          return;
+        }
         inputActions.setDraft(designStudioAskAiPrompt(event.data.request));
       };
       window.addEventListener("message", receive);
       return () => window.removeEventListener("message", receive);
-    }, [inputActions]);
+    }, [inputActions, projectId]);
 
     if (!workspace) {
       return (
@@ -44,25 +55,8 @@ export function createDeepSeekDesignStudioClient(options: DeepSeekDesignStudioCl
     }
 
     const query = new URLSearchParams({ workspaceId: String(workspace.workspaceId), sessionId: String(sessionId) });
-    const projectId = `${String(sessionId)}${options.projectSuffix ?? ""}`;
     return (
       <section style={shellStyle} aria-label={`iPolloWork ${options.studioTitle}`}>
-        <header style={headerStyle}>
-          <div><div style={eyebrowStyle}>iPolloWork</div><strong style={titleStyle}>{options.studioTitle}</strong></div>
-          <button
-            type="button"
-            style={buttonStyle}
-            onClick={() => inputActions.setDraft([
-              `Help me improve the current ${options.studioTitle} document.`,
-              `Project: design/${projectId}`,
-              "Read manifest.json, then read its entry file and linked design-tokens.css before editing.",
-              "Preserve the existing structure unless I request a redesign.",
-              "My requested change:",
-            ].join("\n"))}
-          >
-            Ask AI
-          </button>
-        </header>
         <iframe
           ref={iframeRef}
           title={`iPolloWork ${options.studioTitle}`}
@@ -92,9 +86,5 @@ export const apply = createDeepSeekDesignStudioClient({
 });
 
 const shellStyle: React.CSSProperties = { display: "flex", flexDirection: "column", width: "100%", height: "100%", minHeight: 0, background: "var(--color-background, #f6f7f9)" };
-const headerStyle: React.CSSProperties = { display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, minHeight: 62, padding: "10px 16px", borderBottom: "1px solid color-mix(in srgb, currentColor 12%, transparent)" };
-const eyebrowStyle: React.CSSProperties = { color: "#70757f", fontSize: 10, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase" };
-const titleStyle: React.CSSProperties = { fontSize: 14, lineHeight: 1.3 };
-const buttonStyle: React.CSSProperties = { border: "1px solid color-mix(in srgb, currentColor 14%, transparent)", borderRadius: 10, padding: "8px 13px", color: "inherit", background: "color-mix(in srgb, currentColor 6%, transparent)", font: "inherit", fontSize: 12, fontWeight: 650, cursor: "pointer" };
 const frameStyle: React.CSSProperties = { flex: 1, width: "100%", minHeight: 0, border: 0, background: "#f6f7f9" };
 const emptyStyle: React.CSSProperties = { display: "grid", placeContent: "center", gap: 8, height: "100%", padding: 32, color: "#70757f", textAlign: "center" };

--- a/external-plugins/deepseek-harness/design-studio/studio/src/main.tsx
+++ b/external-plugins/deepseek-harness/design-studio/studio/src/main.tsx
@@ -41,6 +41,17 @@ function Studio() {
             description: t(__DEEPSEEK_STUDIO_MODE__ === "slides" ? "design_templates.slides_description" : "design_templates.design_description"),
           },
         }}
+        branding={{
+          kind: __DEEPSEEK_STUDIO_MODE__ === "slides" ? "slides" : "design",
+          title: __DEEPSEEK_STUDIO_MODE__ === "slides" ? "iPPT" : "iDesign",
+          byline: "by iPolloWork",
+          bylineUrl: "https://github.com/Devin-AXIS/iPolloWork",
+          repositoryUrl: "https://github.com/Devin-AXIS/deepseek-design",
+          onAskAi: () => window.parent.postMessage({
+            channel: DESIGN_STUDIO_HOST_CHANNEL,
+            type: "ask-document-ai",
+          }, window.location.origin),
+        }}
         onAskAi={(context) => window.parent.postMessage({
           channel: DESIGN_STUDIO_HOST_CHANNEL,
           type: "ask-ai",

--- a/external-plugins/deepseek-harness/ppt-studio/package.json
+++ b/external-plugins/deepseek-harness/ppt-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-ippt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "iPolloWork PPT Studio and its curated slide templates as a native DeepSeek Harness conversation view.",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/design-studio/src/bridge.ts
+++ b/packages/design-studio/src/bridge.ts
@@ -4,11 +4,16 @@ export const DESIGN_STUDIO_HOST_CHANNEL = "ipollowork-design-studio-host-v1";
 
 export type DesignStudioAskAiRequest = Omit<DesignAiSelectionContext, "beforeHtml">;
 
-export type DesignStudioHostMessage = {
-  channel: typeof DESIGN_STUDIO_HOST_CHANNEL;
-  type: "ask-ai";
-  request: DesignStudioAskAiRequest;
-};
+export type DesignStudioHostMessage =
+  | {
+    channel: typeof DESIGN_STUDIO_HOST_CHANNEL;
+    type: "ask-ai";
+    request: DesignStudioAskAiRequest;
+  }
+  | {
+    channel: typeof DESIGN_STUDIO_HOST_CHANNEL;
+    type: "ask-document-ai";
+  };
 
 export function designStudioAskAiRequest(
   context: DesignAiSelectionContext,
@@ -20,7 +25,9 @@ export function designStudioAskAiRequest(
 export function isDesignStudioHostMessage(value: unknown): value is DesignStudioHostMessage {
   if (!value || typeof value !== "object") return false;
   if (Reflect.get(value, "channel") !== DESIGN_STUDIO_HOST_CHANNEL) return false;
-  if (Reflect.get(value, "type") !== "ask-ai") return false;
+  const type = Reflect.get(value, "type");
+  if (type === "ask-document-ai") return true;
+  if (type !== "ask-ai") return false;
   const request = Reflect.get(value, "request");
   if (!request || typeof request !== "object") return false;
   const target = Reflect.get(request, "target");


### PR DESCRIPTION
## What changed

- remove the redundant DeepSeek plugin shell header
- merge iDesign/iPPT identity, `by iPolloWork`, Ask AI, editing, and GitHub into the existing Studio toolbar
- add restrained glass styling and responsive icon treatment
- keep built-in iPolloWork Design behavior unchanged unless external branding is provided
- release `deepseek-idesign` 0.2.2 and `deepseek-ippt` 0.1.2

## Verification

- `pnpm --dir apps/app typecheck`
- `pnpm --dir apps/app exec bun test --isolate tests/design-studio-bridge.test.ts`
- Design Studio check and production build
- PPT Studio check and production build
- package tarballs inspected for both plugins
- maintainability audit passed with no warnings
- public repository sync tests: 3/3 passed
- `git diff --check`

Manual browser proof was skipped at the maintainer's request; the production bundles and focused bridge behavior were verified.