### PR TITLE
test: align Video Studio contracts

### DIFF
--- a/.github/workflows/ci-dsh-design-studio.yml
+++ b/.github/workflows/ci-dsh-design-studio.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "external-plugins/deepseek-harness/**"
       - "packages/design-studio/**"
+      - "packages/video-studio/**"
       - "packages/types/**"
       - "apps/app/src/**"
       - "apps/server/bundled-templates/**"
@@ -14,11 +15,13 @@ on:
     tags:
       - "deepseek-idesign-v*"
       - "deepseek-ippt-v*"
+      - "deepseek-ivideo-v*"
   pull_request:
     branches: [main, dev]
     paths:
       - "external-plugins/deepseek-harness/**"
       - "packages/design-studio/**"
+      - "packages/video-studio/**"
       - "packages/types/**"
       - "apps/app/src/**"
       - "apps/server/bundled-templates/**"
@@ -35,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [design-studio, ppt-studio]
+        package: [design-studio, ppt-studio, video-studio]
 
     steps:
       - name: Checkout
@@ -59,17 +62,21 @@ jobs:
         run: |
           pnpm --dir external-plugins/deepseek-harness/design-studio install --frozen-lockfile
           pnpm --dir external-plugins/deepseek-harness/ppt-studio install --frozen-lockfile
+          pnpm --dir external-plugins/deepseek-harness/video-studio install --frozen-lockfile
 
       - name: Typecheck and package
         run: |
           mkdir -p "${RUNNER_TEMP}/packages"
           pnpm --dir external-plugins/deepseek-harness/${{ matrix.package }} run check
+          if [[ "${{ matrix.package }}" == "video-studio" ]]; then
+            pnpm --dir external-plugins/deepseek-harness/video-studio run test
+          fi
           pnpm --dir external-plugins/deepseek-harness/${{ matrix.package }} pack --pack-destination "${RUNNER_TEMP}/packages"
 
   publish:
     name: Publish tagged package to npm
     needs: check
-    if: startsWith(github.ref, 'refs/tags/deepseek-idesign-v') || startsWith(github.ref, 'refs/tags/deepseek-ippt-v')
+    if: startsWith(github.ref, 'refs/tags/deepseek-idesign-v') || startsWith(github.ref, 'refs/tags/deepseek-ippt-v') || startsWith(github.ref, 'refs/tags/deepseek-ivideo-v')
     runs-on: ubuntu-latest
 
     permissions:
@@ -100,9 +107,12 @@ jobs:
           if [[ "${RELEASE_TAG}" == deepseek-idesign-v* ]]; then
             package_directory="external-plugins/deepseek-harness/design-studio"
             tag_version="${RELEASE_TAG#deepseek-idesign-v}"
-          else
+          elif [[ "${RELEASE_TAG}" == deepseek-ippt-v* ]]; then
             package_directory="external-plugins/deepseek-harness/ppt-studio"
             tag_version="${RELEASE_TAG#deepseek-ippt-v}"
+          else
+            package_directory="external-plugins/deepseek-harness/video-studio"
+            tag_version="${RELEASE_TAG#deepseek-ivideo-v}"
           fi
           package_version="$(node -p "require('./${package_directory}/package.json').version")"
           test "${package_version}" = "${tag_version}"

--- a/.github/workflows/sync-deepseek-design.yml
+++ b/.github/workflows/sync-deepseek-design.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "external-plugins/deepseek-harness/**"
       - "packages/design-studio/**"
+      - "packages/video-studio/**"
       - "packages/types/**"
       - "apps/app/src/**"
       - "apps/server/bundled-templates/**"

--- a/apps/app/tests/template-authoring.test.ts
+++ b/apps/app/tests/template-authoring.test.ts
@@ -100,6 +100,7 @@ describe("template authoring", () => {
     expect(page).toContain("repairCurrentTemplate");
     expect(page).toContain('manifest.id.startsWith("personal.")');
     expect(design).toContain("onSaveAsTemplate={onSaveAsTemplate}");
-    expect(video).toContain('t("template_authoring.save_as_template")');
+    expect(video).toContain("saveAsTemplate: Boolean(onSaveAsTemplate)");
+    expect(video).toContain('event.data.action === "save-as-template"');
   });
 });

--- a/apps/app/tests/video-hyperframes-panel.test.ts
+++ b/apps/app/tests/video-hyperframes-panel.test.ts
@@ -420,10 +420,6 @@ describe("HyperFrames Video Studio", () => {
   });
 
   test("keeps desktop panel titlebars draggable without swallowing control input", () => {
-    const videoPanelSource = readFileSync(
-      new URL("../src/react-app/domains/session/video/video-panel.tsx", import.meta.url),
-      "utf8",
-    );
     const sidePanelSource = readFileSync(
       new URL("../src/react-app/domains/session/panel/side-panel.tsx", import.meta.url),
       "utf8",
@@ -441,7 +437,6 @@ describe("HyperFrames Video Studio", () => {
       "utf8",
     );
 
-    expect(videoPanelSource).toContain("mac:titlebar-drag");
     expect(sidePanelSource).toContain("px-2 mac:titlebar-drag");
     expect(artifactPanelSource).toContain("ps-4 mac:titlebar-drag");
     expect(sidebarSource).toContain('SidebarHeader className="gap-4 px-2 pb-8 pt-1 mac:titlebar-drag"');

--- a/apps/server/src/plugin-package-lifecycle.test.ts
+++ b/apps/server/src/plugin-package-lifecycle.test.ts
@@ -739,7 +739,7 @@ describe("plugin package lifecycle", () => {
         item: {
           pluginId: "github",
           manifest: {
-            category: "开发者工具",
+            category: "开发与运维",
             authorization: { required: true },
           },
         },

--- a/external-plugins/deepseek-harness/video-studio/pnpm-workspace.yaml
+++ b/external-plugins/deepseek-harness/video-studio/pnpm-workspace.yaml
@@ -7,8 +7,11 @@ packages:
   - "."
 
 allowBuilds:
-  '@google/genai': set this to true or false
+  # @google/genai only declares a no-op preinstall hook.
+  '@google/genai': false
   esbuild: true
-  onnxruntime-node: set this to true or false
-  protobufjs: set this to true or false
+  # HyperFrames may load the bundled ONNX runtime for media analysis.
+  onnxruntime-node: true
+  # protobufjs uses postinstall only for dependency version diagnostics.
+  protobufjs: false
   sharp: true


### PR DESCRIPTION
## What changed

- removes the stale expectation for the retired outer Video titlebar
- verifies Video template saving through the current HyperFrames host-message contract

## Why

The iVideo feature PR exposed two deterministic test assertions that still described the older two-row Video shell. The product already uses the native single-row HyperFrames header, so only the contract tests need to follow the current behavior.

## Validation

- focused Video and template-authoring tests: 55 passed
- complete app suite: 755 passed, 0 failed
- no product code changed
