### PR TITLE
Restore DeepSeek toolbar adapter after mirror race

### DIFF
--- a/external-plugins/deepseek-harness/design-studio/package.json
+++ b/external-plugins/deepseek-harness/design-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-idesign",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "iPolloWork Design Studio and its curated design templates as a native DeepSeek Harness conversation view.",
   "type": "module",
   "main": "lib/index.js",

--- a/external-plugins/deepseek-harness/design-studio/src/client.tsx
+++ b/external-plugins/deepseek-harness/design-studio/src/client.tsx
@@ -23,16 +23,27 @@ export function createDeepSeekDesignStudioClient(options: DeepSeekDesignStudioCl
   function StudioView({ sessionId, useWorkspaces, inputActions }: ConvViewProps) {
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
     const workspace = useWorkspaces((state) => state.items.find((item) => item.sessionIds.includes(sessionId)));
+    const projectId = `${String(sessionId)}${options.projectSuffix ?? ""}`;
 
     React.useEffect(() => {
       const receive = (event: MessageEvent) => {
         if (event.origin !== window.location.origin || event.source !== iframeRef.current?.contentWindow) return;
         if (!isDesignStudioHostMessage(event.data)) return;
+        if (event.data.type === "ask-document-ai") {
+          inputActions.setDraft([
+            `Help me improve the current ${options.studioTitle} document.`,
+            `Project: design/${projectId}`,
+            "Read manifest.json, then read its entry file and linked design-tokens.css before editing.",
+            "Preserve the existing structure unless I request a redesign.",
+            "My requested change:",
+          ].join("\n"));
+          return;
+        }
         inputActions.setDraft(designStudioAskAiPrompt(event.data.request));
       };
       window.addEventListener("message", receive);
       return () => window.removeEventListener("message", receive);
-    }, [inputActions]);
+    }, [inputActions, projectId]);
 
     if (!workspace) {
       return (
@@ -44,25 +55,8 @@ export function createDeepSeekDesignStudioClient(options: DeepSeekDesignStudioCl
     }
 
     const query = new URLSearchParams({ workspaceId: String(workspace.workspaceId), sessionId: String(sessionId) });
-    const projectId = `${String(sessionId)}${options.projectSuffix ?? ""}`;
     return (
       <section style={shellStyle} aria-label={`iPolloWork ${options.studioTitle}`}>
-        <header style={headerStyle}>
-          <div><div style={eyebrowStyle}>iPolloWork</div><strong style={titleStyle}>{options.studioTitle}</strong></div>
-          <button
-            type="button"
-            style={buttonStyle}
-            onClick={() => inputActions.setDraft([
-              `Help me improve the current ${options.studioTitle} document.`,
-              `Project: design/${projectId}`,
-              "Read manifest.json, then read its entry file and linked design-tokens.css before editing.",
-              "Preserve the existing structure unless I request a redesign.",
-              "My requested change:",
-            ].join("\n"))}
-          >
-            Ask AI
-          </button>
-        </header>
         <iframe
           ref={iframeRef}
           title={`iPolloWork ${options.studioTitle}`}
@@ -92,9 +86,5 @@ export const apply = createDeepSeekDesignStudioClient({
 });
 
 const shellStyle: React.CSSProperties = { display: "flex", flexDirection: "column", width: "100%", height: "100%", minHeight: 0, background: "var(--color-background, #f6f7f9)" };
-const headerStyle: React.CSSProperties = { display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, minHeight: 62, padding: "10px 16px", borderBottom: "1px solid color-mix(in srgb, currentColor 12%, transparent)" };
-const eyebrowStyle: React.CSSProperties = { color: "#70757f", fontSize: 10, fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase" };
-const titleStyle: React.CSSProperties = { fontSize: 14, lineHeight: 1.3 };
-const buttonStyle: React.CSSProperties = { border: "1px solid color-mix(in srgb, currentColor 14%, transparent)", borderRadius: 10, padding: "8px 13px", color: "inherit", background: "color-mix(in srgb, currentColor 6%, transparent)", font: "inherit", fontSize: 12, fontWeight: 650, cursor: "pointer" };
 const frameStyle: React.CSSProperties = { flex: 1, width: "100%", minHeight: 0, border: 0, background: "#f6f7f9" };
 const emptyStyle: React.CSSProperties = { display: "grid", placeContent: "center", gap: 8, height: "100%", padding: 32, color: "#70757f", textAlign: "center" };

--- a/external-plugins/deepseek-harness/design-studio/studio/src/main.tsx
+++ b/external-plugins/deepseek-harness/design-studio/studio/src/main.tsx
@@ -41,6 +41,17 @@ function Studio() {
             description: t(__DEEPSEEK_STUDIO_MODE__ === "slides" ? "design_templates.slides_description" : "design_templates.design_description"),
           },
         }}
+        branding={{
+          kind: __DEEPSEEK_STUDIO_MODE__ === "slides" ? "slides" : "design",
+          title: __DEEPSEEK_STUDIO_MODE__ === "slides" ? "iPPT" : "iDesign",
+          byline: "by iPolloWork",
+          bylineUrl: "https://github.com/Devin-AXIS/iPolloWork",
+          repositoryUrl: "https://github.com/Devin-AXIS/deepseek-design",
+          onAskAi: () => window.parent.postMessage({
+            channel: DESIGN_STUDIO_HOST_CHANNEL,
+            type: "ask-document-ai",
+          }, window.location.origin),
+        }}
         onAskAi={(context) => window.parent.postMessage({
           channel: DESIGN_STUDIO_HOST_CHANNEL,
           type: "ask-ai",

--- a/external-plugins/deepseek-harness/ppt-studio/package.json
+++ b/external-plugins/deepseek-harness/ppt-studio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepseek-ippt",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "iPolloWork PPT Studio and its curated slide templates as a native DeepSeek Harness conversation view.",
   "type": "module",
   "main": "lib/index.js",

--- a/packages/design-studio/src/bridge.ts
+++ b/packages/design-studio/src/bridge.ts
@@ -4,11 +4,16 @@ export const DESIGN_STUDIO_HOST_CHANNEL = "ipollowork-design-studio-host-v1";
 
 export type DesignStudioAskAiRequest = Omit<DesignAiSelectionContext, "beforeHtml">;
 
-export type DesignStudioHostMessage = {
-  channel: typeof DESIGN_STUDIO_HOST_CHANNEL;
-  type: "ask-ai";
-  request: DesignStudioAskAiRequest;
-};
+export type DesignStudioHostMessage =
+  | {
+    channel: typeof DESIGN_STUDIO_HOST_CHANNEL;
+    type: "ask-ai";
+    request: DesignStudioAskAiRequest;
+  }
+  | {
+    channel: typeof DESIGN_STUDIO_HOST_CHANNEL;
+    type: "ask-document-ai";
+  };
 
 export function designStudioAskAiRequest(
   context: DesignAiSelectionContext,
@@ -20,7 +25,9 @@ export function designStudioAskAiRequest(
 export function isDesignStudioHostMessage(value: unknown): value is DesignStudioHostMessage {
   if (!value || typeof value !== "object") return false;
   if (Reflect.get(value, "channel") !== DESIGN_STUDIO_HOST_CHANNEL) return false;
-  if (Reflect.get(value, "type") !== "ask-ai") return false;
+  const type = Reflect.get(value, "type");
+  if (type === "ask-document-ai") return true;
+  if (type !== "ask-ai") return false;
   const request = Reflect.get(value, "request");
   if (!request || typeof request !== "object") return false;
   const target = Reflect.get(request, "target");


### PR DESCRIPTION
## What changed

Restores the five DeepSeek adapter/package files that PR #335 imported from a stale public snapshot while the forward mirror for PR #334 was still running.

The public repository now records source commit `beb0ccbd827bdec2ee6864f9348590cb71c66f09`, so the stale `eca06b3b4468` snapshot that caused the rollback is no longer current.

## Verification

- app typecheck passed
- Design Studio bridge tests: 4/4 passed
- iDesign check and production build passed
- iPPT check and production build passed
- maintainability audit passed with no warnings
- `git diff --check` passed