### PR TITLE
feat(server): pluggable public API component under /api/v1

### DIFF
--- a/apps/server/src/api/README.md
+++ b/apps/server/src/api/README.md
@@ -1,0 +1,190 @@
+# Public API component (`/api/v1`)
+
+A self-contained, pluggable API surface for `ipollowork-server`. Every operation is
+declared by a **module**; the declaration is the single source of truth, so the live route
+table and the published OpenAPI document are generated from the same objects and cannot
+drift.
+
+Two things make it a component rather than another routes file:
+
+- **Engine independence.** Handlers talk to `EngineConnection` (`engine/types.ts`), not to
+  OpenCode or DeepSeek Harness. `engine/opencode.ts` and `engine/harness.ts` are the only
+  files that know an engine's wire format.
+- **Independent enable/disable.** Each module can be turned off without touching code, and
+  the OpenAPI document follows.
+
+## Mounting
+
+`registerApiV1({ ... })` (`index.ts`) is the composition root: it builds the
+`EngineAdapterRegistry`, owns the task and webhook stores, assembles the
+`ApiModuleContext`, resolves which modules are enabled, and calls `registerApiModules`.
+
+It is invoked once, at the **end** of `createRoutes` in `../server.ts`, after every legacy
+`register*Routes` call. Order matters in exactly one direction: `matchRoute`
+(`../routes/registry.ts`) scans the array and returns the **first** match, so appending
+routes can never shadow an existing one — but the `compat` module re-dispatches into the
+legacy table and must be able to see all of it. It receives `legacyRoutes: () => routes`,
+a getter rather than a snapshot, so it reads the finished table at request time.
+
+## Modules
+
+| id | stability | ops | base paths |
+| --- | --- | --- | --- |
+| `sessions` | stable | 11 | `/api/v1/workspaces/{workspaceId}/sessions…` |
+| `tasks` | preview | 5 | `/api/v1/workspaces/{workspaceId}/tasks…` |
+| `webhooks` | preview | 5 | `/api/v1/workspaces/{workspaceId}/webhooks…` |
+| `policy` | preview | 3 | `/api/v1/whoami`, `/api/v1/tokens/{tokenId}/policy` |
+| `openapi` | stable | 3 | `/api/v1/openapi.json`, `/api/v1/docs`, `/api/v1/modules` |
+| `compat` | stable | 135 | `/api/v1/…` aliases of legacy routes |
+
+- **`sessions`** — engine-agnostic conversations: create, inspect, prompt, interrupt,
+  stream events (SSE, resumable via `?after=` where the engine has a durable cursor), and
+  answer permission and question requests.
+- **`tasks`** — one-shot automation over a session. Records live in **server memory and are
+  lost on restart**; the `sessionId` a task reports is the durable handle. Depends on
+  `sessions`.
+- **`webhooks`** — outbound subscriptions per workspace, HMAC-signed, bounded retries,
+  private-network targets rejected unless explicitly opted in. `index.ts` bridges the task
+  store's event log into delivery, which is what makes the `task.*` event names real.
+- **`policy`** — the caller's resolved identity, plus per-token workspace binding, approval
+  policy and expiry. Policy mutation is `host`-authenticated.
+- **`openapi`** — the generated OpenAPI 3.1 document, a dependency-free HTML reference, and
+  the catalogue of enabled modules.
+- **`compat`** — republishes legacy routes under `/api/v1` by re-dispatching into the legacy
+  handler. Legacy paths stay available and unchanged. The toy UI, the raw `/opencode/*`
+  proxy, `/w/:id/*` mounts, browser OAuth callbacks, `/mcp-proxy/*` and `/dev/log` are
+  deliberately **not** aliased — they are not a stable public contract.
+
+### Enabling and disabling
+
+Every module is enabled by default.
+
+| env var | effect |
+| --- | --- |
+| `IPOLLOWORK_API_MODULES` | Comma-separated **allowlist**. Only these modules load. |
+| `IPOLLOWORK_API_MODULES_DISABLED` | Comma-separated **denylist**, applied after the allowlist. |
+
+An unknown id in either list is a startup error (`api_module_unknown`), not a silent no-op,
+so a typo cannot quietly drop an API surface. Disabling a module another enabled module
+depends on is also a startup error (`api_module_dependency_missing`) — e.g. `tasks` without
+`sessions`.
+
+`GET /api/v1/modules` reports what is actually live, including each operation's method,
+path, effect and scope.
+
+## Engines are uniform, but not identical
+
+`EngineConnection` gives both engines one shape, and most of the time a caller never needs
+to know which one is behind a workspace. Where the engines genuinely differ, the difference
+is reported rather than hidden — `GET /api/v1/workspaces/{id}/sessions/{sid}` returns a
+`capabilities` object, and an operation the engine cannot perform answers `501
+engine_capability_unsupported` instead of failing in some engine-specific way.
+
+Two differences matter in practice today:
+
+| | OpenCode | DeepSeek Harness |
+| --- | --- | --- |
+| `?after=` stream resumption | yes — events carry a durable cursor | no — `resumableStreaming: false` |
+| `system` / `reasoningEffort` on prompt | not applied | applied |
+
+The second one is the reason `promptOptions` exists. OpenCode's v2 prompt endpoint has no
+field for a per-turn system prompt, so passing one would have quietly done nothing; the
+module rejects it with `501 engine_prompt_option_unsupported` instead, naming the fields in
+`details.unsupported`. A silent no-op is the worse failure: the caller gets a 202 and never
+learns the instruction was dropped.
+
+## Auth model
+
+Three gates, applied in this order by `registerApiModules` before a handler runs:
+
+1. **Route auth mode** (`auth`, default `client`) — handed to `addRoute` and enforced by the
+   server's dispatcher, exactly as for legacy routes. `client` authenticates a client token,
+   `host` a host token.
+2. **Writability** — every operation whose `effect` is `write` or `destructive` calls
+   `ensureWritable(config)`, which throws `403 read_only` on a read-only server.
+3. **Client token scope** — for `auth: "client"` operations only. The required scope is the
+   operation's `scope`, defaulting by effect: `read → viewer`, `write` and
+   `destructive → collaborator`.
+
+**Handlers must not repeat these checks.** Re-checking scope or writability inside a handler
+is redundant at best and, when it disagrees with the declaration, makes the OpenAPI document
+lie about what a token needs.
+
+`compat` aliases are the one deliberate exception to the effect-based defaults: each alias
+copies the legacy route's auth mode and declares a scope no stricter than the legacy
+handler's own check, so an alias can never reject a request the legacy path would accept.
+The 13 cases where an alias is stricter — legacy write handlers that never call
+`ensureWritable`, and only on a read-only server — are listed in `COMPAT_READ_ONLY_STRICTER`.
+That divergence is fail-closed.
+
+Errors are the server's standard shape: `throw new ApiError(status, code, message, details?)`
+serialises to `{ code, message, details }`.
+
+## Adding a module
+
+1. Create `modules/<id>/module.ts` exporting an `ApiModule`:
+
+   ```ts
+   export const thingsModule: ApiModule = {
+     id: "things",
+     title: "Things",
+     description: "…",
+     version: "1.0.0",
+     stability: "preview",
+     dependsOn: ["sessions"],           // optional; checked against the enabled set
+     register(context: ApiModuleContext): ApiOperation[] {
+       return [
+         {
+           operationId: "listThings",   // unique across all modules; becomes the SDK method
+           method: "GET",
+           path: "/api/v1/workspaces/:workspaceId/things",
+           summary: "List things",
+           effect: "read",              // read | write | destructive
+           // auth defaults to "client"; scope defaults from effect
+           responses: { 200: { description: "…", schema: { type: "array" } } },
+           handler: async (ctx) => context.jsonResponse({ items: [] }),
+         },
+       ];
+     },
+   };
+   ```
+
+2. Take everything the handler needs from `ApiModuleContext`: `config`, `jsonResponse`,
+   `readJsonBody`, `resolveWorkspace`, and late-bound singletons from `context.services`.
+   `index.ts` supplies `engines`, `legacyRoutes`, `getApiRegistry`, `serverVersion`, and —
+   when the owning module is enabled — `taskStore`, `taskRunner` and `webhookStore`. A
+   module may also accept its own optional injection point (`policy` reads
+   `tokenPolicies`, `webhooks` reads `webhookFetch`) and construct a default when absent.
+   Read a required service defensively and fail with a `500` naming it — that is a wiring
+   bug, not a request error.
+3. Add it to `API_MODULES` in `index.ts`. `compat` stays last: its aliases are the broadest
+   patterns in the component.
+4. Register anything the module owns as a singleton in `index.ts` rather than inside
+   `register()` when something else needs the same instance.
+5. Write tests next to the source (`module.test.ts`, `bun:test`). Registry behaviour, pure
+   parsing/mapping and schema validation are testable without a live engine — use a stub
+   connection, never a real OpenCode process.
+
+Registration is fail-fast: a duplicate module id, a duplicate `operationId` and a duplicate
+`method + path` each throw at startup.
+
+Set `internal: true` to route an operation without publishing it; set `streaming: "sse"` so
+the document and generated SDKs describe it as a stream.
+
+## OpenAPI and docs
+
+| endpoint | returns |
+| --- | --- |
+| `GET /api/v1/openapi.json` | OpenAPI 3.1 document of every enabled, non-`internal` operation. Deterministic — identical input produces byte-identical JSON, so it can be committed and diffed in CI. |
+| `GET /api/v1/docs` | Self-contained HTML reference. No CDN, no external assets. |
+| `GET /api/v1/modules` | The enabled module catalogue (`describeModules`), including each operation's effect and required scope. |
+
+The document is built by `openapi.ts` from the same `ApiOperation` objects that produced the
+routes, and is cached per registry identity.
+
+## Tests
+
+```sh
+bun test src/api                       # the whole component
+npx tsc -p tsconfig.json --noEmit      # whole server, including this component
+```

--- a/apps/server/src/api/engine/harness.test.ts
+++ b/apps/server/src/api/engine/harness.test.ts
@@ -1,0 +1,784 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DeepSeekHarnessRpcError,
+  DeepSeekHarnessUnavailableError,
+} from "../../deepseek-harness-runtime.js";
+import { ApiError } from "../../errors.js";
+import {
+  createHarnessEngineAdapter,
+  createHarnessStreamState,
+  HARNESS_CAPABILITIES,
+  harnessPromptContent,
+  mapHarnessError,
+  mapHarnessEvent,
+  mapHarnessEvents,
+  normalizeHarnessErrorText,
+  type HarnessRuntimeLike,
+} from "./harness.js";
+import type { EngineEvent } from "./types.js";
+
+const SESSION_ID = "dsh-session";
+
+function envelope(payload: Record<string, unknown>, rpcId = "rpc-1") {
+  return { type: "server-request", rpcId, payload };
+}
+
+function sessionEvent(event: Record<string, unknown>, sessionId = SESSION_ID) {
+  return envelope({ type: "session/event", sessionId, event });
+}
+
+function sseResponse(frames: unknown[]): Response {
+  const body = frames.map((frame) => `data: ${JSON.stringify(frame)}\n\n`).join("");
+  return new Response(new TextEncoder().encode(body));
+}
+
+type RuntimeCall = { method: string; payload: unknown };
+
+function stubRuntime(input: {
+  results?: Record<string, unknown>;
+  mux?: unknown[];
+  host?: unknown[];
+} = {}) {
+  const calls: RuntimeCall[] = [];
+  const responded: Array<{ rpcId: string; result: unknown }> = [];
+  const runtime: HarnessRuntimeLike = {
+    async call<T>(method: string, payload: unknown): Promise<T> {
+      calls.push({ method, payload });
+      return (input.results?.[method] ?? {}) as T;
+    },
+    async respond(request) {
+      responded.push(request);
+    },
+    async events(stream) {
+      return sseResponse((stream === "mux" ? input.mux : input.host) ?? []);
+    },
+  };
+  return { runtime, calls, responded };
+}
+
+describe("mapHarnessEvent", () => {
+  test("maps an assistant text delta to message.delta without a durable cursor", () => {
+    const event = mapHarnessEvent(
+      sessionEvent({
+        type: "assistant/chunk",
+        seq: 7,
+        time: 10,
+        data: { turn: 1, step: 2, chunk: { type: "text-delta", index: 0, text: "Hel" } },
+      }),
+      SESSION_ID,
+    );
+
+    expect(event).toEqual({
+      type: "message.delta",
+      sessionId: SESSION_ID,
+      messageId: "dsh:dsh-session:assistant:1:2",
+      partId: "dsh:dsh-session:assistant:1:2:block:0",
+      kind: "text",
+      delta: "Hel",
+    });
+    expect(event && "seq" in event).toBe(false);
+  });
+
+  test("maps a reasoning delta to the reasoning kind", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({
+        type: "assistant/chunk",
+        seq: 8,
+        time: 11,
+        data: { turn: 0, step: 0, chunk: { type: "reasoning-delta", index: 3, text: "why" } },
+      }),
+      SESSION_ID,
+    )).toMatchObject({ type: "message.delta", kind: "reasoning", delta: "why" });
+  });
+
+  test("maps a user message and strips the internal system block", () => {
+    const event = mapHarnessEvent(
+      sessionEvent({
+        type: "user/message",
+        seq: 1,
+        time: 5,
+        data: {
+          id: "user-1",
+          role: "user",
+          content: [
+            { type: "text", text: "<system>\n<!-- ipollowork-internal-context -->\nhidden\n</system>Build it" },
+          ],
+        },
+      }),
+      SESSION_ID,
+    );
+
+    expect(event).toEqual({
+      type: "message.upsert",
+      sessionId: SESSION_ID,
+      message: {
+        id: "user-1",
+        role: "user",
+        parts: [{ id: "user-1:block:0", type: "text", text: "Build it" }],
+        createdAt: 5,
+      },
+    });
+  });
+
+  test("drops plugin-authored user turns", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({
+        type: "user/message",
+        seq: 2,
+        time: 6,
+        data: {
+          id: "runtime-context",
+          role: "user",
+          source: { kind: "plugin", plugin: "@deepseek-ai/dsh-system-prompt" },
+          content: [{ type: "text", text: "Current runtime context" }],
+        },
+      }),
+      SESSION_ID,
+    )).toBeNull();
+  });
+
+  test("maps an assistant message onto the turn/step message id", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({
+        type: "assistant/message",
+        seq: 4,
+        time: 20,
+        data: {
+          turn: 1,
+          step: 1,
+          message: { id: "assistant-native", role: "assistant", content: [{ type: "text", text: "Done" }] },
+        },
+      }),
+      SESSION_ID,
+    )).toEqual({
+      type: "message.upsert",
+      sessionId: SESSION_ID,
+      message: {
+        id: "dsh:dsh-session:assistant:1:1",
+        role: "assistant",
+        parts: [{ id: "dsh:dsh-session:assistant:1:1:block:0", type: "text", text: "Done" }],
+        createdAt: 20,
+      },
+    });
+  });
+
+  test("maps tool/call and normalizes snake_case tool input", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({
+        type: "tool/call",
+        seq: 9,
+        time: 30,
+        data: {
+          turn: 1,
+          step: 0,
+          callId: "call-1",
+          name: "read",
+          arguments: JSON.stringify({ file_path: "/tmp/a.txt" }),
+        },
+      }),
+      SESSION_ID,
+    )).toEqual({
+      type: "tool.called",
+      sessionId: SESSION_ID,
+      messageId: "dsh:dsh-session:assistant:1:0",
+      callId: "call-1",
+      tool: "read",
+      input: { filePath: "/tmp/a.txt" },
+    });
+  });
+
+  test("pairs tool/result with the recorded tool/call through the stream state", () => {
+    const state = createHarnessStreamState();
+    mapHarnessEvents(
+      sessionEvent({
+        type: "tool/call",
+        seq: 9,
+        time: 30,
+        data: { turn: 2, step: 1, callId: "call-9", name: "bash", arguments: { command: "ls" } },
+      }),
+      SESSION_ID,
+      state,
+    );
+
+    expect(mapHarnessEvents(
+      sessionEvent({
+        type: "tool/result",
+        seq: 10,
+        time: 31,
+        data: {
+          message: {
+            content: [{ type: "tool-result", toolCallId: "call-9", content: [{ type: "text", text: "a.txt" }] }],
+          },
+        },
+      }),
+      SESSION_ID,
+      state,
+    )).toEqual([{
+      type: "tool.completed",
+      sessionId: SESSION_ID,
+      messageId: "dsh:dsh-session:assistant:2:1",
+      callId: "call-9",
+      tool: "bash",
+      status: "success",
+      output: "a.txt",
+    }]);
+    expect(state.tools.size).toBe(0);
+  });
+
+  test("reports a failed tool result", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({
+        type: "tool/result",
+        seq: 11,
+        time: 32,
+        data: {
+          name: "bash",
+          message: {
+            content: [{ type: "tool-result", toolCallId: "call-x", content: [], isError: true }],
+          },
+          error: { name: "CommandFailed" },
+        },
+      }),
+      SESSION_ID,
+    )).toMatchObject({ type: "tool.completed", status: "failed", tool: "bash", error: "CommandFailed" });
+  });
+
+  test("maps an approval request to a permission carrying its reply address", () => {
+    const event = mapHarnessEvent(
+      envelope({
+        type: "approval/requested",
+        sessionId: SESSION_ID,
+        approvalId: "approval-1",
+        toolName: "bash",
+        reason: "Run tests",
+      }, "rpc-approval"),
+      SESSION_ID,
+    );
+
+    expect(event).toMatchObject({
+      type: "permission.asked",
+      permission: {
+        id: "approval-1",
+        sessionId: SESSION_ID,
+        kind: "bash",
+        resources: ["Run tests"],
+        // Harness cannot persist an answer, so no scope is offered.
+        remember: [],
+        metadata: { rpcId: "rpc-approval", toolName: "bash", reason: "Run tests" },
+      },
+    });
+  });
+
+  test("maps approval/resolved and question/resolved to replies", () => {
+    expect(mapHarnessEvent(
+      envelope({ type: "approval/resolved", sessionId: SESSION_ID, approvalId: "approval-1" }),
+      SESSION_ID,
+    )).toEqual({ type: "permission.replied", sessionId: SESSION_ID, requestId: "approval-1" });
+
+    expect(mapHarnessEvent(
+      envelope({ type: "question/resolved", sessionId: SESSION_ID, questionRpcId: "rpc-question" }),
+      SESSION_ID,
+    )).toEqual({ type: "question.replied", sessionId: SESSION_ID, requestId: "rpc-question" });
+  });
+
+  test("maps a question request, using the rpc id as the question id", () => {
+    expect(mapHarnessEvent(
+      envelope({
+        type: "question/requested",
+        sessionId: SESSION_ID,
+        questions: [{
+          id: "q1",
+          header: "Pick",
+          question: "Which build?",
+          options: [{ label: "debug", description: "slow" }, { label: "release" }],
+          multiSelect: false,
+        }],
+      }, "rpc-question"),
+      SESSION_ID,
+    )).toEqual({
+      type: "question.asked",
+      question: {
+        id: "rpc-question",
+        sessionId: SESSION_ID,
+        questions: [{
+          header: "Pick",
+          question: "Which build?",
+          options: [{ label: "debug", description: "slow" }, { label: "release" }],
+          multiple: false,
+          custom: true,
+        }],
+        receivedAt: expect.any(Number),
+      },
+    });
+  });
+
+  test("turn/start and turn/end carry the session lifecycle", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({ type: "turn/start", seq: 3, time: 9, data: { turn: 1 } }),
+      SESSION_ID,
+    )).toEqual({ type: "session.status", sessionId: SESSION_ID, status: { type: "busy" } });
+
+    expect(mapHarnessEvents(
+      sessionEvent({ type: "turn/end", seq: 6, time: 40, data: { turn: 1, reason: { kind: "completed" } } }),
+      SESSION_ID,
+    )).toEqual([
+      { type: "session.status", sessionId: SESSION_ID, status: { type: "idle" } },
+      { type: "session.idle", sessionId: SESSION_ID },
+    ]);
+  });
+
+  test("a failed turn reports the error before idling", () => {
+    const events = mapHarnessEvents(
+      sessionEvent({
+        type: "turn/end",
+        seq: 6,
+        time: 40,
+        data: {
+          turn: 1,
+          reason: {
+            kind: "error",
+            error: { message: 'llm-deepseek: no API key for provider route "deepseek-official"' },
+          },
+        },
+      }),
+      SESSION_ID,
+    );
+
+    expect(events.map((event) => event.type)).toEqual(["session.error", "session.status", "session.idle"]);
+    expect(events[0]).toMatchObject({ error: { message: expect.stringContaining("API key") } });
+  });
+
+  test("maps todos, titles, compaction and host frames", () => {
+    expect(mapHarnessEvent(
+      sessionEvent({
+        type: "todo/write",
+        seq: 5,
+        time: 30,
+        data: { todos: [{ content: "Verify", status: "in_progress" }] },
+      }),
+      SESSION_ID,
+    )).toEqual({
+      type: "todo.updated",
+      sessionId: SESSION_ID,
+      todos: [{ id: "dsh-session:0:Verify", content: "Verify", status: "in_progress", priority: "medium" }],
+    });
+
+    expect(mapHarnessEvent(
+      envelope({ type: "session/projection", sessionId: SESSION_ID, key: "title", value: "Ship it" }),
+      SESSION_ID,
+    )).toEqual({
+      type: "session.updated",
+      sessionId: SESSION_ID,
+      session: { id: SESSION_ID, title: "Ship it" },
+    });
+
+    expect(mapHarnessEvent(
+      sessionEvent({ type: "compaction/start", seq: 12, time: 50, data: {} }),
+      SESSION_ID,
+    )).toEqual({ type: "session.compaction", sessionId: SESSION_ID, running: true });
+
+    expect(mapHarnessEvent(
+      envelope({ type: "host/session-removed", sessionId: SESSION_ID }),
+      SESSION_ID,
+    )).toEqual({ type: "session.deleted", sessionId: SESSION_ID });
+
+    expect(mapHarnessEvent(
+      envelope({ type: "host/agent-error", sessionId: SESSION_ID, message: "boom" }),
+      SESSION_ID,
+    )).toEqual({ type: "session.error", sessionId: SESSION_ID, error: { message: "boom" } });
+  });
+
+  test("filters frames belonging to another session", () => {
+    const other = sessionEvent(
+      { type: "turn/start", seq: 3, time: 9, data: { turn: 1 } },
+      "another-session",
+    );
+    expect(mapHarnessEvent(other, SESSION_ID)).toBeNull();
+    expect(mapHarnessEvents(other, SESSION_ID)).toEqual([]);
+    expect(mapHarnessEvent(
+      envelope({ type: "approval/requested", sessionId: "another-session", approvalId: "a" }),
+      SESSION_ID,
+    )).toBeNull();
+  });
+
+  test("returns null for unknown, malformed and deliberately ignored frames", () => {
+    expect(mapHarnessEvent(null, SESSION_ID)).toBeNull();
+    expect(mapHarnessEvent("nope", SESSION_ID)).toBeNull();
+    expect(mapHarnessEvent({ type: "server-request", rpcId: "r" }, SESSION_ID)).toBeNull();
+    expect(mapHarnessEvent(envelope({ type: "totally/unknown", sessionId: SESSION_ID }), SESSION_ID)).toBeNull();
+    expect(mapHarnessEvent(sessionEvent({ type: "unknown/inner", seq: 1, time: 1, data: {} }), SESSION_ID)).toBeNull();
+    // host/session-status races the ordered turn lifecycle and is dropped on purpose.
+    expect(mapHarnessEvent(
+      envelope({ type: "host/session-status", sessionId: SESSION_ID, running: true }),
+      SESSION_ID,
+    )).toBeNull();
+  });
+});
+
+describe("mapHarnessError", () => {
+  test("maps an unavailable runtime to 503 with its own code", () => {
+    const mapped = mapHarnessError(new DeepSeekHarnessUnavailableError("DeepSeek Harness could not be reached"));
+    expect(mapped).toBeInstanceOf(ApiError);
+    expect(mapped).toMatchObject({
+      status: 503,
+      code: "deepseek_harness_unavailable",
+      message: "DeepSeek Harness could not be reached",
+    });
+  });
+
+  test("maps not-found RPC failures to 404 and everything else to 502", () => {
+    for (const code of ["not-found", "session-not-found"]) {
+      expect(mapHarnessError(new DeepSeekHarnessRpcError({ code, message: "gone" }))).toMatchObject({
+        status: 404,
+        code: `deepseek_harness_${code}`,
+      });
+    }
+
+    expect(mapHarnessError(new DeepSeekHarnessRpcError({
+      code: "bad-request",
+      message: "nope",
+      details: { field: "sessionId" },
+    }))).toMatchObject({
+      status: 502,
+      code: "deepseek_harness_bad-request",
+      message: "nope",
+      details: { field: "sessionId" },
+    });
+  });
+
+  test("passes unrelated errors through untouched", () => {
+    const error = new Error("unrelated");
+    expect(mapHarnessError(error)).toBe(error);
+    const apiError = new ApiError(404, "session_not_found", "Session not found");
+    expect(mapHarnessError(apiError)).toBe(apiError);
+  });
+
+  test("replaces credential internals with an actionable message", () => {
+    expect(normalizeHarnessErrorText(
+      'llm-deepseek: no API key for provider route "deepseek-official"; store DEEPSEEK_API_KEY through the credentials service',
+    )).toContain("API key");
+    expect(normalizeHarnessErrorText("")).toBe("DeepSeek Harness failed to run this turn");
+  });
+});
+
+describe("harness engine connection", () => {
+  const adapter = createHarnessEngineAdapter({ runtime: stubRuntime().runtime });
+
+  test("reports capabilities honestly", () => {
+    expect(adapter.id).toBe("deepseek-harness");
+    expect(HARNESS_CAPABILITIES).toEqual({
+      streaming: true,
+      resumableStreaming: false,
+      permissions: true,
+      questions: true,
+      interrupt: true,
+      wait: false,
+      promptOptions: { system: true, reasoningEffort: true, variant: true },
+    });
+  });
+
+  test("routes each operation to its allowlisted RPC method", async () => {
+    const { runtime, calls } = stubRuntime({
+      results: {
+        "session.create": { sessionId: "s1", agentPreset: "standard" },
+        // A workspace-scoped connection confirms ownership before every write, so the
+        // session has to be visible in this cwd for the writes below to be allowed.
+        "session.list": {
+          items: [{ sessionId: "s1", updatedAt: 1, running: false, blank: false, cwd: "/work/repo" }],
+        },
+        "workspace.list": { archivedSessionIds: [] },
+      },
+    });
+    const connection = createHarnessEngineAdapter({ runtime }).connect({ path: "/work/repo" });
+
+    const session = await connection.createSession({ title: "Ship it", agent: "code" });
+    expect(session).toMatchObject({ id: "s1", title: "Ship it", directory: "/work/repo" });
+
+    await connection.renameSession("s1", "Renamed");
+    expect(await connection.interrupt("s1")).toBe(true);
+    await connection.prompt({
+      sessionId: "s1",
+      parts: [{ type: "text", text: "hello" }],
+      model: { providerID: "deepseek", modelID: "deepseek-chat" },
+      reasoningEffort: "high",
+    });
+
+    // `session.list` + `workspace.list` pairs are the ownership check that precedes each
+    // write; the writes themselves keep their original order.
+    expect(calls.map((entry) => entry.method).filter((method) => method !== "session.list" && method !== "workspace.list"))
+      .toEqual([
+        "session.create",
+        "agentPreset.select",
+        "session.rename",
+        "session.rename",
+        "session.cancel",
+        "session.selectModel",
+        "session.prompt",
+      ]);
+    expect(calls.at(-2)?.payload).toMatchObject({ reasoningEffort: "high", model: "deepseek-chat" });
+    expect(calls.at(-1)?.payload).toMatchObject({
+      sessionId: "s1",
+      mode: "queue",
+      content: [{ type: "text", text: "hello" }],
+    });
+  });
+
+  test("throws 501 for operations DeepSeek Harness has no RPC for", async () => {
+    const connection = createHarnessEngineAdapter({ runtime: stubRuntime().runtime }).connect({});
+
+    const rejects = async (promise: Promise<unknown>) => {
+      try {
+        await promise;
+      } catch (error) {
+        return error as ApiError;
+      }
+      throw new Error("expected a rejection");
+    };
+
+    for (const promise of [
+      connection.deleteSession("s1"),
+      connection.prompt({ sessionId: "s1", parts: [], delivery: "steer" }),
+      connection.replyPermission({ sessionId: "s1", permissionId: "p1", reply: "always" }),
+      connection.subscribe({
+        sessionId: "s1",
+        after: "42",
+        signal: new AbortController().signal,
+        onEvent: () => undefined,
+      }),
+    ]) {
+      const error = await rejects(promise);
+      expect(error.status).toBe(501);
+      expect(error.code).toBe("engine_capability_unsupported");
+      expect(error.message).toContain("DeepSeek Harness");
+    }
+  });
+
+  test("subscribe consumes both multiplexed streams and answers a permission", async () => {
+    const { runtime, responded } = stubRuntime({
+      mux: [
+        envelope({
+          type: "approval/requested",
+          sessionId: SESSION_ID,
+          approvalId: "approval-1",
+          toolName: "bash",
+          reason: "Run tests",
+        }, "rpc-approval"),
+        sessionEvent({ type: "turn/end", seq: 6, time: 40, data: { turn: 1, reason: { kind: "completed" } } }),
+        sessionEvent({ type: "turn/start", seq: 1, time: 1, data: { turn: 0 } }, "other-session"),
+      ],
+      host: [envelope({ type: "host/agent-error", sessionId: SESSION_ID, message: "boom" })],
+    });
+    const connection = createHarnessEngineAdapter({ runtime }).connect({});
+    const events: EngineEvent[] = [];
+
+    await connection.subscribe({
+      sessionId: SESSION_ID,
+      signal: new AbortController().signal,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events.map((event) => event.type).sort()).toEqual([
+      "permission.asked",
+      "session.error",
+      "session.idle",
+      "session.status",
+    ]);
+    expect(await connection.listPermissions(SESSION_ID)).toHaveLength(1);
+    expect(await connection.listPermissions("other-session")).toHaveLength(0);
+
+    await connection.replyPermission({ sessionId: SESSION_ID, permissionId: "approval-1", reply: "once" });
+    expect(responded).toEqual([{
+      rpcId: "rpc-approval",
+      result: {
+        ok: true,
+        value: { sessionId: SESSION_ID, approvalId: "approval-1", outcome: "allowed-once" },
+      },
+    }]);
+    expect(await connection.listPermissions(SESSION_ID)).toHaveLength(0);
+  });
+
+  test("answers a question against the pending frame and rejects a stale id", async () => {
+    const { runtime, responded } = stubRuntime({
+      mux: [envelope({
+        type: "question/requested",
+        sessionId: SESSION_ID,
+        questions: [{
+          id: "q1",
+          question: "Which build?",
+          options: [{ label: "debug" }, { label: "release" }],
+          multiSelect: true,
+        }],
+      }, "rpc-question")],
+    });
+    const connection = createHarnessEngineAdapter({ runtime }).connect({});
+    await connection.subscribe({
+      sessionId: SESSION_ID,
+      signal: new AbortController().signal,
+      onEvent: () => undefined,
+    });
+
+    expect(await connection.listQuestions(SESSION_ID)).toHaveLength(1);
+    await connection.replyQuestion({
+      sessionId: SESSION_ID,
+      questionId: "rpc-question",
+      answers: [["release", "wasm"]],
+    });
+    expect(responded).toEqual([{
+      rpcId: "rpc-question",
+      result: {
+        ok: true,
+        value: { sessionId: SESSION_ID, answer: { answers: [{ id: "q1", selected: ["release"], custom: "wasm" }] } },
+      },
+    }]);
+
+    await expect(connection.replyQuestion({
+      sessionId: SESSION_ID,
+      questionId: "rpc-question",
+      answers: [[]],
+    })).rejects.toMatchObject({ status: 404, code: "engine_question_not_found" });
+  });
+
+  test("getSession maps the summary and refuses a session from another workspace", async () => {
+    const { runtime } = stubRuntime({
+      results: {
+        "session.list": {
+          items: [
+            {
+              sessionId: SESSION_ID,
+              updatedAt: 1_700_000,
+              running: false,
+              blank: false,
+              cwd: "/work/repo",
+              projections: { asOfSeq: 3, values: { title: "Ship it" } },
+            },
+            { sessionId: "elsewhere", updatedAt: 1, running: false, blank: true, cwd: "/other/repo" },
+          ],
+        },
+        "workspace.list": { archivedSessionIds: [SESSION_ID] },
+      },
+    });
+    const connection = createHarnessEngineAdapter({ runtime }).connect({ path: "/work/repo" });
+
+    expect(await connection.getSession(SESSION_ID)).toEqual({
+      id: SESSION_ID,
+      title: "Ship it",
+      parentId: null,
+      directory: "/work/repo",
+      createdAt: 1_700_000,
+      updatedAt: 1_700_000,
+      archivedAt: 1_700_000,
+    });
+    await expect(connection.getSession("elsewhere"))
+      .rejects.toMatchObject({ status: 404, code: "session_not_found" });
+  });
+
+  test("write operations refuse a session that belongs to another workspace", async () => {
+    // The Harness runtime is one process shared by every workspace and `session.list`
+    // returns all of them, so a session id proves nothing about access on its own.
+    // Without the check, a prompt aimed at another workspace's session would run there —
+    // against its files and its agent.
+    const foreign = () => stubRuntime({
+      results: {
+        "session.list": {
+          items: [
+            { sessionId: SESSION_ID, updatedAt: 1, running: false, blank: false, cwd: "/work/repo" },
+            { sessionId: "elsewhere", updatedAt: 1, running: false, blank: true, cwd: "/other/repo" },
+          ],
+        },
+        "workspace.list": { archivedSessionIds: [] },
+      },
+    });
+
+    for (const [label, act] of [
+      ["prompt", (c: ReturnType<ReturnType<typeof createHarnessEngineAdapter>["connect"]>) =>
+        c.prompt({ sessionId: "elsewhere", parts: [{ type: "text", text: "hi" }] })],
+      ["renameSession", (c: ReturnType<ReturnType<typeof createHarnessEngineAdapter>["connect"]>) =>
+        c.renameSession("elsewhere", "renamed")],
+      ["interrupt", (c: ReturnType<ReturnType<typeof createHarnessEngineAdapter>["connect"]>) =>
+        c.interrupt("elsewhere")],
+    ] as const) {
+      const { runtime, calls } = foreign();
+      const connection = createHarnessEngineAdapter({ runtime }).connect({ path: "/work/repo" });
+
+      await expect(act(connection)).rejects.toMatchObject({ status: 404, code: "session_not_found" });
+      // The mutation must not reach the runtime at all.
+      expect(calls.map((call) => call.method)).not.toContain("session.prompt");
+      expect(calls.map((call) => call.method)).not.toContain("session.rename");
+      expect(calls.map((call) => call.method)).not.toContain("session.cancel");
+      expect(label).toBeTruthy();
+    }
+  });
+
+  test("write operations still work on a session in this workspace", async () => {
+    const { runtime, calls } = stubRuntime({
+      results: {
+        "session.list": {
+          items: [{ sessionId: SESSION_ID, updatedAt: 1, running: false, blank: false, cwd: "/work/repo" }],
+        },
+        "workspace.list": { archivedSessionIds: [] },
+      },
+    });
+    const connection = createHarnessEngineAdapter({ runtime }).connect({ path: "/work/repo" });
+
+    await connection.interrupt(SESSION_ID);
+    expect(calls.map((call) => call.method)).toContain("session.cancel");
+  });
+
+  test("an unscoped connection skips the ownership lookup", async () => {
+    // A connection with no directory is not workspace-scoped, so there is nothing to
+    // check and the extra `session.list` round-trip would be wasted.
+    const { runtime, calls } = stubRuntime();
+    const connection = createHarnessEngineAdapter({ runtime }).connect({});
+
+    await connection.interrupt(SESSION_ID);
+    expect(calls.map((call) => call.method)).toEqual(["session.cancel"]);
+  });
+
+  test("wait polls session.list until the session stops running", async () => {
+    let running = true;
+    const runtime: HarnessRuntimeLike = {
+      async call<T>(method: string): Promise<T> {
+        if (method === "workspace.list") return { archivedSessionIds: [] } as T;
+        const items = [{ sessionId: SESSION_ID, updatedAt: 1, running, blank: false }];
+        running = false;
+        return { items } as T;
+      },
+      async respond() {},
+      async events() {
+        return sseResponse([]);
+      },
+    };
+    const connection = createHarnessEngineAdapter({ runtime, waitPollIntervalMs: 1 }).connect({});
+
+    await connection.wait(SESSION_ID);
+    expect(connection.capabilities.wait).toBe(false);
+  });
+
+  test("wait aborts with the caller's signal", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const connection = createHarnessEngineAdapter({ runtime: stubRuntime().runtime, waitPollIntervalMs: 1 })
+      .connect({});
+    await expect(connection.wait(SESSION_ID, controller.signal)).rejects.toBeInstanceOf(ApiError);
+  });
+
+  test("prompt content carries files, agents and the internal system block", () => {
+    expect(harnessPromptContent({
+      sessionId: "s1",
+      system: "context",
+      parts: [
+        { type: "text", text: "hi" },
+        { type: "agent", name: "reviewer" },
+        { type: "file", mime: "image/png", url: "data:image/png;base64,AAA", filename: "shot.png" },
+        { type: "file", mime: "text/plain", url: "data:text/plain,hello", filename: "a.txt" },
+      ],
+    })).toEqual([
+      { type: "text", text: "hi" },
+      { type: "text", text: "@reviewer" },
+      { type: "image", mediaType: "image/png", data: "AAA", name: "shot.png" },
+      { type: "text", text: "[Attached file: a.txt]\nhello" },
+      { type: "text", text: "<system>\n<!-- ipollowork-internal-context -->\ncontext\n</system>" },
+    ]);
+  });
+});

--- a/apps/server/src/api/engine/harness.ts
+++ b/apps/server/src/api/engine/harness.ts
@@ -1,0 +1,969 @@
+/**
+ * DeepSeek Harness engine adapter.
+ *
+ * Harness speaks a JSON-RPC dialect over `DeepSeekHarnessRuntime` plus two
+ * multiplexed SSE streams (`mux` / `host`). It has no per-session, resumable
+ * event stream and no durable cursor, so `EngineEvent.seq` stays undefined and
+ * `capabilities.resumableStreaming` is false.
+ *
+ * The payload shapes and the frame vocabulary mirror the browser engine in
+ * `apps/app/src/react-app/domains/session/engine/deepseek-harness-conversation-mapper.ts`,
+ * which is the reference implementation for this mapping.
+ */
+
+import { resolve } from "node:path";
+
+import { DEEPSEEK_HARNESS_ENGINE_ID } from "@ipollowork/types/workspace";
+
+import {
+  DeepSeekHarnessRpcError,
+  DeepSeekHarnessUnavailableError,
+} from "../../deepseek-harness-runtime.js";
+import { ApiError } from "../../errors.js";
+import type {
+  EngineAdapter,
+  EngineCapabilities,
+  EngineConnection,
+  EngineEvent,
+  EngineMessage,
+  EngineMessagePart,
+  EnginePermission,
+  EnginePromptInput,
+  EngineQuestion,
+  EngineSession,
+  EngineSubscribeInput,
+} from "./types.js";
+
+/**
+ * Structural view of `DeepSeekHarnessRuntime`, so a test can hand in a stub
+ * without spawning the `dsh` process.
+ */
+export interface HarnessRuntimeLike {
+  call<T>(method: string, payload: unknown): Promise<T>;
+  respond(input: { rpcId: string; result: unknown }): Promise<void>;
+  events(stream: "mux" | "host", signal: AbortSignal): Promise<Response>;
+}
+
+export interface HarnessEngineAdapterDeps {
+  runtime: HarnessRuntimeLike;
+  /** Upper bound for the polled `wait()` fallback. Defaults to 10 minutes. */
+  waitTimeoutMs?: number;
+  /** First poll interval for `wait()`; it backs off to 2s. Defaults to 250ms. */
+  waitPollIntervalMs?: number;
+}
+
+export const HARNESS_INTERNAL_SYSTEM_PREFIX = "<system>\n<!-- ipollowork-internal-context -->\n";
+
+const LEGACY_SYSTEM_BLOCK = /^<system>\n[\s\S]*\n<\/system>$/u;
+const INTERNAL_SESSION_TITLE = /^<system(?:>|\s)/iu;
+const MISSING_CREDENTIAL = /no api key for provider route|missing[_ -]?credential/iu;
+const DEFAULT_SESSION_TITLE = "New conversation";
+
+/**
+ * Harness reports a tool's name only on `tool/call`; `tool/result` carries just
+ * the call id. The stream keeps the pairing so `tool.completed` can name its tool.
+ */
+export interface HarnessStreamState {
+  tools: Map<string, { messageId: string; tool: string; input: unknown }>;
+}
+
+export function createHarnessStreamState(): HarnessStreamState {
+  return { tools: new Map() };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Errors                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Shared error translation, identical to `routes/deepseek-harness.ts` so both
+ * the RPC passthrough and the engine adapter report the same status and code.
+ * Returns the original error untouched when it is not a Harness error.
+ */
+export function mapHarnessError(error: unknown): unknown {
+  if (error instanceof DeepSeekHarnessUnavailableError) {
+    return new ApiError(503, error.code, error.message);
+  }
+  if (error instanceof DeepSeekHarnessRpcError) {
+    const status = error.code === "not-found" || error.code === "session-not-found" ? 404 : 502;
+    return new ApiError(status, `deepseek_harness_${error.code}`, error.message, error.details);
+  }
+  return error;
+}
+
+export function throwHarnessError(error: unknown): never {
+  throw mapHarnessError(error);
+}
+
+function unsupported(operation: string, detail: string): ApiError {
+  return new ApiError(
+    501,
+    "engine_capability_unsupported",
+    `DeepSeek Harness does not support ${operation}: ${detail}`,
+    { engineId: DEEPSEEK_HARNESS_ENGINE_ID, operation },
+  );
+}
+
+export function normalizeHarnessErrorText(value: unknown): string {
+  const message = typeof value === "string" ? value.trim() : "";
+  if (MISSING_CREDENTIAL.test(message)) {
+    return "DeepSeek Harness has no API key for this model provider. Connect the provider credential first.";
+  }
+  return message || "DeepSeek Harness failed to run this turn";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pure event mapping                                                          */
+/* -------------------------------------------------------------------------- */
+
+function parseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value ?? {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeToolInput(toolName: string, value: unknown): unknown {
+  const parsed = parseJson(value);
+  if (!isRecord(parsed)) return parsed;
+  const fieldMappings: Partial<Record<string, Record<string, string>>> = {
+    apply_patch: { patch_text: "patchText" },
+    edit: { file_path: "filePath", new_string: "newString", old_string: "oldString", replace_all: "replaceAll" },
+    read: { file_path: "filePath" },
+    write: { file_path: "filePath" },
+  };
+  const mappings = fieldMappings[toolName];
+  if (!mappings) return parsed;
+  const normalized = { ...parsed };
+  for (const [source, target] of Object.entries(mappings)) {
+    if (!(target in normalized) && source in normalized) normalized[target] = normalized[source];
+    delete normalized[source];
+  }
+  return normalized;
+}
+
+function assistantMessageId(sessionId: string, turn: number, step: number): string {
+  return `dsh:${sessionId}:assistant:${turn}:${step}`;
+}
+
+function partId(messageId: string, index: number): string {
+  return `${messageId}:block:${index}`;
+}
+
+function numberField(data: Record<string, unknown> | null, key: string): number {
+  const value = data?.[key];
+  return typeof value === "number" ? value : 0;
+}
+
+function visibleUserContent(message: Record<string, unknown>): unknown {
+  const content = message.content;
+  if (!Array.isArray(content)) return content;
+  return content.flatMap((block, index) => {
+    if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") return [block];
+    if (index === 0 && content.length > 1 && LEGACY_SYSTEM_BLOCK.test(block.text.trim())) return [];
+    let text = block.text;
+    let start = text.indexOf(HARNESS_INTERNAL_SYSTEM_PREFIX);
+    while (start !== -1) {
+      const end = text.indexOf("</system>", start + HARNESS_INTERNAL_SYSTEM_PREFIX.length);
+      text = end === -1
+        ? text.slice(0, start)
+        : `${text.slice(0, start)}${text.slice(end + "</system>".length)}`;
+      start = text.indexOf(HARNESS_INTERNAL_SYSTEM_PREFIX);
+    }
+    return text.trim() ? [{ ...block, text }] : [];
+  });
+}
+
+function messageParts(messageId: string, content: unknown): EngineMessagePart[] {
+  if (!Array.isArray(content)) return [];
+  return content.flatMap((block, index): EngineMessagePart[] => {
+    if (!isRecord(block)) return [];
+    const id = partId(messageId, index);
+    if ((block.type === "text" || block.type === "reasoning") && typeof block.text === "string") {
+      return [{ id, type: block.type, text: block.text }];
+    }
+    if (block.type === "tool-call" && typeof block.id === "string" && typeof block.name === "string") {
+      return [{
+        id: block.id,
+        type: "tool",
+        callId: block.id,
+        tool: block.name,
+        input: normalizeToolInput(block.name, block.arguments),
+      }];
+    }
+    if (block.type === "image") {
+      // The raw base64 payload is deliberately dropped: the public API streams
+      // conversation structure, not attachment bytes.
+      return [{
+        id,
+        type: "file",
+        mime: typeof block.mediaType === "string" ? block.mediaType : "application/octet-stream",
+        ...(typeof block.name === "string" ? { filename: block.name } : {}),
+      }];
+    }
+    return [];
+  });
+}
+
+function engineMessage(sessionId: string, event: Record<string, unknown>): EngineMessage | null {
+  const data = isRecord(event.data) ? event.data : null;
+  const message = data && isRecord(data.message)
+    ? data.message
+    : event.type === "user/message" && data
+      ? data
+      : null;
+  if (!message || typeof message.id !== "string") return null;
+  if (event.type === "user/message") {
+    const source = isRecord(message.source) ? message.source : null;
+    // Plugin-injected turns are runtime context, not conversation content.
+    if (source && source.kind !== "user") return null;
+  }
+  const declaredRole = message.role === "assistant"
+    ? "assistant"
+    : message.role === "system"
+      ? "system"
+      : "user";
+  const createdAt = typeof event.time === "number" ? event.time : null;
+  if (event.type === "assistant/message" || declaredRole === "assistant") {
+    const id = event.type === "assistant/message"
+      ? assistantMessageId(sessionId, numberField(data, "turn"), numberField(data, "step"))
+      : message.id;
+    return {
+      id,
+      role: "assistant",
+      parts: messageParts(id, event.type === "user/message" ? visibleUserContent(message) : message.content),
+      createdAt,
+    };
+  }
+  return {
+    id: message.id,
+    role: declaredRole,
+    parts: messageParts(message.id, visibleUserContent(message)),
+    createdAt,
+  };
+}
+
+function textOutput(content: unknown): unknown {
+  if (!Array.isArray(content)) return content;
+  const text = content.flatMap((block) => {
+    if (!isRecord(block)) return [];
+    if ((block.type === "text" || block.type === "reasoning") && typeof block.text === "string") return [block.text];
+    return [];
+  }).join("\n");
+  return text || content;
+}
+
+function toolResult(data: Record<string, unknown>) {
+  if (!isRecord(data.message) || !Array.isArray(data.message.content)) return null;
+  const block = data.message.content.find((item) => isRecord(item) && item.type === "tool-result");
+  if (!isRecord(block) || typeof block.toolCallId !== "string") return null;
+  return {
+    callId: block.toolCallId,
+    output: textOutput(block.content),
+    isError: block.isError === true || isRecord(data.error),
+    errorText: isRecord(data.error) && typeof data.error.name === "string" ? data.error.name : undefined,
+  };
+}
+
+function harnessTodos(sessionId: string, data: Record<string, unknown>): unknown[] {
+  if (!Array.isArray(data.todos)) return [];
+  return data.todos.flatMap((todo, index) => {
+    if (!isRecord(todo) || typeof todo.content !== "string" || typeof todo.status !== "string") return [];
+    return [{
+      id: `${sessionId}:${index}:${todo.content}`,
+      content: todo.content,
+      status: todo.status,
+      priority: "medium",
+    }];
+  });
+}
+
+function harnessPermission(
+  sessionId: string,
+  rpcId: string,
+  frame: Record<string, unknown>,
+): EnginePermission {
+  return {
+    id: String(frame.approvalId),
+    sessionId,
+    kind: typeof frame.toolName === "string" ? frame.toolName : "tool",
+    resources: typeof frame.reason === "string" ? [frame.reason] : [],
+    // Harness answers one approval at a time; it has no persistent grant scope.
+    remember: [],
+    metadata: {
+      rpcId,
+      ...(typeof frame.toolName === "string" ? { toolName: frame.toolName } : {}),
+      ...(typeof frame.callId === "string" ? { callId: frame.callId } : {}),
+      ...(typeof frame.reason === "string" ? { reason: frame.reason } : {}),
+    },
+    receivedAt: Date.now(),
+  };
+}
+
+function harnessQuestion(
+  sessionId: string,
+  rpcId: string,
+  frame: Record<string, unknown>,
+): EngineQuestion | null {
+  if (!Array.isArray(frame.questions)) return null;
+  return {
+    // The RPC id is the reply address, so it is also the question id.
+    id: rpcId,
+    sessionId,
+    questions: frame.questions.flatMap((item) => {
+      if (!isRecord(item) || typeof item.question !== "string") return [];
+      return [{
+        ...(typeof item.header === "string" ? { header: item.header } : {}),
+        question: item.question,
+        options: Array.isArray(item.options)
+          ? item.options.flatMap((option) => isRecord(option) && typeof option.label === "string"
+            ? [{
+                label: option.label,
+                ...(typeof option.description === "string" ? { description: option.description } : {}),
+              }]
+            : [])
+          : [],
+        multiple: item.multiSelect === true,
+        custom: true,
+      }];
+    }),
+    receivedAt: Date.now(),
+  };
+}
+
+/**
+ * Maps one Harness SSE envelope to the normalized engine events.
+ *
+ * A single Harness frame can carry more than one engine-level fact (`turn/end`
+ * both fails and idles a session), so the full-fidelity mapping is the plural
+ * form; `mapHarnessEvent` is the single-event view required by the adapter
+ * contract. Both are pure: `state` is supplied by the caller and only records
+ * the tool-call pairing that Harness itself omits from `tool/result`.
+ */
+export function mapHarnessEvents(
+  event: unknown,
+  sessionId: string,
+  state?: HarnessStreamState,
+): EngineEvent[] {
+  const envelope = isRecord(event) ? event : null;
+  const frame = envelope && isRecord(envelope.payload) ? envelope.payload : null;
+  if (!frame) return [];
+  const rpcId = envelope && typeof envelope.rpcId === "string" ? envelope.rpcId : "";
+  const type = typeof frame.type === "string" ? frame.type : "";
+  const frameSessionId = typeof frame.sessionId === "string" ? frame.sessionId : "";
+  if (!frameSessionId || frameSessionId !== sessionId) return [];
+
+  // `host/session-status` races ahead of assistant chunks on the other stream;
+  // turn/start and turn/end are the ordered, authoritative lifecycle boundary.
+  if (type === "host/session-status") return [];
+  if (type === "host/session-removed") return [{ type: "session.deleted", sessionId }];
+  if (type === "host/agent-error") {
+    return [{
+      type: "session.error",
+      sessionId,
+      error: { message: normalizeHarnessErrorText(frame.message) },
+    }];
+  }
+  if (type === "approval/requested" && typeof frame.approvalId === "string") {
+    return [{ type: "permission.asked", permission: harnessPermission(sessionId, rpcId, frame) }];
+  }
+  if (type === "approval/resolved" && typeof frame.approvalId === "string") {
+    return [{ type: "permission.replied", sessionId, requestId: frame.approvalId }];
+  }
+  if (type === "question/requested") {
+    const question = harnessQuestion(sessionId, rpcId, frame);
+    return question ? [{ type: "question.asked", question }] : [];
+  }
+  if (type === "question/resolved" && typeof frame.questionRpcId === "string") {
+    return [{ type: "question.replied", sessionId, requestId: frame.questionRpcId }];
+  }
+  if (type === "session/projection" && frame.key === "title" && typeof frame.value === "string") {
+    return [{ type: "session.updated", sessionId, session: { id: sessionId, title: frame.value } }];
+  }
+  if (type !== "session/event" || !isRecord(frame.event)) return [];
+
+  const inner = frame.event;
+  const innerType = typeof inner.type === "string" ? inner.type : "";
+  if (innerType === "user/message" || innerType === "assistant/message") {
+    const message = engineMessage(sessionId, inner);
+    return message ? [{ type: "message.upsert", sessionId, message }] : [];
+  }
+  const data = isRecord(inner.data) ? inner.data : null;
+  if (!data) return [];
+  const messageId = assistantMessageId(sessionId, numberField(data, "turn"), numberField(data, "step"));
+
+  if (innerType === "assistant/chunk" && isRecord(data.chunk)) {
+    const chunk = data.chunk;
+    if ((chunk.type !== "text-delta" && chunk.type !== "reasoning-delta") || typeof chunk.text !== "string") {
+      return [];
+    }
+    return [{
+      type: "message.delta",
+      sessionId,
+      messageId,
+      partId: partId(messageId, typeof chunk.index === "number" ? chunk.index : 0),
+      kind: chunk.type === "reasoning-delta" ? "reasoning" : "text",
+      delta: chunk.text,
+    }];
+  }
+  if (innerType === "tool/call" && typeof data.callId === "string" && typeof data.name === "string") {
+    const input = normalizeToolInput(data.name, data.arguments);
+    state?.tools.set(data.callId, { messageId, tool: data.name, input });
+    return [{ type: "tool.called", sessionId, messageId, callId: data.callId, tool: data.name, input }];
+  }
+  if (innerType === "tool/result") {
+    const result = toolResult(data);
+    if (!result) return [];
+    const pending = state?.tools.get(result.callId);
+    state?.tools.delete(result.callId);
+    return [{
+      type: "tool.completed",
+      sessionId,
+      messageId: pending?.messageId ?? messageId,
+      callId: result.callId,
+      tool: pending?.tool ?? (typeof data.name === "string" ? data.name : "unknown"),
+      status: result.isError ? "failed" : "success",
+      output: result.output,
+      ...(result.isError ? { error: result.errorText ?? "Tool failed" } : {}),
+    }];
+  }
+  if (innerType === "todo/write") {
+    return [{ type: "todo.updated", sessionId, todos: harnessTodos(sessionId, data) }];
+  }
+  if (innerType === "session/title" && typeof data.title === "string") {
+    return [{ type: "session.updated", sessionId, session: { id: sessionId, title: data.title } }];
+  }
+  if (innerType === "turn/start") {
+    return [{ type: "session.status", sessionId, status: { type: "busy" } }];
+  }
+  if (innerType === "turn/end") {
+    const reason = isRecord(data.reason) ? data.reason : null;
+    const error = reason?.kind === "error" && isRecord(reason.error) ? reason.error : null;
+    return [
+      ...(reason?.kind === "error"
+        ? [{
+            type: "session.error" as const,
+            sessionId,
+            error: { message: normalizeHarnessErrorText(error?.message) },
+          }]
+        : []),
+      { type: "session.status", sessionId, status: { type: "idle" } },
+      { type: "session.idle", sessionId },
+    ];
+  }
+  if (innerType === "compaction/start") return [{ type: "session.compaction", sessionId, running: true }];
+  if (innerType === "compaction/end") return [{ type: "session.compaction", sessionId, running: false }];
+  return [];
+}
+
+/**
+ * Single-event view of {@link mapHarnessEvents}: the first engine event a
+ * Harness envelope produces, or `null` when the envelope is unknown, internal,
+ * or belongs to another session. `seq` is never set — Harness exposes no
+ * durable cursor on its live streams.
+ */
+export function mapHarnessEvent(event: unknown, sessionId: string): EngineEvent | null {
+  return mapHarnessEvents(event, sessionId)[0] ?? null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Session read model                                                          */
+/* -------------------------------------------------------------------------- */
+
+type HarnessSummary = {
+  sessionId: string;
+  updatedAt: number;
+  running: boolean;
+  blank: boolean;
+  parentSessionId?: string;
+  cwd?: string;
+  agentPreset?: string;
+  projections?: { asOfSeq: number; values: Record<string, unknown> };
+};
+
+function summaryTitle(summary: HarnessSummary): string {
+  const projected = summary.projections?.values.title;
+  if (typeof projected !== "string" || !projected.trim()) return DEFAULT_SESSION_TITLE;
+  const title = projected.trim();
+  return INTERNAL_SESSION_TITLE.test(title) ? DEFAULT_SESSION_TITLE : title;
+}
+
+function engineSession(summary: HarnessSummary, archived: boolean): EngineSession {
+  return {
+    id: summary.sessionId,
+    title: summaryTitle(summary),
+    parentId: summary.parentSessionId ?? null,
+    directory: summary.cwd ?? null,
+    createdAt: summary.updatedAt,
+    updatedAt: summary.updatedAt,
+    archivedAt: archived ? summary.updatedAt : null,
+  };
+}
+
+function pathMatches(left: string | undefined, right: string): boolean {
+  if (!left?.trim()) return false;
+  const normalizedLeft = resolve(left);
+  const normalizedRight = resolve(right);
+  return process.platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function workspacePath(workspace: unknown): string | undefined {
+  if (!isRecord(workspace)) return undefined;
+  const path = typeof workspace.path === "string" ? workspace.path : undefined;
+  return path?.trim() ? path : undefined;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Prompt payload                                                              */
+/* -------------------------------------------------------------------------- */
+
+function internalPromptText(text: string): string {
+  if (text.startsWith(HARNESS_INTERNAL_SYSTEM_PREFIX)) return text;
+  return `${HARNESS_INTERNAL_SYSTEM_PREFIX}${text}\n</system>`;
+}
+
+function textDataUrl(url: string): string | null {
+  const match = /^data:(text\/[^;,]+)(;base64)?,([\s\S]*)$/u.exec(url);
+  if (!match?.[1] || match[3] === undefined) return null;
+  if (!match[2]) return decodeURIComponent(match[3]);
+  return Buffer.from(match[3], "base64").toString("utf8");
+}
+
+export function harnessPromptContent(input: EnginePromptInput): unknown[] {
+  const content: Array<Record<string, unknown>> = [];
+  for (const part of input.parts) {
+    if (part.type === "text") {
+      content.push({ type: "text", text: part.text });
+      continue;
+    }
+    if (part.type === "agent") {
+      content.push({ type: "text", text: `@${part.name}` });
+      continue;
+    }
+    const image = /^data:(image\/(?:png|jpeg|webp|gif));base64,(.+)$/u.exec(part.url);
+    if (image?.[1] && image[2]) {
+      content.push({
+        type: "image",
+        mediaType: image[1],
+        data: image[2],
+        ...(part.filename ? { name: part.filename } : {}),
+      });
+      continue;
+    }
+    const text = part.url.startsWith("data:") ? textDataUrl(part.url) : part.url;
+    if (text === null) {
+      throw unsupported(
+        "this attachment type",
+        "only raster images and text attachments can be sent in a conversation",
+      );
+    }
+    content.push({ type: "text", text: `[Attached file: ${part.filename || "file"}]\n${text}` });
+  }
+  if (input.system?.trim()) {
+    content.push({ type: "text", text: internalPromptText(input.system.trim()) });
+  }
+  return content;
+}
+
+/* -------------------------------------------------------------------------- */
+/* SSE                                                                         */
+/* -------------------------------------------------------------------------- */
+
+type HarnessEnvelope = { type: string; rpcId: string; method?: string; payload: Record<string, unknown> };
+
+/**
+ * Parses the Harness SSE body. There is no SDK helper for this stream, and the
+ * runtime also bridges a WebSocket transport into the same `data: <json>` frame
+ * shape, so one parser covers both.
+ */
+export async function* readHarnessEnvelopes(response: Response): AsyncGenerator<HarnessEnvelope> {
+  if (!response.body) return;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      let boundary = buffer.indexOf("\n\n");
+      while (boundary !== -1) {
+        const chunk = buffer.slice(0, boundary);
+        buffer = buffer.slice(boundary + 2);
+        const data = chunk
+          .split("\n")
+          .filter((line) => line.startsWith("data: "))
+          .map((line) => line.slice(6))
+          .join("");
+        if (data) {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data);
+          } catch {
+            parsed = null;
+          }
+          if (isRecord(parsed) && parsed.type === "server-request" && typeof parsed.rpcId === "string") {
+            yield {
+              type: "server-request",
+              rpcId: parsed.rpcId,
+              ...(typeof parsed.method === "string" ? { method: parsed.method } : {}),
+              payload: isRecord(parsed.payload) ? parsed.payload : {},
+            };
+          }
+        }
+        boundary = buffer.indexOf("\n\n");
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return isRecord(error) && error.name === "AbortError";
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolveSleep, rejectSleep) => {
+    if (signal?.aborted) {
+      rejectSleep(new ApiError(499, "client_closed_request", "Wait was aborted"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolveSleep();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      rejectSleep(new ApiError(499, "client_closed_request", "Wait was aborted"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Adapter                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Honest capability report.
+ *
+ * - `resumableStreaming`: `runtime.events()` accepts only a stream name and an
+ *   abort signal — there is no cursor parameter and no durable sequence on live
+ *   frames, so `?after=` cannot be honoured.
+ * - `wait`: no RPC in the Harness allowlist blocks until idle, so `wait()` is a
+ *   polled fallback over `session.list`'s `running` flag.
+ * - `shell` / `commands`: Harness exposes neither direct shell execution nor a
+ *   command catalogue through its conversation RPC surface.
+ */
+export const HARNESS_CAPABILITIES: EngineCapabilities = {
+  streaming: true,
+  resumableStreaming: false,
+  permissions: true,
+  questions: true,
+  interrupt: true,
+  wait: false,
+  // A system prompt is carried as an internal `<system>` content block on the prompt
+  // itself, and the reasoning-effort hint rides on `session.selectModel` alongside the
+  // variant, so all three are genuinely applied here.
+  promptOptions: { system: true, reasoningEffort: true, variant: true },
+};
+
+export function createHarnessEngineAdapter(deps: HarnessEngineAdapterDeps): EngineAdapter {
+  const { runtime } = deps;
+  const waitTimeoutMs = deps.waitTimeoutMs ?? 600_000;
+  const pollIntervalMs = deps.waitPollIntervalMs ?? 250;
+
+  return {
+    id: DEEPSEEK_HARNESS_ENGINE_ID,
+    connect(workspace: unknown): EngineConnection {
+      return createHarnessConnection({ runtime, waitTimeoutMs, pollIntervalMs, workspace });
+    },
+  };
+}
+
+function createHarnessConnection(input: {
+  runtime: HarnessRuntimeLike;
+  waitTimeoutMs: number;
+  pollIntervalMs: number;
+  workspace: unknown;
+}): EngineConnection {
+  const { runtime } = input;
+  const directory = workspacePath(input.workspace);
+  const permissions = new Map<string, EnginePermission>();
+  const questions = new Map<string, { question: EngineQuestion; frame: Record<string, unknown> }>();
+  const state = createHarnessStreamState();
+
+  const call = async <T>(method: string, payload: unknown): Promise<T> => {
+    try {
+      return await runtime.call<T>(method, payload);
+    } catch (error) {
+      throw mapHarnessError(error);
+    }
+  };
+
+  const respond = async (rpcId: string, result: unknown): Promise<void> => {
+    try {
+      await runtime.respond({ rpcId, result });
+    } catch (error) {
+      throw mapHarnessError(error);
+    }
+  };
+
+  const readSummary = async (sessionId: string): Promise<{ summary: HarnessSummary; archived: boolean }> => {
+    const [sessions, workspaces] = await Promise.all([
+      call<{ items: HarnessSummary[] }>("session.list", {}),
+      call<{ archivedSessionIds: string[] }>("workspace.list", {}),
+    ]);
+    // A runtime that answers without an `items` array means "no sessions", not a crash:
+    // a TypeError here would surface as a 500 on what is really a plain lookup miss.
+    const items = Array.isArray(sessions?.items) ? sessions.items : [];
+    const summary = items.find((item) => item.sessionId === sessionId);
+    // A workspace-scoped connection must not leak sessions from another cwd.
+    if (!summary || (directory && !pathMatches(summary.cwd, directory))) {
+      throw new ApiError(404, "session_not_found", "Session not found");
+    }
+    const archivedIds = Array.isArray(workspaces?.archivedSessionIds) ? workspaces.archivedSessionIds : [];
+    return { summary, archived: archivedIds.includes(sessionId) };
+  };
+
+  /**
+   * Confirms a session belongs to this connection's workspace before acting on it.
+   *
+   * The Harness runtime is one process shared by every workspace, and `session.list`
+   * returns all of them, so a session id is not self-scoping the way it is with OpenCode's
+   * per-directory client. Without this check, `POST /workspaces/wA/sessions/{id_from_wB}/prompt`
+   * would run in workspace B — against B's files, with B's agent — while the caller only ever
+   * proved access to A. Reads already went through `readSummary`; writes have to as well.
+   */
+  const assertSessionInWorkspace = async (sessionId: string): Promise<void> => {
+    if (!directory) return;
+    await readSummary(sessionId);
+  };
+
+  return {
+    engineId: DEEPSEEK_HARNESS_ENGINE_ID,
+    capabilities: HARNESS_CAPABILITIES,
+
+    async createSession(request) {
+      const created = await call<{ sessionId: string; agentPreset?: string }>("session.create", {
+        ...(directory ? { cwd: directory } : {}),
+      });
+      if (request.agent) {
+        await call("agentPreset.select", { sessionId: created.sessionId, agentPreset: request.agent });
+      }
+      if (request.model) {
+        await call("session.selectModel", {
+          sessionId: created.sessionId,
+          provider: request.model.providerID,
+          model: request.model.modelID,
+        });
+      }
+      if (request.title?.trim()) {
+        await call("session.rename", { sessionId: created.sessionId, title: request.title.trim() });
+      }
+      const now = Date.now();
+      return {
+        id: created.sessionId,
+        title: request.title?.trim() || DEFAULT_SESSION_TITLE,
+        parentId: null,
+        directory: directory ?? null,
+        createdAt: now,
+        updatedAt: now,
+        archivedAt: null,
+      };
+    },
+
+    async getSession(sessionId) {
+      const { summary, archived } = await readSummary(sessionId);
+      return engineSession(summary, archived);
+    },
+
+    async deleteSession(sessionId) {
+      void sessionId;
+      throw unsupported(
+        "deleteSession",
+        "its RPC surface offers only workspace.archiveSession, which hides a session without deleting it",
+      );
+    },
+
+    async renameSession(sessionId, title) {
+      await assertSessionInWorkspace(sessionId);
+      await call("session.rename", { sessionId, title });
+    },
+
+    async prompt(request) {
+      await assertSessionInWorkspace(request.sessionId);
+      if (request.delivery === "steer") {
+        throw unsupported("steering an in-flight turn", "session.prompt only accepts queued delivery");
+      }
+      if (request.agent) {
+        await call("agentPreset.select", { sessionId: request.sessionId, agentPreset: request.agent });
+      }
+      if (request.model) {
+        const reasoningEffort = request.reasoningEffort || request.variant;
+        await call("session.selectModel", {
+          sessionId: request.sessionId,
+          provider: request.model.providerID,
+          model: request.model.modelID,
+          ...(reasoningEffort ? { reasoningEffort } : {}),
+        });
+      }
+      await call("session.prompt", {
+        sessionId: request.sessionId,
+        mode: "queue",
+        content: harnessPromptContent(request),
+      });
+      // Harness assigns the assistant message id itself and reports it only on
+      // the event stream, so there is no id to return here.
+      return {};
+    },
+
+    async interrupt(sessionId) {
+      await assertSessionInWorkspace(sessionId);
+      await call("session.cancel", { sessionId });
+      return true;
+    },
+
+    /**
+     * Polled fallback: Harness has no blocking "run until idle" RPC, so this
+     * watches the `running` flag `session.list` reports, backing off to 2s.
+     */
+    async wait(sessionId, signal) {
+      const deadline = Date.now() + input.waitTimeoutMs;
+      let delay = input.pollIntervalMs;
+      for (;;) {
+        await sleep(delay, signal);
+        const { summary } = await readSummary(sessionId);
+        if (!summary.running) return;
+        if (Date.now() >= deadline) {
+          throw new ApiError(504, "engine_wait_timeout", "DeepSeek Harness session is still running", {
+            engineId: DEEPSEEK_HARNESS_ENGINE_ID,
+            sessionId,
+          });
+        }
+        delay = Math.min(delay * 2, 2_000);
+      }
+    },
+
+    /**
+     * Only permissions seen on this connection's live stream are listed:
+     * Harness has no "list pending approvals" RPC.
+     */
+    async listPermissions(sessionId) {
+      return [...permissions.values()].filter((permission) => permission.sessionId === sessionId);
+    },
+
+    async replyPermission(request) {
+      if (request.reply === "always") {
+        throw unsupported(
+          "remembering a permission answer",
+          "an approval is answered once and never persisted, so reply must be \"once\" or \"reject\"",
+        );
+      }
+      const permission = permissions.get(request.permissionId);
+      const rpcId = permission && typeof permission.metadata.rpcId === "string" ? permission.metadata.rpcId : null;
+      if (!permission || !rpcId) {
+        throw new ApiError(404, "engine_permission_not_found", "DeepSeek Harness approval is no longer pending", {
+          engineId: DEEPSEEK_HARNESS_ENGINE_ID,
+          permissionId: request.permissionId,
+        });
+      }
+      await respond(rpcId, {
+        ok: true,
+        value: {
+          sessionId: permission.sessionId,
+          approvalId: permission.id,
+          outcome: request.reply === "reject" ? "rejected" : "allowed-once",
+        },
+      });
+      permissions.delete(request.permissionId);
+    },
+
+    async listQuestions(sessionId) {
+      return [...questions.values()]
+        .map((entry) => entry.question)
+        .filter((question) => question.sessionId === sessionId);
+    },
+
+    async replyQuestion(request) {
+      const pending = questions.get(request.questionId);
+      if (!pending || !Array.isArray(pending.frame.questions)) {
+        throw new ApiError(404, "engine_question_not_found", "DeepSeek Harness question is no longer pending", {
+          engineId: DEEPSEEK_HARNESS_ENGINE_ID,
+          questionId: request.questionId,
+        });
+      }
+      const answers = pending.frame.questions.flatMap((question, index) => {
+        if (!isRecord(question) || typeof question.id !== "string") return [];
+        const selected = request.answers[index] ?? [];
+        const optionLabels = new Set(
+          Array.isArray(question.options)
+            ? question.options.flatMap((option) => isRecord(option) && typeof option.label === "string"
+              ? [option.label]
+              : [])
+            : [],
+        );
+        const custom = selected.find((value) => !optionLabels.has(value));
+        return [{
+          id: question.id,
+          selected: selected.filter((value) => optionLabels.has(value)),
+          ...(custom ? { custom } : {}),
+        }];
+      });
+      await respond(request.questionId, {
+        ok: true,
+        value: { sessionId: pending.question.sessionId, answer: { answers } },
+      });
+      questions.delete(request.questionId);
+    },
+
+    /**
+     * Harness multiplexes every session onto `mux` (conversation frames,
+     * approvals, questions) and `host` (session lifecycle and agent errors), so
+     * both are consumed and filtered down to one session id.
+     */
+    async subscribe(subscription: EngineSubscribeInput) {
+      if (subscription.after) {
+        throw unsupported(
+          "resuming an event stream",
+          "its live streams carry no durable cursor, so `after` cannot be replayed",
+        );
+      }
+      const consume = async (stream: "mux" | "host") => {
+        let response: Response;
+        try {
+          response = await runtime.events(stream, subscription.signal);
+        } catch (error) {
+          if (subscription.signal.aborted || isAbortError(error)) return;
+          throw mapHarnessError(error);
+        }
+        try {
+          for await (const envelope of readHarnessEnvelopes(response)) {
+            for (const event of mapHarnessEvents(envelope, subscription.sessionId, state)) {
+              if (event.type === "permission.asked") permissions.set(event.permission.id, event.permission);
+              if (event.type === "permission.replied") permissions.delete(event.requestId);
+              if (event.type === "question.asked") {
+                questions.set(event.question.id, { question: event.question, frame: envelope.payload });
+              }
+              if (event.type === "question.replied") questions.delete(event.requestId);
+              subscription.onEvent(event);
+            }
+          }
+        } catch (error) {
+          if (subscription.signal.aborted || isAbortError(error)) return;
+          throw mapHarnessError(error);
+        }
+      };
+      await Promise.all([consume("mux"), consume("host")]);
+    },
+  };
+}

--- a/apps/server/src/api/engine/opencode.test.ts
+++ b/apps/server/src/api/engine/opencode.test.ts
@@ -1,0 +1,628 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildOpencodePromptInput,
+  createOpencodeEngineAdapter,
+  describeOpencodeError,
+  mapOpencodeEvent,
+  mapOpencodePermission,
+  mapOpencodeSession,
+  opencodePermissionKind,
+  OPENCODE_ENGINE_CAPABILITIES,
+} from "./opencode.js";
+
+function envelope(type: string, data: unknown, seq?: number) {
+  return {
+    id: `evt_${type}`,
+    type,
+    ...(seq === undefined ? {} : { durable: { aggregateID: "ses_1", seq, version: 1 } }),
+    data,
+  };
+}
+
+describe("mapOpencodeEvent", () => {
+  test("maps session.next.text.delta to a text message delta", () => {
+    const event = mapOpencodeEvent(envelope("session.next.text.delta", {
+      timestamp: 1,
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      textID: "prt_1",
+      delta: "Hello",
+    }));
+
+    expect(event).toEqual({
+      type: "message.delta",
+      sessionId: "ses_1",
+      messageId: "msg_1",
+      partId: "prt_1",
+      kind: "text",
+      delta: "Hello",
+    });
+  });
+
+  test("maps session.next.reasoning.delta to a reasoning message delta", () => {
+    const event = mapOpencodeEvent(envelope("session.next.reasoning.delta", {
+      timestamp: 1,
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      reasoningID: "prt_r1",
+      delta: "thinking",
+    }));
+
+    expect(event).toMatchObject({ type: "message.delta", kind: "reasoning", partId: "prt_r1", delta: "thinking" });
+  });
+
+  test("maps session.next.tool.called", () => {
+    const event = mapOpencodeEvent(envelope("session.next.tool.called", {
+      timestamp: 1,
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      callID: "call_1",
+      tool: "bash",
+      input: { command: "ls" },
+      provider: { executed: true },
+    }));
+
+    expect(event).toEqual({
+      type: "tool.called",
+      sessionId: "ses_1",
+      messageId: "msg_1",
+      callId: "call_1",
+      tool: "bash",
+      input: { command: "ls" },
+    });
+  });
+
+  test("maps session.next.tool.success, leaving the tool name blank for the caller to fill", () => {
+    const event = mapOpencodeEvent(envelope("session.next.tool.success", {
+      timestamp: 2,
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      callID: "call_1",
+      structured: { exit: 0 },
+      content: [],
+      result: "README.md",
+      provider: { executed: true },
+    }));
+
+    expect(event).toEqual({
+      type: "tool.completed",
+      sessionId: "ses_1",
+      messageId: "msg_1",
+      callId: "call_1",
+      tool: "",
+      status: "success",
+      output: "README.md",
+    });
+  });
+
+  test("falls back to the structured payload when a tool success carries no result", () => {
+    const event = mapOpencodeEvent(envelope("session.next.tool.success", {
+      timestamp: 2,
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      callID: "call_2",
+      structured: { exit: 0 },
+      content: [],
+      provider: { executed: true },
+    }));
+
+    expect(event).toMatchObject({ type: "tool.completed", status: "success", output: { exit: 0 } });
+  });
+
+  test("maps session.next.tool.failed with a flattened error message", () => {
+    const event = mapOpencodeEvent(envelope("session.next.tool.failed", {
+      timestamp: 3,
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      callID: "call_1",
+      error: { type: "unknown", message: "command not found" },
+      provider: { executed: false },
+    }));
+
+    expect(event).toEqual({
+      type: "tool.completed",
+      sessionId: "ses_1",
+      messageId: "msg_1",
+      callId: "call_1",
+      tool: "",
+      status: "failed",
+      error: "command not found",
+    });
+  });
+
+  test("maps permission.v2.asked", () => {
+    const event = mapOpencodeEvent(envelope("permission.v2.asked", {
+      id: "per_1",
+      sessionID: "ses_1",
+      action: "file.edit",
+      resources: ["/repo/src/index.ts"],
+      save: ["session"],
+      metadata: { reason: "write" },
+      source: { type: "tool", messageID: "msg_1", callID: "call_1" },
+    }));
+
+    expect(event?.type).toBe("permission.asked");
+    if (event?.type !== "permission.asked") throw new Error("unexpected event");
+    expect(event.permission.id).toBe("per_1");
+    expect(event.permission.sessionId).toBe("ses_1");
+    expect(event.permission.kind).toBe("edit");
+    expect(event.permission.resources).toEqual(["/repo/src/index.ts"]);
+    expect(event.permission.remember).toEqual(["session"]);
+    expect(event.permission.metadata).toMatchObject({
+      reason: "write",
+      action: "file.edit",
+      save: "session",
+      tool: { messageID: "msg_1", callID: "call_1" },
+    });
+    expect(typeof event.permission.receivedAt).toBe("number");
+  });
+
+  test("maps permission.v2.replied", () => {
+    expect(mapOpencodeEvent(envelope("permission.v2.replied", {
+      sessionID: "ses_1",
+      requestID: "per_1",
+      reply: "once",
+    }))).toEqual({ type: "permission.replied", sessionId: "ses_1", requestId: "per_1" });
+  });
+
+  test("maps question.v2.asked", () => {
+    const event = mapOpencodeEvent(envelope("question.v2.asked", {
+      id: "qst_1",
+      sessionID: "ses_1",
+      questions: [
+        {
+          question: "Which branch should I target?",
+          header: "Branch",
+          options: [
+            { label: "main", description: "the default branch" },
+            { label: "develop", description: "the integration branch" },
+          ],
+          multiple: false,
+          custom: true,
+        },
+      ],
+      tool: { messageID: "msg_1", callID: "call_1" },
+    }));
+
+    expect(event).toEqual({
+      type: "question.asked",
+      question: {
+        id: "qst_1",
+        sessionId: "ses_1",
+        questions: [
+          {
+            header: "Branch",
+            question: "Which branch should I target?",
+            options: [
+              { label: "main", description: "the default branch" },
+              { label: "develop", description: "the integration branch" },
+            ],
+            multiple: false,
+            custom: true,
+          },
+        ],
+        // receivedAt is wall-clock; asserted separately below.
+        receivedAt: (event as { question: { receivedAt: number } }).question.receivedAt,
+      },
+    });
+    if (event?.type !== "question.asked") throw new Error("unexpected event");
+    expect(typeof event.question.receivedAt).toBe("number");
+  });
+
+  test("maps session.idle", () => {
+    expect(mapOpencodeEvent(envelope("session.idle", { sessionID: "ses_1" })))
+      .toEqual({ type: "session.idle", sessionId: "ses_1" });
+  });
+
+  test("maps session.error, flattening the named v2 error envelope", () => {
+    expect(mapOpencodeEvent(envelope("session.error", {
+      sessionID: "ses_1",
+      error: { name: "ContextOverflowError", data: { message: "context window exceeded" } },
+    }))).toEqual({
+      type: "session.error",
+      sessionId: "ses_1",
+      error: { code: "ContextOverflowError", message: "context window exceeded" },
+    });
+  });
+
+  test("maps message.part.updated, carrying the raw part through", () => {
+    const part = {
+      id: "prt_1",
+      sessionID: "ses_1",
+      messageID: "msg_1",
+      type: "text",
+      text: "hello world",
+    };
+    expect(mapOpencodeEvent(envelope("message.part.updated", { sessionID: "ses_1", part, time: 5 })))
+      .toEqual({
+        type: "message.part",
+        sessionId: "ses_1",
+        messageId: "msg_1",
+        partId: "prt_1",
+        part,
+      });
+  });
+
+  test("maps message.updated to a message upsert", () => {
+    expect(mapOpencodeEvent(envelope("message.updated", {
+      sessionID: "ses_1",
+      info: { id: "msg_1", sessionID: "ses_1", role: "assistant", time: { created: 10, completed: 20 } },
+    }))).toEqual({
+      type: "message.upsert",
+      sessionId: "ses_1",
+      message: { id: "msg_1", role: "assistant", parts: [], createdAt: 10, completedAt: 20 },
+    });
+  });
+
+  test("maps session.status, including the retry variant", () => {
+    expect(mapOpencodeEvent(envelope("session.status", {
+      sessionID: "ses_1",
+      status: { type: "retry", attempt: 2, message: "rate limited", next: 1500 },
+    }))).toEqual({
+      type: "session.status",
+      sessionId: "ses_1",
+      status: { type: "retry", attempt: 2, message: "rate limited", next: 1500 },
+    });
+  });
+
+  test("maps compaction start and end onto a single running flag", () => {
+    expect(mapOpencodeEvent(envelope("session.next.compaction.started", { timestamp: 1, sessionID: "ses_1" })))
+      .toEqual({ type: "session.compaction", sessionId: "ses_1", running: true });
+    expect(mapOpencodeEvent(envelope("session.compacted", { sessionID: "ses_1" })))
+      .toEqual({ type: "session.compaction", sessionId: "ses_1", running: false });
+  });
+
+  test("ignores unknown event types", () => {
+    expect(mapOpencodeEvent(envelope("pty.created", { id: "pty_1" }))).toBeNull();
+    expect(mapOpencodeEvent(envelope("session.next.tool.input.delta", { sessionID: "ses_1" }))).toBeNull();
+    expect(mapOpencodeEvent({ type: "not.a.real.event" })).toBeNull();
+    expect(mapOpencodeEvent(null)).toBeNull();
+    expect(mapOpencodeEvent("session.idle")).toBeNull();
+    expect(mapOpencodeEvent({ data: { sessionID: "ses_1" } })).toBeNull();
+  });
+
+  test("drops events whose required identifiers are missing", () => {
+    expect(mapOpencodeEvent(envelope("session.idle", {}))).toBeNull();
+    expect(mapOpencodeEvent(envelope("session.next.text.delta", {
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      textID: "prt_1",
+      delta: "",
+    }))).toBeNull();
+    expect(mapOpencodeEvent(envelope("message.part.updated", { sessionID: "ses_1", part: { type: "text" } }))).toBeNull();
+  });
+
+  test("propagates durable.seq as a string cursor", () => {
+    expect(mapOpencodeEvent(envelope("session.idle", { sessionID: "ses_1" }, 42)))
+      .toEqual({ type: "session.idle", sessionId: "ses_1", seq: "42" });
+
+    expect(mapOpencodeEvent(envelope("session.next.text.delta", {
+      sessionID: "ses_1",
+      assistantMessageID: "msg_1",
+      textID: "prt_1",
+      delta: "x",
+    }, 0))).toMatchObject({ seq: "0" });
+
+    // No durable block on transient events: no cursor is invented.
+    expect(mapOpencodeEvent(envelope("session.idle", { sessionID: "ses_1" }))).not.toHaveProperty("seq");
+    expect(mapOpencodeEvent({ type: "session.idle", durable: { aggregateID: "a" }, data: { sessionID: "ses_1" } }))
+      .not.toHaveProperty("seq");
+  });
+
+  test("accepts the classic `properties` envelope as well as the v2 `data` envelope", () => {
+    expect(mapOpencodeEvent({ id: "evt", type: "session.idle", properties: { sessionID: "ses_1" } }))
+      .toEqual({ type: "session.idle", sessionId: "ses_1" });
+
+    const legacy = mapOpencodeEvent({
+      id: "evt",
+      type: "permission.asked",
+      properties: {
+        id: "per_1",
+        sessionID: "ses_1",
+        permission: "bash",
+        patterns: ["rm *"],
+        metadata: {},
+        always: ["session"],
+      },
+    });
+    expect(legacy?.type).toBe("permission.asked");
+    if (legacy?.type !== "permission.asked") throw new Error("unexpected event");
+    expect(legacy.permission.kind).toBe("bash");
+    expect(legacy.permission.resources).toEqual(["rm *"]);
+    expect(legacy.permission.remember).toEqual(["session"]);
+  });
+});
+
+describe("describeOpencodeError", () => {
+  test("reads every error envelope shape OpenCode emits", () => {
+    expect(describeOpencodeError({ type: "unknown", message: "boom" })).toEqual({ code: "unknown", message: "boom" });
+    expect(describeOpencodeError({ _tag: "ConflictError", message: "conflict" }))
+      .toEqual({ code: "ConflictError", message: "conflict" });
+    expect(describeOpencodeError({ name: "APIError", data: { message: "429" } }))
+      .toEqual({ code: "APIError", message: "429" });
+    expect(describeOpencodeError("plain")).toEqual({ message: "plain" });
+    expect(describeOpencodeError(undefined).message.length).toBeGreaterThan(0);
+  });
+});
+
+describe("opencodePermissionKind", () => {
+  test("normalizes the v2 action vocabulary", () => {
+    expect(opencodePermissionKind("file.read")).toBe("read");
+    expect(opencodePermissionKind("file.edit")).toBe("edit");
+    expect(opencodePermissionKind("file.write")).toBe("edit");
+    expect(opencodePermissionKind("workspace.external_directory")).toBe("external_directory");
+    expect(opencodePermissionKind("bash")).toBe("bash");
+  });
+});
+
+describe("mapOpencodeSession", () => {
+  test("maps a v2 SessionV2Info", () => {
+    expect(mapOpencodeSession({
+      id: "ses_1",
+      projectID: "prj_1",
+      parentID: "ses_0",
+      cost: 0,
+      tokens: { input: 1, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 1, updated: 2, archived: 3 },
+      title: "Fix the parser",
+      location: { directory: "/repo" },
+    })).toEqual({
+      id: "ses_1",
+      title: "Fix the parser",
+      parentId: "ses_0",
+      directory: "/repo",
+      createdAt: 1,
+      updatedAt: 2,
+      archivedAt: 3,
+    });
+  });
+
+  test("rejects a payload without an id", () => {
+    expect(mapOpencodeSession({ title: "orphan" })).toBeNull();
+    expect(mapOpencodeSession(null)).toBeNull();
+  });
+});
+
+describe("mapOpencodePermission", () => {
+  test("keeps the raw metadata alongside the action", () => {
+    const permission = mapOpencodePermission({
+      id: "per_1",
+      sessionID: "ses_1",
+      action: "file.read",
+      resources: ["/repo/a.ts"],
+    }, 1234);
+    expect(permission).toEqual({
+      id: "per_1",
+      sessionId: "ses_1",
+      kind: "read",
+      resources: ["/repo/a.ts"],
+      remember: [],
+      metadata: { action: "file.read" },
+      receivedAt: 1234,
+    });
+  });
+});
+
+describe("buildOpencodePromptInput", () => {
+  test("splits engine prompt parts into text, files and agents", () => {
+    expect(buildOpencodePromptInput([
+      { type: "text", text: "first" },
+      { type: "file", mime: "text/plain", url: "file:///repo/a.txt", filename: "a.txt" },
+      { type: "agent", name: "reviewer" },
+      { type: "text", text: "second" },
+      { type: "file", mime: "image/png", url: "file:///repo/b.png" },
+    ])).toEqual({
+      text: "first\n\nsecond",
+      files: [{ uri: "file:///repo/a.txt", name: "a.txt" }, { uri: "file:///repo/b.png" }],
+      agents: [{ name: "reviewer" }],
+    });
+  });
+
+  test("omits empty collections and empty text parts", () => {
+    expect(buildOpencodePromptInput([{ type: "text", text: "" }, { type: "text", text: "only" }]))
+      .toEqual({ text: "only" });
+    expect(buildOpencodePromptInput([])).toEqual({ text: "" });
+  });
+});
+
+describe("createOpencodeEngineAdapter", () => {
+  function stubClient() {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const ok = (method: string, data: unknown) => (params: unknown) => {
+      calls.push({ method, params });
+      return Promise.resolve({ data, error: undefined, response: new Response(null) });
+    };
+    const client = {
+      session: {
+        delete: ok("session.delete", true),
+        update: ok("session.update", { id: "ses_1", title: "renamed" }),
+      },
+      v2: {
+        session: {
+          create: ok("v2.session.create", { data: { id: "ses_1", title: "", time: { created: 1, updated: 1 } } }),
+          get: ok("v2.session.get", { data: { id: "ses_1", title: "T", time: { created: 1, updated: 2 } } }),
+          prompt: ok("v2.session.prompt", { data: { id: "inp_1", sessionID: "ses_1" } }),
+          switchAgent: ok("v2.session.switchAgent", undefined),
+          switchModel: ok("v2.session.switchModel", undefined),
+          interrupt: ok("v2.session.interrupt", undefined),
+          wait: ok("v2.session.wait", undefined),
+          permission: {
+            list: ok("v2.session.permission.list", {
+              data: [{ id: "per_1", sessionID: "ses_1", action: "file.read", resources: ["/a"] }],
+            }),
+            reply: ok("v2.session.permission.reply", undefined),
+          },
+          question: {
+            list: ok("v2.session.question.list", {
+              data: [{ id: "qst_1", sessionID: "ses_1", questions: [{ question: "q?", header: "h", options: [] }] }],
+            }),
+            reply: ok("v2.session.question.reply", undefined),
+          },
+          events: (params: unknown) => {
+            calls.push({ method: "v2.session.events", params });
+            return Promise.resolve({
+              stream: (async function* () {
+                yield envelope("session.next.tool.called", {
+                  timestamp: 1,
+                  sessionID: "ses_1",
+                  assistantMessageID: "msg_1",
+                  callID: "call_1",
+                  tool: "bash",
+                  input: {},
+                }, 1);
+                yield envelope("pty.created", { id: "pty_1" }, 2);
+                yield envelope("session.next.tool.success", {
+                  timestamp: 2,
+                  sessionID: "ses_1",
+                  assistantMessageID: "msg_1",
+                  callID: "call_1",
+                  structured: {},
+                  content: [],
+                }, 3);
+                yield envelope("session.idle", { sessionID: "ses_1" }, 4);
+              })(),
+            });
+          },
+        },
+      },
+    };
+    return { client, calls };
+  }
+
+  function connect(stub: ReturnType<typeof stubClient>) {
+    const adapter = createOpencodeEngineAdapter({
+      createClient: () => stub.client as never,
+      unwrap: ((result: { data?: unknown; error?: unknown }) => {
+        if (result.error !== undefined) throw new Error("opencode_request_failed");
+        return result.data;
+      }) as never,
+    });
+    expect(adapter.id).toBe("opencode");
+    return adapter.connect({ id: "ws_1" });
+  }
+
+  test("advertises the full OpenCode capability set", () => {
+    const connection = connect(stubClient());
+    expect(connection.engineId).toBe("opencode");
+    expect(connection.capabilities).toEqual(OPENCODE_ENGINE_CAPABILITIES);
+    expect(OPENCODE_ENGINE_CAPABILITIES).toEqual({
+      streaming: true,
+      resumableStreaming: true,
+      permissions: true,
+      questions: true,
+      interrupt: true,
+      wait: true,
+      promptOptions: { system: false, reasoningEffort: false, variant: true },
+    });
+  });
+
+  test("names a new session through the classic update endpoint", async () => {
+    const stub = stubClient();
+    const session = await connect(stub).createSession({ title: "renamed", agent: "build" });
+    expect(session).toMatchObject({ id: "ses_1", title: "renamed" });
+    expect(stub.calls.map((call) => call.method)).toEqual(["v2.session.create", "session.update"]);
+    expect(stub.calls[1]?.params).toEqual({ sessionID: "ses_1", title: "renamed" });
+  });
+
+  test("switches agent and model before sending the prompt and returns the admitted id", async () => {
+    const stub = stubClient();
+    const result = await connect(stub).prompt({
+      sessionId: "ses_1",
+      parts: [{ type: "text", text: "hi" }],
+      agent: "plan",
+      model: { providerID: "anthropic", modelID: "claude-opus-5" },
+      variant: "thinking",
+      delivery: "queue",
+    });
+
+    expect(result).toEqual({ messageId: "inp_1" });
+    expect(stub.calls.map((call) => call.method))
+      .toEqual(["v2.session.switchAgent", "v2.session.switchModel", "v2.session.prompt"]);
+    expect(stub.calls[1]?.params).toEqual({
+      sessionID: "ses_1",
+      model: { id: "claude-opus-5", providerID: "anthropic", variant: "thinking" },
+    });
+    expect(stub.calls[2]?.params).toEqual({
+      sessionID: "ses_1",
+      prompt: { text: "hi" },
+      delivery: "queue",
+    });
+  });
+
+  test("maps pending permissions and questions", async () => {
+    const connection = connect(stubClient());
+    const permissions = await connection.listPermissions("ses_1");
+    expect(permissions).toHaveLength(1);
+    expect(permissions[0]).toMatchObject({ id: "per_1", kind: "read", resources: ["/a"] });
+
+    const questions = await connection.listQuestions("ses_1");
+    expect(questions).toHaveLength(1);
+    expect(questions[0]?.questions[0]).toMatchObject({ question: "q?", header: "h", options: [] });
+  });
+
+  test("sends question answers in the v2 body shape", async () => {
+    const stub = stubClient();
+    await connect(stub).replyQuestion({ sessionId: "ses_1", questionId: "qst_1", answers: [["main"]] });
+    expect(stub.calls[0]).toEqual({
+      method: "v2.session.question.reply",
+      params: { sessionID: "ses_1", requestID: "qst_1", questionV2Reply: { answers: [["main"]] } },
+    });
+  });
+
+  test("subscribes with the resume cursor and restores the tool name on completion", async () => {
+    const stub = stubClient();
+    const controller = new AbortController();
+    const events: Array<{ type: string; seq?: string; tool?: string }> = [];
+
+    await connect(stub).subscribe({
+      sessionId: "ses_1",
+      after: "7",
+      signal: controller.signal,
+      onEvent: (event) => {
+        events.push({
+          type: event.type,
+          seq: event.seq,
+          ...("tool" in event ? { tool: event.tool } : {}),
+        });
+      },
+    });
+
+    expect(stub.calls[0]?.params).toEqual({ sessionID: "ses_1", after: "7" });
+    expect(events).toEqual([
+      { type: "tool.called", seq: "1", tool: "bash" },
+      { type: "tool.completed", seq: "3", tool: "bash" },
+      { type: "session.idle", seq: "4" },
+    ]);
+  });
+
+  test("stops delivering events once the signal aborts", async () => {
+    const stub = stubClient();
+    const controller = new AbortController();
+    const seen: string[] = [];
+
+    await connect(stub).subscribe({
+      sessionId: "ses_1",
+      signal: controller.signal,
+      onEvent: (event) => {
+        seen.push(event.type);
+        controller.abort();
+      },
+    });
+
+    expect(seen).toEqual(["tool.called"]);
+  });
+
+  test("surfaces a 204 interrupt as success", async () => {
+    const stub = stubClient();
+    expect(await connect(stub).interrupt("ses_1")).toBe(true);
+    expect(stub.calls[0]?.method).toBe("v2.session.interrupt");
+  });
+
+  test("wraps SDK failures through the injected unwrap", async () => {
+    const stub = stubClient();
+    stub.client.v2.session.get = (() =>
+      Promise.resolve({ data: undefined, error: { message: "nope" }, response: new Response(null) })) as never;
+    await expect(connect(stub).getSession("ses_1")).rejects.toThrow("opencode_request_failed");
+  });
+});

--- a/apps/server/src/api/engine/opencode.ts
+++ b/apps/server/src/api/engine/opencode.ts
@@ -1,0 +1,644 @@
+/**
+ * OpenCode engine adapter.
+ *
+ * Maps the OpenCode **v2** SDK surface onto the server-side `EngineConnection`
+ * contract in `./types.ts`. Everything session-scoped goes through
+ * `client.v2.session.*`; the two operations v2 does not expose (permanent delete and
+ * title update) fall back to the classic `client.session.*` endpoints.
+ *
+ * The event translation lives in the pure `mapOpencodeEvent` below so it can be tested
+ * without a live OpenCode process, mirroring how the browser adapter splits
+ * `opencode-conversation-engine.ts` from `opencode-conversation-mapper.ts`.
+ */
+
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { DEFAULT_ENGINE_ID } from "@ipollowork/types/workspace";
+
+import type { WorkspaceInfo } from "../../types.js";
+import type {
+  EngineAdapter,
+  EngineCapabilities,
+  EngineConnection,
+  EngineEvent,
+  EngineMessage,
+  EngineMessagePart,
+  EnginePermission,
+  EnginePromptInput,
+  EngineQuestion,
+  EngineQuestionInfo,
+  EngineSession,
+  EngineSessionStatus,
+  EngineSubscribeInput,
+} from "./types.js";
+
+export type OpencodeEngineClient = ReturnType<typeof createOpencodeClient>;
+
+type OpencodeClientResult<T, E> =
+  | { data: T | undefined; error: undefined; response: Response }
+  | { data: undefined; error: E; response: Response };
+
+export type UnwrapOpencodeResult = <T, E>(result: OpencodeClientResult<T, E>, path: string) => NonNullable<T>;
+
+export interface OpencodeEngineAdapterDeps {
+  /** Per-workspace client factory. The server injects `createWorkspaceOpencodeClient`. */
+  createClient: (workspace: WorkspaceInfo) => OpencodeEngineClient;
+  /** The server's `unwrapOpencodeResult`, which turns SDK failures into `ApiError`. */
+  unwrap: UnwrapOpencodeResult;
+}
+
+export const OPENCODE_ENGINE_CAPABILITIES: EngineCapabilities = {
+  streaming: true,
+  resumableStreaming: true,
+  permissions: true,
+  questions: true,
+  interrupt: true,
+  wait: true,
+  // `client.v2.session.prompt` takes only `{sessionID, id?, prompt, delivery?, resume?}`,
+  // and `PromptInput` is `{text, files?, agents?}` — there is nowhere to put a per-turn
+  // system prompt or a reasoning-effort hint. The classic `session.promptAsync` accepts
+  // both, but using it would give up the durable event cursor that makes `?after=`
+  // resumption work, which is the more valuable property for a public API.
+  // `variant` survives because it rides along on `switchModel`.
+  promptOptions: { system: false, reasoningEffort: false, variant: true },
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+/** The v2 envelope carries `data`; the classic envelope carries `properties`. */
+function readEventPayload(event: Record<string, unknown>): Record<string, unknown> {
+  if (isRecord(event.data)) return event.data;
+  if (isRecord(event.properties)) return event.properties;
+  return {};
+}
+
+function readDurableSeq(event: Record<string, unknown>): string | undefined {
+  const durable = isRecord(event.durable) ? event.durable : undefined;
+  if (!durable) return undefined;
+  const seq = readNumber(durable.seq);
+  return seq === undefined ? undefined : String(seq);
+}
+
+/**
+ * Flattens the several error envelopes OpenCode uses: the v2 named error
+ * (`{name, data:{message}}`), the effect-tagged error (`{_tag, message}`) and the
+ * inline session error (`{type:"unknown", message}`).
+ */
+export function describeOpencodeError(value: unknown): { code?: string; message: string } {
+  if (typeof value === "string" && value.length > 0) return { message: value };
+  if (!isRecord(value)) return { message: "OpenCode reported an unknown error" };
+
+  const code = readString(value.name) ?? readString(value._tag) ?? readString(value.type);
+  const inner = isRecord(value.data) ? value.data : undefined;
+  const message = readString(value.message)
+    ?? readString(inner?.message)
+    ?? code
+    ?? "OpenCode reported an unknown error";
+  return code ? { code, message } : { message };
+}
+
+/** Normalizes a v2 permission action into the browser adapter's permission kinds. */
+export function opencodePermissionKind(action: string): string {
+  if (action === "external_directory" || action.endsWith(".external_directory")) return "external_directory";
+  if (action === "file.read") return "read";
+  if (action === "file.edit" || action === "file.write") return "edit";
+  return action;
+}
+
+function mapSessionStatus(value: unknown): EngineSessionStatus {
+  if (!isRecord(value)) return { type: "idle" };
+  if (value.type === "retry") {
+    return {
+      type: "retry",
+      attempt: readNumber(value.attempt) ?? 0,
+      message: readString(value.message) ?? "",
+      next: readNumber(value.next) ?? 0,
+    };
+  }
+  return value.type === "idle" ? { type: "idle" } : { type: "busy" };
+}
+
+/** Maps either `SessionV2Info` (v2) or the classic `Session` onto `EngineSession`. */
+export function mapOpencodeSession(value: unknown): EngineSession | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value.id);
+  if (!id) return null;
+  const time = isRecord(value.time) ? value.time : undefined;
+  const location = isRecord(value.location) ? value.location : undefined;
+  return {
+    id,
+    title: typeof value.title === "string" ? value.title : "",
+    parentId: readString(value.parentID) ?? null,
+    directory: readString(value.directory) ?? readString(location?.directory) ?? null,
+    createdAt: readNumber(time?.created) ?? null,
+    updatedAt: readNumber(time?.updated) ?? null,
+    archivedAt: readNumber(time?.archived) ?? null,
+  };
+}
+
+/** Maps a v2 `PermissionV2Request` or a classic `PermissionRequest`. */
+export function mapOpencodePermission(value: unknown, receivedAt: number): EnginePermission | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value.id);
+  const sessionId = readString(value.sessionID);
+  if (!id || !sessionId) return null;
+
+  const action = readString(value.action);
+  if (action !== undefined) {
+    const metadata: Record<string, unknown> = { ...(isRecord(value.metadata) ? value.metadata : {}), action };
+    const save = readStringArray(value.save);
+    if (save.length > 0) metadata.save = save.join(", ");
+    if (isRecord(value.source)) {
+      metadata.tool = { messageID: value.source.messageID, callID: value.source.callID };
+    }
+    return {
+      id,
+      sessionId,
+      kind: opencodePermissionKind(action),
+      resources: readStringArray(value.resources),
+      remember: save,
+      metadata,
+      receivedAt,
+    };
+  }
+
+  return {
+    id,
+    sessionId,
+    kind: readString(value.permission) ?? "unknown",
+    resources: readStringArray(value.patterns),
+    remember: readStringArray(value.always),
+    metadata: isRecord(value.metadata) ? value.metadata : {},
+    receivedAt,
+  };
+}
+
+/** Maps a v2 `QuestionV2Request` or a classic `QuestionRequest`. */
+export function mapOpencodeQuestion(value: unknown, receivedAt: number): EngineQuestion | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value.id);
+  const sessionId = readString(value.sessionID);
+  if (!id || !sessionId || !Array.isArray(value.questions)) return null;
+
+  const questions: EngineQuestionInfo[] = [];
+  for (const entry of value.questions) {
+    if (!isRecord(entry)) continue;
+    const question = typeof entry.question === "string" ? entry.question : "";
+    const options = Array.isArray(entry.options)
+      ? entry.options
+        .filter(isRecord)
+        .map((option) => ({
+          label: typeof option.label === "string" ? option.label : "",
+          ...(readString(option.description) ? { description: option.description as string } : {}),
+        }))
+      : [];
+    questions.push({
+      ...(readString(entry.header) ? { header: entry.header as string } : {}),
+      question,
+      options,
+      ...(typeof entry.multiple === "boolean" ? { multiple: entry.multiple } : {}),
+      ...(typeof entry.custom === "boolean" ? { custom: entry.custom } : {}),
+    });
+  }
+
+  return { id, sessionId, questions, receivedAt };
+}
+
+function mapMessageInfo(value: unknown): EngineMessage | null {
+  if (!isRecord(value)) return null;
+  const id = readString(value.id);
+  const role = value.role;
+  if (!id || (role !== "user" && role !== "assistant" && role !== "system")) return null;
+  const time = isRecord(value.time) ? value.time : undefined;
+  return {
+    id,
+    role,
+    parts: [],
+    createdAt: readNumber(time?.created) ?? null,
+    completedAt: readNumber(time?.completed) ?? null,
+  };
+}
+
+/**
+ * Translates one OpenCode event envelope into the normalized engine event.
+ *
+ * Returns `null` for every event the public API does not model, which is most of the
+ * OpenCode stream (pty, lsp, tui, installation, workspace, ...). The function is pure:
+ * `subscribe` layers the call-id → tool-name memory on top of it, because
+ * `session.next.tool.success` / `.failed` do not repeat the tool name.
+ */
+export function mapOpencodeEvent(event: unknown): EngineEvent | null {
+  if (!isRecord(event)) return null;
+  const type = readString(event.type);
+  if (!type) return null;
+
+  const data = readEventPayload(event);
+  const seq = readDurableSeq(event);
+  const emit = (value: EngineEvent): EngineEvent => (seq === undefined ? value : { ...value, seq });
+
+  const sessionId = readString(data.sessionID);
+
+  switch (type) {
+    case "session.created":
+    case "session.updated": {
+      const session = mapOpencodeSession(data.info);
+      if (!session) return null;
+      return emit({ type: "session.updated", sessionId: sessionId ?? session.id, session });
+    }
+
+    case "session.deleted": {
+      const id = sessionId ?? mapOpencodeSession(data.info)?.id;
+      return id ? emit({ type: "session.deleted", sessionId: id }) : null;
+    }
+
+    case "session.error":
+    case "session.next.step.failed": {
+      if (!sessionId) return null;
+      return emit({ type: "session.error", sessionId, error: describeOpencodeError(data.error) });
+    }
+
+    case "session.status": {
+      if (!sessionId) return null;
+      return emit({ type: "session.status", sessionId, status: mapSessionStatus(data.status) });
+    }
+
+    case "session.idle": {
+      return sessionId ? emit({ type: "session.idle", sessionId }) : null;
+    }
+
+    case "session.next.compaction.started": {
+      return sessionId ? emit({ type: "session.compaction", sessionId, running: true }) : null;
+    }
+
+    case "session.next.compaction.ended":
+    case "session.compacted": {
+      return sessionId ? emit({ type: "session.compaction", sessionId, running: false }) : null;
+    }
+
+    case "todo.updated": {
+      if (!sessionId || !Array.isArray(data.todos)) return null;
+      return emit({ type: "todo.updated", sessionId, todos: data.todos });
+    }
+
+    case "permission.asked":
+    case "permission.v2.asked": {
+      const permission = mapOpencodePermission(data, Date.now());
+      return permission ? emit({ type: "permission.asked", permission }) : null;
+    }
+
+    case "permission.replied":
+    case "permission.v2.replied": {
+      const requestId = readString(data.requestID);
+      if (!sessionId || !requestId) return null;
+      return emit({ type: "permission.replied", sessionId, requestId });
+    }
+
+    case "question.asked":
+    case "question.v2.asked": {
+      const question = mapOpencodeQuestion(data, Date.now());
+      return question ? emit({ type: "question.asked", question }) : null;
+    }
+
+    case "question.replied":
+    case "question.rejected":
+    case "question.v2.replied":
+    case "question.v2.rejected": {
+      const requestId = readString(data.requestID);
+      if (!sessionId || !requestId) return null;
+      return emit({ type: "question.replied", sessionId, requestId });
+    }
+
+    case "message.updated": {
+      const message = mapMessageInfo(data.info);
+      if (!message) return null;
+      const id = sessionId ?? readString(isRecord(data.info) ? data.info.sessionID : undefined);
+      return id ? emit({ type: "message.upsert", sessionId: id, message }) : null;
+    }
+
+    case "message.removed": {
+      const messageId = readString(data.messageID);
+      if (!sessionId || !messageId) return null;
+      return emit({ type: "message.removed", sessionId, messageId });
+    }
+
+    case "message.part.updated": {
+      const part = isRecord(data.part) ? data.part : undefined;
+      const partId = readString(part?.id);
+      const messageId = readString(part?.messageID);
+      const id = sessionId ?? readString(part?.sessionID);
+      if (!part || !partId || !messageId || !id) return null;
+      return emit({
+        type: "message.part",
+        sessionId: id,
+        messageId,
+        partId,
+        part: part as EngineMessagePart,
+      });
+    }
+
+    case "message.part.delta": {
+      const messageId = readString(data.messageID);
+      const partId = readString(data.partID);
+      const delta = readString(data.delta);
+      if (!sessionId || !messageId || !partId || !delta) return null;
+      return emit({
+        type: "message.delta",
+        sessionId,
+        messageId,
+        partId,
+        kind: data.field === "reasoning" ? "reasoning" : "text",
+        delta,
+      });
+    }
+
+    case "session.next.text.delta": {
+      const messageId = readString(data.assistantMessageID);
+      const partId = readString(data.textID);
+      const delta = readString(data.delta);
+      if (!sessionId || !messageId || !partId || !delta) return null;
+      return emit({ type: "message.delta", sessionId, messageId, partId, kind: "text", delta });
+    }
+
+    case "session.next.reasoning.delta": {
+      const messageId = readString(data.assistantMessageID);
+      const partId = readString(data.reasoningID);
+      const delta = readString(data.delta);
+      if (!sessionId || !messageId || !partId || !delta) return null;
+      return emit({ type: "message.delta", sessionId, messageId, partId, kind: "reasoning", delta });
+    }
+
+    case "session.next.tool.called": {
+      const messageId = readString(data.assistantMessageID);
+      const callId = readString(data.callID);
+      const tool = readString(data.tool);
+      if (!sessionId || !messageId || !callId || !tool) return null;
+      return emit({ type: "tool.called", sessionId, messageId, callId, tool, input: data.input });
+    }
+
+    case "session.next.tool.success": {
+      const messageId = readString(data.assistantMessageID);
+      const callId = readString(data.callID);
+      if (!sessionId || !messageId || !callId) return null;
+      return emit({
+        type: "tool.completed",
+        sessionId,
+        messageId,
+        callId,
+        // `session.next.tool.success` omits the tool name; `subscribe` fills it in
+        // from the matching `session.next.tool.called`.
+        tool: readString(data.tool) ?? "",
+        status: "success",
+        output: data.result !== undefined ? data.result : data.structured,
+      });
+    }
+
+    case "session.next.tool.failed": {
+      const messageId = readString(data.assistantMessageID);
+      const callId = readString(data.callID);
+      if (!sessionId || !messageId || !callId) return null;
+      return emit({
+        type: "tool.completed",
+        sessionId,
+        messageId,
+        callId,
+        tool: readString(data.tool) ?? "",
+        status: "failed",
+        error: describeOpencodeError(data.error).message,
+      });
+    }
+
+    default:
+      return null;
+  }
+}
+
+/** Builds the v2 `PromptInput` body from the engine-neutral prompt parts. */
+export function buildOpencodePromptInput(parts: EnginePromptInput["parts"]) {
+  const texts: string[] = [];
+  const files: Array<{ uri: string; name?: string }> = [];
+  const agents: Array<{ name: string }> = [];
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text.length > 0) texts.push(part.text);
+      continue;
+    }
+    if (part.type === "file") {
+      files.push({ uri: part.url, ...(part.filename ? { name: part.filename } : {}) });
+      continue;
+    }
+    if (part.type === "agent") agents.push({ name: part.name });
+  }
+
+  return {
+    text: texts.join("\n\n"),
+    ...(files.length > 0 ? { files } : {}),
+    ...(agents.length > 0 ? { agents } : {}),
+  };
+}
+
+function sessionPath(sessionId: string): string {
+  return `/session/${encodeURIComponent(sessionId)}`;
+}
+
+function createOpencodeEngineConnection(
+  deps: OpencodeEngineAdapterDeps,
+  workspace: WorkspaceInfo,
+): EngineConnection {
+  const client = deps.createClient(workspace);
+  const unwrap = deps.unwrap;
+
+  /** Throws through `unwrap` when the SDK reported a failure; tolerates 204 bodies. */
+  const ensureOk = <T, E>(result: OpencodeClientResult<T, E>, path: string): void => {
+    if (result.error !== undefined) unwrap(result, path);
+  };
+
+  const readSession = async (sessionId: string): Promise<EngineSession> => {
+    const body = unwrap(await client.v2.session.get({ sessionID: sessionId }), sessionPath(sessionId));
+    const session = mapOpencodeSession(body.data);
+    if (!session) throw new Error(`OpenCode returned an invalid session: ${sessionId}`);
+    return session;
+  };
+
+  return {
+    engineId: DEFAULT_ENGINE_ID,
+    capabilities: OPENCODE_ENGINE_CAPABILITIES,
+
+    async createSession(input) {
+      const body = unwrap(
+        await client.v2.session.create({
+          ...(input.agent ? { agent: input.agent } : {}),
+          ...(input.model ? { model: { id: input.model.modelID, providerID: input.model.providerID } } : {}),
+        }),
+        "/session",
+      );
+      const session = mapOpencodeSession(body.data);
+      if (!session) throw new Error("OpenCode returned an invalid session");
+      if (!input.title) return session;
+      // v2 has no title field on create or on the session resource, so the classic
+      // `session.update` endpoint is the only way to name a session.
+      await this.renameSession(session.id, input.title);
+      return { ...session, title: input.title };
+    },
+
+    getSession: readSession,
+
+    async deleteSession(sessionId) {
+      // `client.v2.session` exposes no delete; `Session2.delete` is the only one.
+      ensureOk(await client.session.delete({ sessionID: sessionId }), sessionPath(sessionId));
+    },
+
+    async renameSession(sessionId, title) {
+      // `client.v2.session` exposes no update; `Session2.update` carries `title`.
+      ensureOk(await client.session.update({ sessionID: sessionId, title }), sessionPath(sessionId));
+    },
+
+    async prompt(input) {
+      const path = `${sessionPath(input.sessionId)}/prompt`;
+      if (input.agent) {
+        ensureOk(
+          await client.v2.session.switchAgent({ sessionID: input.sessionId, agent: input.agent }),
+          `${sessionPath(input.sessionId)}/agent`,
+        );
+      }
+      if (input.model) {
+        ensureOk(
+          await client.v2.session.switchModel({
+            sessionID: input.sessionId,
+            model: {
+              id: input.model.modelID,
+              providerID: input.model.providerID,
+              ...(input.variant ? { variant: input.variant } : {}),
+            },
+          }),
+          `${sessionPath(input.sessionId)}/model`,
+        );
+      }
+
+      const body = unwrap(
+        await client.v2.session.prompt({
+          sessionID: input.sessionId,
+          prompt: buildOpencodePromptInput(input.parts),
+          ...(input.delivery ? { delivery: input.delivery } : {}),
+        }),
+        path,
+      );
+      const messageId = readString(isRecord(body.data) ? body.data.id : undefined);
+      return messageId ? { messageId } : {};
+    },
+
+    async interrupt(sessionId) {
+      // 204 No Content: there is no body to unwrap, only an error to surface.
+      ensureOk(await client.v2.session.interrupt({ sessionID: sessionId }), `${sessionPath(sessionId)}/interrupt`);
+      return true;
+    },
+
+    async wait(sessionId, signal) {
+      ensureOk(
+        await client.v2.session.wait({ sessionID: sessionId }, signal ? { signal } : {}),
+        `${sessionPath(sessionId)}/wait`,
+      );
+    },
+
+    async listPermissions(sessionId) {
+      const body = unwrap(
+        await client.v2.session.permission.list({ sessionID: sessionId }),
+        `${sessionPath(sessionId)}/permission`,
+      );
+      const receivedAt = Date.now();
+      return (Array.isArray(body.data) ? body.data : [])
+        .map((permission) => mapOpencodePermission(permission, receivedAt))
+        .filter((permission): permission is EnginePermission => permission !== null);
+    },
+
+    async replyPermission(input) {
+      ensureOk(
+        await client.v2.session.permission.reply({
+          sessionID: input.sessionId,
+          requestID: input.permissionId,
+          reply: input.reply,
+        }),
+        `${sessionPath(input.sessionId)}/permission/${encodeURIComponent(input.permissionId)}`,
+      );
+    },
+
+    async listQuestions(sessionId) {
+      const body = unwrap(
+        await client.v2.session.question.list({ sessionID: sessionId }),
+        `${sessionPath(sessionId)}/question`,
+      );
+      const receivedAt = Date.now();
+      return (Array.isArray(body.data) ? body.data : [])
+        .map((question) => mapOpencodeQuestion(question, receivedAt))
+        .filter((question): question is EngineQuestion => question !== null);
+    },
+
+    async replyQuestion(input) {
+      ensureOk(
+        await client.v2.session.question.reply({
+          sessionID: input.sessionId,
+          requestID: input.questionId,
+          questionV2Reply: { answers: input.answers },
+        }),
+        `${sessionPath(input.sessionId)}/question/${encodeURIComponent(input.questionId)}`,
+      );
+    },
+
+    async subscribe(input: EngineSubscribeInput) {
+      // `events` returns `{ stream }` (see `core/serverSentEvents.gen.d.ts`), an async
+      // generator yielding the already-parsed `data:` payload of each SSE frame.
+      const subscription = await client.v2.session.events(
+        { sessionID: input.sessionId, ...(input.after ? { after: input.after } : {}) },
+        { signal: input.signal },
+      );
+
+      // `session.next.tool.success` / `.failed` omit the tool name, so remember it
+      // from the matching `.called` event and restore it on completion.
+      const toolNames = new Map<string, string>();
+
+      try {
+        for await (const raw of subscription.stream) {
+          if (input.signal.aborted) return;
+          const event = mapOpencodeEvent(raw as unknown);
+          if (!event) continue;
+          if (event.type === "tool.called") {
+            toolNames.set(event.callId, event.tool);
+          } else if (event.type === "tool.completed") {
+            if (!event.tool) {
+              const remembered = toolNames.get(event.callId);
+              if (remembered) event.tool = remembered;
+            }
+            toolNames.delete(event.callId);
+          }
+          input.onEvent(event);
+        }
+      } catch (error) {
+        if (input.signal.aborted) return;
+        throw error;
+      }
+    },
+  };
+}
+
+export function createOpencodeEngineAdapter(deps: OpencodeEngineAdapterDeps): EngineAdapter {
+  return {
+    id: DEFAULT_ENGINE_ID,
+    connect(workspace: unknown): EngineConnection {
+      return createOpencodeEngineConnection(deps, workspace as WorkspaceInfo);
+    },
+  };
+}

--- a/apps/server/src/api/engine/types.ts
+++ b/apps/server/src/api/engine/types.ts
@@ -1,0 +1,316 @@
+import { ApiError } from "../../errors.js";
+
+/**
+ * Server-side conversation engine abstraction.
+ *
+ * iPolloWork already unifies its engines behind a `ConversationEngineAdapter` in the
+ * browser (`apps/app/src/react-app/domains/session/engine/conversation-engine.ts`).
+ * That abstraction is what lets the UI drive OpenCode and DeepSeek Harness through one
+ * set of calls. The public API needs the same thing on the server, so this module
+ * mirrors that contract — same event names, same permission and question vocabulary —
+ * rather than inventing a second, competing one.
+ *
+ * The engine-specific mapping lives in `opencode.ts` and `harness.ts`.
+ */
+
+export type EngineSessionStatus =
+  | { type: "idle" }
+  | { type: "busy" }
+  | { type: "retry"; attempt: number; message: string; next: number };
+
+export interface EngineSession {
+  id: string;
+  title: string;
+  parentId?: string | null;
+  directory?: string | null;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+  archivedAt?: number | null;
+}
+
+export interface EnginePermission {
+  id: string;
+  sessionId: string;
+  /** Engine-specific permission kind, e.g. a tool name or an action id. */
+  kind: string;
+  resources: string[];
+  /** Scopes the caller may persist an answer for. */
+  remember: string[];
+  metadata: Record<string, unknown>;
+  receivedAt: number;
+}
+
+export type EnginePermissionReply = "once" | "always" | "reject";
+
+export interface EngineQuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface EngineQuestionInfo {
+  header?: string;
+  question: string;
+  options: EngineQuestionOption[];
+  multiple?: boolean;
+  custom?: boolean;
+}
+
+export interface EngineQuestion {
+  id: string;
+  sessionId: string;
+  questions: EngineQuestionInfo[];
+  receivedAt: number;
+}
+
+export type EnginePromptPart =
+  | { type: "text"; text: string }
+  | { type: "file"; mime: string; url: string; filename?: string }
+  | { type: "agent"; name: string };
+
+export interface EngineModelRef {
+  providerID: string;
+  modelID: string;
+}
+
+export interface EnginePromptInput {
+  sessionId: string;
+  parts: EnginePromptPart[];
+  model?: EngineModelRef;
+  /** Agent / mode identifier. */
+  agent?: string;
+  system?: string;
+  reasoningEffort?: string;
+  variant?: string;
+  /** OpenCode v2 delivery semantics: steer an in-flight turn or queue after it. */
+  delivery?: "steer" | "queue";
+}
+
+export interface EngineMessagePart {
+  id?: string;
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface EngineMessage {
+  id: string;
+  role: "user" | "assistant" | "system";
+  parts: EngineMessagePart[];
+  createdAt?: number | null;
+  completedAt?: number | null;
+}
+
+/**
+ * Normalized event stream.
+ *
+ * Names follow the browser `ConversationEvent` union so a client that already speaks
+ * iPolloWork's UI vocabulary needs no translation table. `seq` carries the engine's
+ * durable cursor where one exists (OpenCode v2 exposes `durable.seq`), which is what
+ * makes `?after=` resumption possible.
+ */
+export type EngineEvent =
+  | { type: "session.updated"; sessionId: string; session: EngineSession; seq?: string }
+  | { type: "session.deleted"; sessionId: string; seq?: string }
+  | { type: "session.error"; sessionId: string; error: { code?: string; message: string }; seq?: string }
+  | { type: "session.status"; sessionId: string; status: EngineSessionStatus; seq?: string }
+  | { type: "session.idle"; sessionId: string; seq?: string }
+  | { type: "session.compaction"; sessionId: string; running: boolean; seq?: string }
+  | { type: "todo.updated"; sessionId: string; todos: unknown[]; seq?: string }
+  | { type: "permission.asked"; permission: EnginePermission; seq?: string }
+  | { type: "permission.replied"; sessionId: string; requestId: string; seq?: string }
+  | { type: "question.asked"; question: EngineQuestion; seq?: string }
+  | { type: "question.replied"; sessionId: string; requestId: string; seq?: string }
+  | { type: "message.upsert"; sessionId: string; message: EngineMessage; seq?: string }
+  | { type: "message.completed"; sessionId: string; messageId: string; completedAt: number; seq?: string }
+  | { type: "message.removed"; sessionId: string; messageId: string; seq?: string }
+  | {
+      type: "message.part";
+      sessionId: string;
+      messageId: string;
+      partId: string;
+      part: EngineMessagePart;
+      seq?: string;
+    }
+  | {
+      type: "message.delta";
+      sessionId: string;
+      messageId: string;
+      partId: string;
+      kind: "text" | "reasoning";
+      delta: string;
+      seq?: string;
+    }
+  | {
+      type: "tool.called";
+      sessionId: string;
+      messageId: string;
+      callId: string;
+      tool: string;
+      input?: unknown;
+      seq?: string;
+    }
+  | {
+      type: "tool.completed";
+      sessionId: string;
+      messageId: string;
+      callId: string;
+      tool: string;
+      status: "success" | "failed";
+      output?: unknown;
+      error?: string;
+      seq?: string;
+    };
+
+export type EngineEventType = EngineEvent["type"];
+
+export const ENGINE_EVENT_TYPES: readonly EngineEventType[] = [
+  "session.updated",
+  "session.deleted",
+  "session.error",
+  "session.status",
+  "session.idle",
+  "session.compaction",
+  "todo.updated",
+  "permission.asked",
+  "permission.replied",
+  "question.asked",
+  "question.replied",
+  "message.upsert",
+  "message.completed",
+  "message.removed",
+  "message.part",
+  "message.delta",
+  "tool.called",
+  "tool.completed",
+] as const;
+
+export interface EngineSubscribeInput {
+  sessionId: string;
+  /** Durable cursor to resume from, as previously reported in `EngineEvent.seq`. */
+  after?: string;
+  signal: AbortSignal;
+  onEvent: (event: EngineEvent) => void;
+}
+
+/**
+ * What every engine must be able to do for the public API.
+ *
+ * Capability gaps are reported through `capabilities` rather than by throwing from a
+ * missing method, so a caller can discover what an engine supports before trying it.
+ */
+export interface EngineCapabilities {
+  /** Streaming session events are available. */
+  streaming: boolean;
+  /** `after` resumption is honoured by `subscribe`. */
+  resumableStreaming: boolean;
+  permissions: boolean;
+  questions: boolean;
+  interrupt: boolean;
+  /** A blocking "run until idle" primitive exists. */
+  wait: boolean;
+  /**
+   * Optional `prompt` fields the engine actually applies.
+   *
+   * The engines diverge here — OpenCode's v2 prompt endpoint has no field for a per-turn
+   * system prompt, while DeepSeek Harness does — and an engine-agnostic API that quietly
+   * ignored the difference would be lying: the caller would set a system prompt, get a
+   * normal-looking 200, and never learn it had no effect. A field reported `false` is
+   * rejected at the edge instead of dropped in the adapter.
+   */
+  promptOptions: EnginePromptOptionSupport;
+}
+
+export interface EnginePromptOptionSupport {
+  /** A per-turn system prompt override. */
+  system: boolean;
+  /** A reasoning-effort hint. */
+  reasoningEffort: boolean;
+  /** A model variant selector. */
+  variant: boolean;
+}
+
+export type EnginePromptOption = keyof EnginePromptOptionSupport;
+
+export const ENGINE_PROMPT_OPTIONS: readonly EnginePromptOption[] = [
+  "system",
+  "reasoningEffort",
+  "variant",
+] as const;
+
+export interface EngineConnection {
+  readonly engineId: string;
+  readonly capabilities: EngineCapabilities;
+
+  createSession(input: { title?: string; agent?: string; model?: EngineModelRef }): Promise<EngineSession>;
+  getSession(sessionId: string): Promise<EngineSession>;
+  deleteSession(sessionId: string): Promise<void>;
+  renameSession(sessionId: string, title: string): Promise<void>;
+
+  prompt(input: EnginePromptInput): Promise<{ messageId?: string }>;
+  interrupt(sessionId: string): Promise<boolean>;
+  /** Resolves once the session goes idle. Only valid when `capabilities.wait`. */
+  wait(sessionId: string, signal?: AbortSignal): Promise<void>;
+
+  listPermissions(sessionId: string): Promise<EnginePermission[]>;
+  replyPermission(input: { sessionId: string; permissionId: string; reply: EnginePermissionReply }): Promise<void>;
+
+  listQuestions(sessionId: string): Promise<EngineQuestion[]>;
+  replyQuestion(input: { sessionId: string; questionId: string; answers: string[][] }): Promise<void>;
+
+  subscribe(input: EngineSubscribeInput): Promise<void>;
+}
+
+export interface EngineAdapter {
+  readonly id: string;
+  /** Builds a connection for one workspace. */
+  connect(workspace: unknown): EngineConnection;
+}
+
+/**
+ * Adapter lookup by engine id.
+ *
+ * Follows the two registries this codebase already has — `PluginEngineAdapterRegistry`
+ * (`../../plugin-engine-adapter.ts`) and the browser's `ConversationEngineAdapterRegistry`
+ * — including their fail-fast construction: an empty or duplicate id is a programming
+ * error and is rejected at startup rather than at the first request. A lookup miss is a
+ * request-time condition, so it surfaces as an `ApiError` the same way the plugin engine
+ * registry reports an unregistered engine.
+ */
+export class EngineAdapterRegistry {
+  readonly #adapters: ReadonlyMap<string, EngineAdapter>;
+  readonly #defaultEngineId: string;
+
+  constructor(defaultEngineId: string, adapters: readonly EngineAdapter[]) {
+    const entries = new Map<string, EngineAdapter>();
+    for (const adapter of adapters) {
+      const id = adapter.id.trim();
+      if (!id) throw new Error("Engine adapter ID is required");
+      if (entries.has(id)) throw new Error(`Duplicate engine adapter: ${id}`);
+      entries.set(id, adapter);
+    }
+    if (!entries.has(defaultEngineId)) {
+      throw new Error(`Default engine adapter is not registered: ${defaultEngineId}`);
+    }
+    this.#adapters = entries;
+    this.#defaultEngineId = defaultEngineId;
+  }
+
+  get(id?: string | null): EngineAdapter {
+    const resolved = id?.trim() || this.#defaultEngineId;
+    const adapter = this.#adapters.get(resolved);
+    if (!adapter) {
+      throw new ApiError(409, "engine_not_registered", `Engine is not registered: ${resolved}`, {
+        engine: resolved,
+        registeredEngines: [...this.#adapters.keys()],
+      });
+    }
+    return adapter;
+  }
+
+  has(id?: string | null): boolean {
+    return this.#adapters.has(id?.trim() || this.#defaultEngineId);
+  }
+
+  ids(): string[] {
+    return [...this.#adapters.keys()];
+  }
+}

--- a/apps/server/src/api/index.test.ts
+++ b/apps/server/src/api/index.test.ts
@@ -1,0 +1,484 @@
+import { describe, expect, test } from "bun:test";
+
+import { ApiError, isApiError } from "../errors.js";
+import { addRoute, matchRoute, type RequestContext, type Route } from "../routes/registry.js";
+import type { ServerConfig, WorkspaceInfo } from "../types.js";
+import type { HarnessRuntimeLike } from "./engine/harness.js";
+import type { OpencodeEngineClient, UnwrapOpencodeResult } from "./engine/opencode.js";
+import {
+  API_MODULES,
+  bridgeTaskEventsToWebhooks,
+  createEngineRegistry,
+  createPolicyEnforcer,
+  registerApiV1,
+  taskWebhookEventType,
+  type RegisterApiV1Input,
+} from "./index.js";
+import { defaultScopeForEffect } from "./module.js";
+import { createTaskStore, type TaskEvent, type TaskRecord } from "./modules/tasks/store.js";
+import { MemoryWebhookStore } from "./modules/webhooks/store.js";
+
+/** Awaits a rejection and narrows it to an ApiError, so assertions stay typed. */
+async function expectRejection(promise: Promise<unknown>): Promise<ApiError> {
+  try {
+    await promise;
+  } catch (error) {
+    if (isApiError(error)) return error as ApiError;
+    throw error;
+  }
+  throw new Error("expected the call to reject");
+}
+
+const config = { workspaces: [], readOnly: false, authorizedRoots: [] } as unknown as ServerConfig;
+
+const workspace = { id: "w1", name: "w1", path: "/tmp/w1", preset: "starter" } as unknown as WorkspaceInfo;
+
+const harnessRuntime: HarnessRuntimeLike = {
+  async call<T>(): Promise<T> {
+    throw new Error("not reached");
+  },
+  async respond() {},
+  async events(): Promise<Response> {
+    throw new Error("not reached");
+  },
+};
+
+const unwrap: UnwrapOpencodeResult = (result, path) => {
+  if (result.data == null) throw new Error(`empty ${path}`);
+  return result.data as NonNullable<typeof result.data>;
+};
+
+const createClient = (): OpencodeEngineClient => ({}) as OpencodeEngineClient;
+
+/** A legacy route table with one entry, so `compat` has something to delegate to. */
+function legacyTable(): Route[] {
+  const routes: Route[] = [];
+  addRoute(routes, "GET", "/workspaces", "client", async () => new Response("legacy", { status: 200 }));
+  return routes;
+}
+
+function baseInput(routes: Route[], overrides: Partial<RegisterApiV1Input> = {}): RegisterApiV1Input {
+  return {
+    routes,
+    config,
+    serverVersion: "9.9.9",
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json" } }),
+    readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+    resolveWorkspace: async () => workspace,
+    createWorkspaceOpencodeClient: createClient,
+    unwrapOpencodeResult: unwrap,
+    deepseekHarness: harnessRuntime,
+    // Deliberately empty so the ambient IPOLLOWORK_API_MODULES* vars cannot change the
+    // result of a test run.
+    env: {},
+    ...overrides,
+  };
+}
+
+describe("createEngineRegistry", () => {
+  test("registers both built-in engines and defaults to opencode", () => {
+    const engines = createEngineRegistry({
+      config,
+      createWorkspaceOpencodeClient: createClient,
+      unwrapOpencodeResult: unwrap,
+      deepseekHarness: harnessRuntime,
+    });
+
+    expect(engines.ids().sort()).toEqual(["deepseek-harness", "opencode"]);
+    expect(engines.get(null).id).toBe("opencode");
+    expect(engines.get(undefined).id).toBe("opencode");
+    expect(engines.get("deepseek-harness").id).toBe("deepseek-harness");
+  });
+
+  test("an unregistered engine id is a 409, not a silent fallback", () => {
+    const engines = createEngineRegistry({
+      config,
+      createWorkspaceOpencodeClient: createClient,
+      unwrapOpencodeResult: unwrap,
+      deepseekHarness: harnessRuntime,
+    });
+
+    try {
+      engines.get("codex");
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      if (isApiError(error)) {
+        expect(error.status).toBe(409);
+        expect(error.code).toBe("engine_not_registered");
+      }
+    }
+  });
+});
+
+describe("registerApiV1", () => {
+  test("registers every module in the catalogue by default", () => {
+    const routes = legacyTable();
+    const result = registerApiV1(baseInput(routes));
+
+    expect(result.modules.map((entry) => entry.module.id)).toEqual([
+      "sessions",
+      "tasks",
+      "webhooks",
+      "policy",
+      "openapi",
+      "compat",
+    ]);
+    expect(result.modules.map((entry) => entry.module.id)).toEqual(API_MODULES.map((module) => module.id));
+    expect(result.operations.length).toBeGreaterThan(0);
+  });
+
+  test("appends routes without removing or reordering the legacy table", () => {
+    const routes = legacyTable();
+    const before = routes.length;
+    const legacy = routes[0];
+
+    const result = registerApiV1(baseInput(routes));
+
+    expect(routes.length).toBe(before + result.operations.length);
+    expect(routes[0]).toBe(legacy);
+    // matchRoute returns the first match, so a legacy path still resolves to its own
+    // handler after v1 is mounted.
+    expect(matchRoute(routes, "GET", "/workspaces")?.handler).toBe(legacy.handler);
+  });
+
+  test("every v1 operation is reachable and lands under /api/v1", () => {
+    const routes = legacyTable();
+    const result = registerApiV1(baseInput(routes));
+
+    for (const operation of result.operations) {
+      expect(operation.path.startsWith("/api/v1/")).toBe(true);
+      const concrete = operation.path.replace(/:([A-Za-z0-9_]+)/g, "x-$1");
+      expect(matchRoute(routes, operation.method, concrete)).not.toBeNull();
+    }
+  });
+
+  test("operation ids and method+path pairs are unique across modules", () => {
+    const result = registerApiV1(baseInput(legacyTable()));
+
+    const ids = result.operations.map((operation) => operation.operationId);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    const keys = result.operations.map((operation) => `${operation.method} ${operation.path}`);
+    expect(new Set(keys).size).toBe(keys.length);
+
+    // Two different patterns can still compile to the same regex (`:id` vs `:workspaceId`),
+    // which the registry's string key cannot see but a router would shadow.
+    const patterns = result.operations.map(
+      (operation) => `${operation.method} ${operation.path.replace(/:[A-Za-z0-9_]+/g, ":p")}`,
+    );
+    expect(new Set(patterns).size).toBe(patterns.length);
+  });
+
+  test("first-class modules never weaken the default scope for a write", () => {
+    const result = registerApiV1(baseInput(legacyTable()));
+    const rank = { viewer: 1, collaborator: 2, owner: 3 } as const;
+    let checked = 0;
+
+    for (const { module, operations } of result.modules) {
+      // `compat` is the documented exception: an alias copies the legacy handler's own
+      // check so the alias can never reject a request the legacy path would accept.
+      if (module.id === "compat") continue;
+      for (const operation of operations) {
+        if (operation.effect === "read") continue;
+        if ((operation.auth ?? "client") !== "client") continue;
+        const scope = operation.scope ?? defaultScopeForEffect(operation.effect);
+        expect(rank[scope]).toBeGreaterThanOrEqual(rank[defaultScopeForEffect(operation.effect)]);
+        checked += 1;
+      }
+    }
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  test("every compat alias declares its scope explicitly", () => {
+    // The alias scope is copied from the legacy handler's own check rather than derived
+    // from the effect (`compat/module.test.ts` verifies that against the route sources),
+    // so an alias that fell back to the effect default would be an unreviewed gate.
+    const result = registerApiV1(baseInput(legacyTable()));
+    const compat = result.modules.find((entry) => entry.module.id === "compat");
+    expect(compat).toBeDefined();
+    expect(compat!.operations.length).toBeGreaterThan(0);
+
+    for (const operation of compat!.operations) {
+      expect(operation.scope).toBeDefined();
+    }
+  });
+
+  test("IPOLLOWORK_API_MODULES narrows the enabled set", () => {
+    const routes = legacyTable();
+    const result = registerApiV1(
+      baseInput(routes, { env: { IPOLLOWORK_API_MODULES: "sessions,openapi" } }),
+    );
+
+    expect(result.modules.map((entry) => entry.module.id)).toEqual(["sessions", "openapi"]);
+    expect(result.taskStore).toBeUndefined();
+    expect(result.webhookStore).toBeUndefined();
+  });
+
+  test("IPOLLOWORK_API_MODULES_DISABLED removes a module", () => {
+    const result = registerApiV1(
+      baseInput(legacyTable(), { env: { IPOLLOWORK_API_MODULES_DISABLED: "compat,webhooks" } }),
+    );
+
+    const ids = result.modules.map((entry) => entry.module.id);
+    expect(ids).not.toContain("compat");
+    expect(ids).not.toContain("webhooks");
+    expect(ids).toContain("sessions");
+  });
+
+  test("an unknown module id fails startup instead of being ignored", () => {
+    try {
+      registerApiV1(baseInput(legacyTable(), { env: { IPOLLOWORK_API_MODULES: "sessions,typo" } }));
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      if (isApiError(error)) expect(error.code).toBe("api_module_unknown");
+    }
+  });
+
+  test("disabling a dependency of an enabled module fails startup", () => {
+    try {
+      registerApiV1(baseInput(legacyTable(), { env: { IPOLLOWORK_API_MODULES: "tasks" } }));
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      if (isApiError(error)) expect(error.code).toBe("api_module_dependency_missing");
+    }
+  });
+
+  test("compat delegates to the legacy table through the injected getter", async () => {
+    const routes = legacyTable();
+    registerApiV1(baseInput(routes, { legacyRoutes: () => routes }));
+
+    const matched = matchRoute(routes, "GET", "/api/v1/workspaces");
+    expect(matched).not.toBeNull();
+    const response = await matched!.handler({
+      request: new Request("http://local/api/v1/workspaces"),
+      url: new URL("http://local/api/v1/workspaces"),
+      params: matched!.params,
+      config,
+    } as unknown as RequestContext);
+    expect(await response.text()).toBe("legacy");
+  });
+
+  test("the openapi module sees the completed registry, including its own operations", async () => {
+    const routes = legacyTable();
+    const result = registerApiV1(baseInput(routes));
+
+    const matched = matchRoute(routes, "GET", "/api/v1/openapi.json");
+    expect(matched).not.toBeNull();
+    const response = await matched!.handler({
+      request: new Request("http://local/api/v1/openapi.json"),
+      url: new URL("http://local/api/v1/openapi.json"),
+      params: {},
+      config,
+    } as unknown as RequestContext);
+    const document = (await response.json()) as { info: { version: string }; paths: Record<string, unknown> };
+
+    expect(response.status).toBe(200);
+    expect(document.info.version).toBe("9.9.9");
+    expect(document.paths["/api/v1/openapi.json"]).toBeDefined();
+    const documented = result.operations.filter((operation) => !operation.internal);
+    expect(Object.keys(document.paths).length).toBeGreaterThan(0);
+    expect(Object.keys(document.paths).length).toBeLessThanOrEqual(documented.length);
+  });
+
+  test("service overrides win over the ones the composition root builds", () => {
+    const taskStore = createTaskStore();
+    const webhookStore = new MemoryWebhookStore();
+    const result = registerApiV1(baseInput(legacyTable(), { services: { taskStore, webhookStore } }));
+
+    expect(result.taskStore).toBe(taskStore);
+    expect(result.webhookStore).toBe(webhookStore);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Task -> webhook bridge                                                      */
+/* -------------------------------------------------------------------------- */
+
+function taskEvent(overrides: Partial<TaskEvent> & { task?: Partial<TaskRecord> } = {}): TaskEvent {
+  const task = { id: "t1", workspaceId: "w1", state: "queued", goal: "g", ...overrides.task } as TaskRecord;
+  return { seq: 1, at: 0, taskId: task.id, type: "task.created", ...overrides, task } as TaskEvent;
+}
+
+describe("taskWebhookEventType", () => {
+  test("maps the four subscribable task events", () => {
+    expect(taskWebhookEventType(taskEvent())).toBe("task.created");
+    expect(taskWebhookEventType(taskEvent({ type: "task.state", to: "done" }))).toBe("task.completed");
+    expect(taskWebhookEventType(taskEvent({ type: "task.state", to: "failed" }))).toBe("task.failed");
+    expect(taskWebhookEventType(taskEvent({ type: "task.state", to: "awaiting_approval" })))
+      .toBe("task.awaiting_approval");
+  });
+
+  test("emits nothing for transitions with no webhook name", () => {
+    expect(taskWebhookEventType(taskEvent({ type: "task.updated" }))).toBeNull();
+    expect(taskWebhookEventType(taskEvent({ type: "task.state", to: "running" }))).toBeNull();
+    expect(taskWebhookEventType(taskEvent({ type: "task.state", to: "cancelled" }))).toBeNull();
+  });
+});
+
+describe("bridgeTaskEventsToWebhooks", () => {
+  test("dispatches the mapped events and detaches on dispose", () => {
+    const tasks = createTaskStore();
+    const webhooks = new MemoryWebhookStore();
+    const sent: Array<{ workspaceId: string; type: string }> = [];
+
+    const detach = bridgeTaskEventsToWebhooks({
+      tasks,
+      webhooks,
+      allowPrivate: () => true,
+      dispatch: async (_store, event) => {
+        sent.push({ workspaceId: event.workspaceId, type: event.type });
+        return [];
+      },
+    });
+
+    const task = tasks.add({ workspaceId: "w1", goal: "ship it" });
+    tasks.update(task.id, { state: "running" });
+    tasks.update(task.id, { state: "done" });
+
+    expect(sent).toEqual([
+      { workspaceId: "w1", type: "task.created" },
+      { workspaceId: "w1", type: "task.completed" },
+    ]);
+
+    detach();
+    const second = tasks.add({ workspaceId: "w1", goal: "again" });
+    expect(second.id).not.toBe(task.id);
+    expect(sent.length).toBe(2);
+  });
+
+  test("a failing delivery never escapes into the task store", () => {
+    const tasks = createTaskStore();
+    const webhooks = new MemoryWebhookStore();
+
+    bridgeTaskEventsToWebhooks({
+      tasks,
+      webhooks,
+      dispatch: async () => {
+        throw new Error("endpoint is gone");
+      },
+    });
+
+    expect(() => tasks.add({ workspaceId: "w1", goal: "ship it" })).not.toThrow();
+  });
+});
+
+describe("createPolicyEnforcer", () => {
+  function ctxWith(params: Record<string, string>, tokenHash?: string): RequestContext {
+    return {
+      request: new Request("http://localhost/api/v1/x"),
+      url: new URL("http://localhost/api/v1/x"),
+      params,
+      config,
+      approvals: {} as never,
+      reloadEvents: {} as never,
+      tokens: {
+        async findByHash(hash: string) {
+          return hash === "hash-ci" ? { id: "tok_ci", scope: "collaborator" as const, label: "ci" } : null;
+        },
+      } as never,
+      ...(tokenHash ? { actor: { type: "remote" as const, tokenHash, scope: "collaborator" as const } } : {}),
+    };
+  }
+
+  const store = {
+    async get(tokenId: string) {
+      if (tokenId === "tok_ci") return { workspaces: ["w1"], expiresAt: null };
+      if (tokenId === "tok_expired") return { expiresAt: 1 };
+      return {};
+    },
+  };
+
+  test("allows a workspace the token is bound to", async () => {
+    await expect(createPolicyEnforcer(store)(ctxWith({ workspaceId: "w1" }, "hash-ci"))).resolves.toBeUndefined();
+  });
+
+  test("rejects a workspace outside the binding", async () => {
+    const error = await expectRejection(createPolicyEnforcer(store)(ctxWith({ workspaceId: "w2" }, "hash-ci")));
+
+    expect(error.status).toBe(403);
+    expect(error.code).toBe("workspace_forbidden");
+    expect(error.details).toMatchObject({ workspaceId: "w2" });
+  });
+
+  test("reads the legacy `:id` param too, so compat aliases are covered", async () => {
+    const error = await expectRejection(createPolicyEnforcer(store)(ctxWith({ id: "w2" }, "hash-ci")));
+    expect(error.code).toBe("workspace_forbidden");
+  });
+
+  test("a route naming no workspace still passes for a bound token", async () => {
+    await expect(createPolicyEnforcer(store)(ctxWith({}, "hash-ci"))).resolves.toBeUndefined();
+  });
+
+  test("an expired token is rejected even on a route naming no workspace", async () => {
+    const expiredStore = { async get() { return { expiresAt: 1 }; } };
+    const error = await expectRejection(createPolicyEnforcer(expiredStore)(ctxWith({}, "hash-ci")));
+
+    expect(error.status).toBe(403);
+    expect(error.code).toBe("token_expired");
+  });
+
+  test("the shared config token has no record and is left alone", async () => {
+    await expect(createPolicyEnforcer(store)(ctxWith({ workspaceId: "w2" }))).resolves.toBeUndefined();
+  });
+
+  test("an unknown token hash is left to the auth layer, not silently bound", async () => {
+    await expect(createPolicyEnforcer(store)(ctxWith({ workspaceId: "w2" }, "hash-unknown")))
+      .resolves.toBeUndefined();
+  });
+});
+
+describe("policy enforcement is applied by the registry", () => {
+  test("a bound token cannot reach another workspace through a registered route", async () => {
+    const routes: Route[] = [];
+    let handlerRan = false;
+
+    registerApiV1({
+      ...baseInput(routes),
+      services: {
+        tokenPolicies: {
+          async get(tokenId: string) {
+            return tokenId === "tok_ci" ? { workspaces: ["w1"] } : {};
+          },
+        },
+      },
+    } as unknown as RegisterApiV1Input);
+
+    const route = matchRoute(routes, "POST", "/api/v1/workspaces/w2/sessions");
+    expect(route).not.toBeNull();
+
+    const ctx: RequestContext = {
+      request: new Request("http://localhost/api/v1/workspaces/w2/sessions", {
+        method: "POST",
+        body: "{}",
+        headers: { "content-type": "application/json" },
+      }),
+      url: new URL("http://localhost/api/v1/workspaces/w2/sessions"),
+      params: route!.params,
+      config,
+      approvals: {} as never,
+      reloadEvents: {} as never,
+      tokens: {
+        async findByHash() {
+          return { id: "tok_ci", scope: "collaborator" as const, label: "ci" };
+        },
+      } as never,
+      actor: { type: "remote", tokenHash: "hash-ci", scope: "collaborator" },
+    };
+
+    const error = await expectRejection(
+      route!.handler(ctx).then(() => {
+        handlerRan = true;
+      }),
+    );
+
+    expect(handlerRan).toBe(false);
+    expect(error.status).toBe(403);
+    expect(error.code).toBe("workspace_forbidden");
+  });
+});

--- a/apps/server/src/api/index.ts
+++ b/apps/server/src/api/index.ts
@@ -1,0 +1,297 @@
+/**
+ * Composition root for the public API component.
+ *
+ * Everything above this file is declarative: an engine adapter says how to talk to one
+ * engine, a module says which operations it exposes. Nothing in either half knows how the
+ * server is wired. This file is the one place that knows, so the component can be mounted
+ * with a single call and, in a test, mounted against stubs without touching a real server.
+ *
+ * Mounting is additive. `matchRoute` (`../routes/registry.ts`) scans the route array in
+ * order and returns the first match, so appending v1 routes after the legacy registrations
+ * cannot shadow an existing route — the legacy table is matched first, unchanged.
+ */
+
+import { DEFAULT_ENGINE_ID } from "@ipollowork/types/workspace";
+
+import type { RequestContext, Route } from "../routes/registry.js";
+import type { ServerConfig, TokenScope, WorkspaceInfo } from "../types.js";
+import { createHarnessEngineAdapter, type HarnessRuntimeLike } from "./engine/harness.js";
+import {
+  createOpencodeEngineAdapter,
+  type OpencodeEngineClient,
+  type UnwrapOpencodeResult,
+} from "./engine/opencode.js";
+import { EngineAdapterRegistry } from "./engine/types.js";
+import {
+  registerApiModules,
+  resolveEnabledModules,
+  type ApiModule,
+  type ApiModuleContext,
+  type ApiModuleRegistryResult,
+  type ApiModuleServices,
+} from "./module.js";
+import { compatModule } from "./modules/compat/module.js";
+import { openApiModule } from "./modules/openapi/module.js";
+import { assertPolicyAllowsWorkspace, policyModule, TokenPolicyStore } from "./modules/policy/module.js";
+import { sessionsModule } from "./modules/sessions/module.js";
+import { serializeTask, tasksModule } from "./modules/tasks/module.js";
+import { createTaskRunner, type TaskRunner } from "./modules/tasks/runner.js";
+import { createTaskStore, type TaskEvent, type TaskStore } from "./modules/tasks/store.js";
+import { webhookPrivateNetworkAllowed } from "./modules/webhooks/delivery.js";
+import { dispatchWebhookEvent, webhooksModule } from "./modules/webhooks/module.js";
+import { WebhookStore, type WebhookStoreLike } from "./modules/webhooks/store.js";
+
+/**
+ * Registration order.
+ *
+ * `compat` is last on purpose: its aliases are the broadest patterns in the component, so
+ * a first-class module always wins a path both could serve. `tasks` declares
+ * `dependsOn: ["sessions"]`, which `registerApiModules` checks against the enabled set
+ * rather than against order, so this list stays readable rather than topologically sorted.
+ */
+export const API_MODULES: readonly ApiModule[] = [
+  sessionsModule,
+  tasksModule,
+  webhooksModule,
+  policyModule,
+  openApiModule,
+  compatModule,
+];
+
+/** Env var narrowing the enabled set to an allowlist. */
+export const API_MODULES_ENV = "IPOLLOWORK_API_MODULES";
+/** Env var removing individual modules. */
+export const API_MODULES_DISABLED_ENV = "IPOLLOWORK_API_MODULES_DISABLED";
+
+export interface RegisterApiV1Input {
+  /** The shared route table. v1 routes are appended to it. */
+  routes: Route[];
+  config: ServerConfig;
+  /** Reported as the OpenAPI document's `info.version`. */
+  serverVersion: string;
+
+  /* The server's own gates and helpers, injected rather than imported: the server owns
+     them, and a test needs to be able to substitute them. */
+  ensureWritable: (config: ServerConfig) => void;
+  requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
+  jsonResponse: (data: unknown, status?: number) => Response;
+  readJsonBody: (request: Request) => Promise<Record<string, unknown>>;
+  resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
+
+  /** Per-workspace OpenCode client factory (`createWorkspaceOpencodeClient`). */
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => OpencodeEngineClient;
+  /** The server's `unwrapOpencodeResult`. */
+  unwrapOpencodeResult: UnwrapOpencodeResult;
+  /** The shared `DeepSeekHarnessRuntime`. */
+  deepseekHarness: HarnessRuntimeLike;
+
+  /**
+   * Returns the full legacy route table, read at request time by `compat`.
+   * Defaults to the same array v1 is being appended to, which is what makes the
+   * delegation see every legacy route regardless of registration order.
+   */
+  legacyRoutes?: () => Route[];
+
+  /** Environment used for the module toggles. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+  /** Overrides the module catalogue. Tests only. */
+  modules?: readonly ApiModule[];
+  /** Extra or overriding services merged into `ApiModuleContext.services`. Tests only. */
+  services?: ApiModuleServices;
+}
+
+export interface RegisterApiV1Result extends ApiModuleRegistryResult {
+  engines: EngineAdapterRegistry;
+  /** Present when the `tasks` module is enabled. */
+  taskStore?: TaskStore;
+  /** Present when the `tasks` module is enabled. Call `shutdown()` to abort in-flight runs. */
+  taskRunner?: TaskRunner;
+  /** Present when the `webhooks` module is enabled. */
+  webhookStore?: WebhookStoreLike;
+  /** Detaches the task -> webhook bridge. No-op when the bridge was not installed. */
+  dispose: () => void;
+}
+
+/**
+ * Builds the engine registry.
+ *
+ * `DEFAULT_ENGINE_ID` ("opencode") is the default because `WorkspaceWire.engineId` is
+ * optional and the legacy session routes treat every workspace that is not
+ * `DEEPSEEK_HARNESS_ENGINE_ID` as an OpenCode workspace.
+ */
+export function createEngineRegistry(input: {
+  config: ServerConfig;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => OpencodeEngineClient;
+  unwrapOpencodeResult: UnwrapOpencodeResult;
+  deepseekHarness: HarnessRuntimeLike;
+}): EngineAdapterRegistry {
+  return new EngineAdapterRegistry(DEFAULT_ENGINE_ID, [
+    createOpencodeEngineAdapter({
+      createClient: (workspace) => input.createWorkspaceOpencodeClient(input.config, workspace),
+      unwrap: input.unwrapOpencodeResult,
+    }),
+    createHarnessEngineAdapter({ runtime: input.deepseekHarness }),
+  ]);
+}
+
+/**
+ * Builds the per-request token-policy gate.
+ *
+ * Enforcement lives at the registry level rather than in individual handlers because a
+ * restriction that only some routes remember to apply is worse than none: `whoami` reports
+ * the workspace binding as being in force, so a caller has every reason to believe a token
+ * scoped to one workspace cannot touch another.
+ *
+ * Only the workspace binding and expiry are enforced here. The approval policy is consumed
+ * where approvals happen, and a route with no `workspaceId` parameter has nothing to bind.
+ */
+export function createPolicyEnforcer(
+  store: Pick<TokenPolicyStore, "get">,
+): (ctx: RequestContext) => Promise<void> {
+  return async (ctx) => {
+    const tokenHash = ctx.actor?.tokenHash;
+    // The shared config token has no stored record and therefore no policy — it is the
+    // deployment-wide credential, and narrowing it is what `POST /tokens` is for.
+    if (!tokenHash) return;
+
+    const record = await ctx.tokens.findByHash(tokenHash);
+    if (!record) return;
+
+    const policy = await store.get(record.id);
+    const workspaceId = ctx.params.workspaceId ?? ctx.params.id;
+    assertPolicyAllowsWorkspace(policy, workspaceId ?? "", Date.now(), {
+      // A route that names no workspace still has to honour expiry.
+      skipWorkspaceCheck: workspaceId === undefined,
+    });
+  };
+}
+
+/**
+ * Maps a task store event onto the webhook event name subscribers can name.
+ *
+ * Pure and exported so the mapping is testable without a store. `task.updated` and a
+ * transition to `running` or `cancelled` deliberately produce nothing: neither is in
+ * `WEBHOOK_TASK_EVENT_TYPES`, and inventing a name here would make a subscription filter
+ * that cannot be expressed.
+ */
+export function taskWebhookEventType(event: TaskEvent): string | null {
+  if (event.type === "task.created") return "task.created";
+  if (event.type !== "task.state") return null;
+  if (event.to === "done") return "task.completed";
+  if (event.to === "failed") return "task.failed";
+  if (event.to === "awaiting_approval") return "task.awaiting_approval";
+  return null;
+}
+
+/**
+ * Connects the task store's event log to webhook delivery.
+ *
+ * Without this the `task.*` events in `WEBHOOK_EVENT_TYPES` would be subscribable but
+ * never sent. Delivery is fire-and-forget: a task run must not slow down or fail because a
+ * subscriber's endpoint is slow or gone, so the promise is detached and every rejection is
+ * swallowed here rather than escaping into the store's listener loop.
+ */
+export function bridgeTaskEventsToWebhooks(input: {
+  tasks: TaskStore;
+  webhooks: WebhookStoreLike;
+  dispatch?: typeof dispatchWebhookEvent;
+  allowPrivate?: () => boolean;
+}): () => void {
+  const dispatch = input.dispatch ?? dispatchWebhookEvent;
+  const allowPrivate = input.allowPrivate ?? webhookPrivateNetworkAllowed;
+  return input.tasks.subscribe({
+    onEvent: (event) => {
+      const type = taskWebhookEventType(event);
+      if (!type) return;
+      try {
+        void dispatch(
+          input.webhooks,
+          { workspaceId: event.task.workspaceId, type, data: serializeTask(event.task) },
+          { allowPrivate: allowPrivate() },
+        ).catch(() => undefined);
+      } catch {
+        // A synchronous throw from a stubbed dispatcher must not break the task run.
+      }
+    },
+  });
+}
+
+/**
+ * Mounts the `/api/v1` surface onto an existing route table.
+ *
+ * Call it after the legacy `register*Routes` calls: nothing here depends on registration
+ * order for matching (appended routes cannot shadow earlier ones), but `compat` re-dispatches
+ * into the legacy table and must be able to see all of it.
+ */
+export function registerApiV1(input: RegisterApiV1Input): RegisterApiV1Result {
+  const env = input.env ?? process.env;
+  const available = input.modules ?? API_MODULES;
+  const enabled = resolveEnabledModules(available, {
+    enabled: env[API_MODULES_ENV] ?? null,
+    disabled: env[API_MODULES_DISABLED_ENV] ?? null,
+  });
+  const enabledIds = new Set(enabled.map((module) => module.id));
+
+  const engines = createEngineRegistry({
+    config: input.config,
+    createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
+    unwrapOpencodeResult: input.unwrapOpencodeResult,
+    deepseekHarness: input.deepseekHarness,
+  });
+
+  const overrides = input.services ?? {};
+
+  // The stores are owned here rather than inside their modules so the task -> webhook
+  // bridge can hold the same two instances the request handlers use.
+  const taskStore = (overrides.taskStore as TaskStore | undefined)
+    ?? (enabledIds.has("tasks") ? createTaskStore() : undefined);
+  const taskRunner = (overrides.taskRunner as TaskRunner | undefined)
+    ?? (taskStore ? createTaskRunner({ store: taskStore }) : undefined);
+  const webhookStore = (overrides.webhookStore as WebhookStoreLike | undefined)
+    ?? (enabledIds.has("webhooks") ? new WebhookStore(input.config) : undefined);
+  const tokenPolicies = (overrides.tokenPolicies as TokenPolicyStore | undefined)
+    ?? (enabledIds.has("policy") ? new TokenPolicyStore(input.config) : undefined);
+
+  // Resolved after `registerApiModules` returns; the openapi module only reads it per
+  // request, so a null here means "registration is still in flight" and surfaces as a 500
+  // rather than as a document missing half the API.
+  let registry: ApiModuleRegistryResult | null = null;
+
+  const services: ApiModuleServices = {
+    engines,
+    legacyRoutes: input.legacyRoutes ?? (() => input.routes),
+    getApiRegistry: () => registry,
+    serverVersion: input.serverVersion,
+    ...(taskStore ? { taskStore } : {}),
+    ...(taskRunner ? { taskRunner } : {}),
+    ...(webhookStore ? { webhookStore } : {}),
+    ...(tokenPolicies ? { tokenPolicies } : {}),
+    ...overrides,
+  };
+
+  const context: ApiModuleContext = {
+    config: input.config,
+    ensureWritable: input.ensureWritable,
+    requireClientScope: input.requireClientScope,
+    jsonResponse: input.jsonResponse,
+    readJsonBody: input.readJsonBody,
+    resolveWorkspace: input.resolveWorkspace,
+    ...(tokenPolicies ? { enforcePolicy: createPolicyEnforcer(tokenPolicies) } : {}),
+    services,
+  };
+
+  registry = registerApiModules(input.routes, enabled, context);
+
+  const detach = taskStore && webhookStore
+    ? bridgeTaskEventsToWebhooks({ tasks: taskStore, webhooks: webhookStore })
+    : undefined;
+
+  return {
+    ...registry,
+    engines,
+    ...(taskStore ? { taskStore } : {}),
+    ...(taskRunner ? { taskRunner } : {}),
+    ...(webhookStore ? { webhookStore } : {}),
+    dispose: () => detach?.(),
+  };
+}

--- a/apps/server/src/api/module.test.ts
+++ b/apps/server/src/api/module.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, test } from "bun:test";
+
+import { isApiError } from "../errors.js";
+import type { RequestContext, Route } from "../routes/registry.js";
+import { matchRoute } from "../routes/registry.js";
+import type { ServerConfig, TokenScope } from "../types.js";
+import {
+  defaultScopeForEffect,
+  describeModules,
+  registerApiModules,
+  resolveEnabledModules,
+  type ApiModule,
+  type ApiModuleContext,
+  type ApiOperation,
+} from "./module.js";
+
+const config = { workspaces: [], readOnly: false } as unknown as ServerConfig;
+
+function createContext(overrides: Partial<ApiModuleContext> = {}): ApiModuleContext {
+  return {
+    config,
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+    readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+    resolveWorkspace: async () => ({ id: "w1" }),
+    services: {},
+    ...overrides,
+  };
+}
+
+function createContextRecordingGates() {
+  const calls: string[] = [];
+  const context = createContext({
+    ensureWritable: () => {
+      calls.push("ensureWritable");
+    },
+    requireClientScope: (_ctx, required) => {
+      calls.push(`requireClientScope:${required}`);
+    },
+  });
+  return { context, calls };
+}
+
+function operation(overrides: Partial<ApiOperation> = {}): ApiOperation {
+  return {
+    operationId: "getThing",
+    method: "GET",
+    path: "/api/v1/thing",
+    summary: "Get a thing",
+    effect: "read",
+    handler: async () => Response.json({ ok: true }),
+    ...overrides,
+  };
+}
+
+function moduleWith(id: string, operations: ApiOperation[], extra: Partial<ApiModule> = {}): ApiModule {
+  return {
+    id,
+    title: id,
+    description: `${id} module`,
+    version: "1.0.0",
+    stability: "stable",
+    register: () => operations,
+    ...extra,
+  };
+}
+
+function requestContext(request: Request, params: Record<string, string> = {}): RequestContext {
+  return {
+    request,
+    url: new URL(request.url),
+    params,
+    config,
+    approvals: {} as never,
+    reloadEvents: {} as never,
+    tokens: {} as never,
+  };
+}
+
+describe("defaultScopeForEffect", () => {
+  test("reads require viewer and writes require collaborator", () => {
+    expect(defaultScopeForEffect("read")).toBe("viewer");
+    expect(defaultScopeForEffect("write")).toBe("collaborator");
+    expect(defaultScopeForEffect("destructive")).toBe("collaborator");
+  });
+});
+
+describe("resolveEnabledModules", () => {
+  const available = [moduleWith("sessions", []), moduleWith("tasks", []), moduleWith("webhooks", [])];
+
+  test("enables everything by default", () => {
+    expect(resolveEnabledModules(available).map((m) => m.id)).toEqual(["sessions", "tasks", "webhooks"]);
+  });
+
+  test("an allowlist narrows the set", () => {
+    expect(resolveEnabledModules(available, { enabled: "sessions,webhooks" }).map((m) => m.id))
+      .toEqual(["sessions", "webhooks"]);
+  });
+
+  test("a denylist removes modules", () => {
+    expect(resolveEnabledModules(available, { disabled: "tasks" }).map((m) => m.id))
+      .toEqual(["sessions", "webhooks"]);
+  });
+
+  test("the denylist wins over the allowlist", () => {
+    expect(resolveEnabledModules(available, { enabled: "sessions,tasks", disabled: "tasks" }).map((m) => m.id))
+      .toEqual(["sessions"]);
+  });
+
+  test("whitespace and empty entries are ignored", () => {
+    expect(resolveEnabledModules(available, { enabled: " sessions , , tasks " }).map((m) => m.id))
+      .toEqual(["sessions", "tasks"]);
+  });
+
+  test("an unknown id fails loudly instead of silently dropping a surface", () => {
+    expect(() => resolveEnabledModules(available, { enabled: "sessions,nope" })).toThrow(/Unknown API module/);
+    expect(() => resolveEnabledModules(available, { disabled: "nope" })).toThrow(/Unknown API module/);
+  });
+});
+
+describe("registerApiModules", () => {
+  test("adds one route per operation and reports them", () => {
+    const routes: Route[] = [];
+    const result = registerApiModules(
+      routes,
+      [moduleWith("thing", [operation(), operation({ operationId: "createThing", method: "POST", effect: "write" })])],
+      createContext(),
+    );
+
+    expect(routes).toHaveLength(2);
+    expect(result.operations.map((op) => op.operationId)).toEqual(["getThing", "createThing"]);
+    expect(matchRoute(routes, "GET", "/api/v1/thing")).not.toBeNull();
+    expect(matchRoute(routes, "POST", "/api/v1/thing")).not.toBeNull();
+  });
+
+  test("rejects duplicate module ids", () => {
+    expect(() => registerApiModules([], [moduleWith("dup", []), moduleWith("dup", [])], createContext()))
+      .toThrow(/Duplicate API module/);
+  });
+
+  test("rejects duplicate operation ids across modules", () => {
+    expect(() =>
+      registerApiModules(
+        [],
+        [moduleWith("a", [operation()]), moduleWith("b", [operation({ path: "/api/v1/other" })])],
+        createContext(),
+      ),
+    ).toThrow(/Duplicate API operationId/);
+  });
+
+  test("rejects two operations claiming the same method and path", () => {
+    expect(() =>
+      registerApiModules(
+        [],
+        [moduleWith("a", [operation()]), moduleWith("b", [operation({ operationId: "otherId" })])],
+        createContext(),
+      ),
+    ).toThrow(/Duplicate API route/);
+  });
+
+  test("rejects an unauthenticated write", () => {
+    expect(() =>
+      registerApiModules(
+        [],
+        [moduleWith("thing", [operation({ auth: "none", effect: "write", method: "POST" })])],
+        createContext(),
+      ),
+    ).toThrow(/auth "none" with a write effect/);
+  });
+
+  test("allows an unauthenticated read", () => {
+    expect(() =>
+      registerApiModules([], [moduleWith("thing", [operation({ auth: "none" })])], createContext()),
+    ).not.toThrow();
+  });
+
+  test("rejects a module whose dependency is not enabled", () => {
+    expect(() =>
+      registerApiModules([], [moduleWith("tasks", [], { dependsOn: ["sessions"] })], createContext()),
+    ).toThrow(/requires sessions/);
+  });
+
+  test("accepts a dependency that is enabled", () => {
+    expect(() =>
+      registerApiModules(
+        [],
+        [moduleWith("sessions", []), moduleWith("tasks", [], { dependsOn: ["sessions"] })],
+        createContext(),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("operation gating", () => {
+  test("read operations skip the write gate and require viewer", async () => {
+    const routes: Route[] = [];
+    const { context, calls } = createContextRecordingGates();
+    registerApiModules(routes, [moduleWith("thing", [operation()])], context);
+
+    const matched = matchRoute(routes, "GET", "/api/v1/thing");
+    await matched!.handler(requestContext(new Request("http://localhost/api/v1/thing")));
+
+    expect(calls).toEqual(["requireClientScope:viewer"]);
+  });
+
+  test("write operations run the write gate before the handler", async () => {
+    const routes: Route[] = [];
+    const { context, calls } = createContextRecordingGates();
+    registerApiModules(
+      routes,
+      [moduleWith("thing", [operation({ operationId: "createThing", method: "POST", effect: "write" })])],
+      context,
+    );
+
+    const matched = matchRoute(routes, "POST", "/api/v1/thing");
+    await matched!.handler(requestContext(new Request("http://localhost/api/v1/thing", { method: "POST" })));
+
+    expect(calls).toEqual(["ensureWritable", "requireClientScope:collaborator"]);
+  });
+
+  test("an explicit scope overrides the effect default", async () => {
+    const routes: Route[] = [];
+    const { context, calls } = createContextRecordingGates();
+    registerApiModules(
+      routes,
+      [moduleWith("thing", [operation({ effect: "write", scope: "owner" as TokenScope, method: "POST" })])],
+      context,
+    );
+
+    await matchRoute(routes, "POST", "/api/v1/thing")!
+      .handler(requestContext(new Request("http://localhost/api/v1/thing", { method: "POST" })));
+
+    expect(calls).toEqual(["ensureWritable", "requireClientScope:owner"]);
+  });
+
+  test("host-authenticated operations skip the client scope check", async () => {
+    const routes: Route[] = [];
+    const { context, calls } = createContextRecordingGates();
+    registerApiModules(
+      routes,
+      [moduleWith("thing", [operation({ auth: "host", effect: "write", method: "POST" })])],
+      context,
+    );
+
+    await matchRoute(routes, "POST", "/api/v1/thing")!
+      .handler(requestContext(new Request("http://localhost/api/v1/thing", { method: "POST" })));
+
+    // The write gate still applies; only the client-token scope check is skipped.
+    expect(calls).toEqual(["ensureWritable"]);
+  });
+
+  test("a failing gate prevents the handler from running", async () => {
+    const routes: Route[] = [];
+    let handlerRan = false;
+    const context = createContext({
+      requireClientScope: () => {
+        throw new Error("insufficient scope");
+      },
+    });
+    registerApiModules(
+      routes,
+      [moduleWith("thing", [operation({ handler: async () => {
+        handlerRan = true;
+        return Response.json({});
+      } })])],
+      context,
+    );
+
+    await expect(
+      matchRoute(routes, "GET", "/api/v1/thing")!.handler(requestContext(new Request("http://localhost/api/v1/thing"))),
+    ).rejects.toThrow(/insufficient scope/);
+    expect(handlerRan).toBe(false);
+  });
+
+  test("the route is registered with the declared auth mode", () => {
+    const routes: Route[] = [];
+    registerApiModules(routes, [moduleWith("thing", [operation({ auth: "host" })])], createContext());
+    expect(routes[0]?.auth).toBe("host");
+  });
+
+  test("client is the default auth mode", () => {
+    const routes: Route[] = [];
+    registerApiModules(routes, [moduleWith("thing", [operation()])], createContext());
+    expect(routes[0]?.auth).toBe("client");
+  });
+});
+
+describe("registration errors", () => {
+  test("are ApiErrors so the server reports them with a code", () => {
+    try {
+      registerApiModules([], [moduleWith("dup", []), moduleWith("dup", [])], createContext());
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { code: string }).code).toBe("api_module_duplicate");
+    }
+  });
+});
+
+describe("describeModules", () => {
+  test("publishes the module and operation catalogue", () => {
+    const routes: Route[] = [];
+    const result = registerApiModules(
+      routes,
+      [
+        moduleWith("sessions", [operation({ operationId: "listSessions", summary: "List sessions" })]),
+        moduleWith("tasks", [operation({
+          operationId: "createTask",
+          method: "POST",
+          path: "/api/v1/tasks",
+          effect: "write",
+          summary: "Create a task",
+          streaming: "sse",
+          deprecated: true,
+        })], { dependsOn: ["sessions"], stability: "preview" }),
+      ],
+      createContext(),
+    );
+
+    expect(describeModules(result)).toEqual([
+      {
+        id: "sessions",
+        title: "sessions",
+        description: "sessions module",
+        version: "1.0.0",
+        stability: "stable",
+        dependsOn: [],
+        operations: [{
+          operationId: "listSessions",
+          method: "GET",
+          path: "/api/v1/thing",
+          effect: "read",
+          scope: "viewer",
+          summary: "List sessions",
+          streaming: null,
+          deprecated: false,
+        }],
+      },
+      {
+        id: "tasks",
+        title: "tasks",
+        description: "tasks module",
+        version: "1.0.0",
+        stability: "preview",
+        dependsOn: ["sessions"],
+        operations: [{
+          operationId: "createTask",
+          method: "POST",
+          path: "/api/v1/tasks",
+          effect: "write",
+          scope: "collaborator",
+          summary: "Create a task",
+          streaming: "sse",
+          deprecated: true,
+        }],
+      },
+    ]);
+  });
+});

--- a/apps/server/src/api/module.ts
+++ b/apps/server/src/api/module.ts
@@ -1,0 +1,292 @@
+import { ApiError } from "../errors.js";
+import { addRoute, type AuthMode, type RequestContext, type Route } from "../routes/registry.js";
+import type { ServerConfig, TokenScope } from "../types.js";
+
+/**
+ * API modules are the pluggable unit of the public API surface.
+ *
+ * A module owns a coherent slice of functionality (sessions, tasks, webhooks, ...),
+ * declares every operation it exposes, and can be enabled or disabled independently.
+ * The declaration is the single source of truth: the registry turns it into both the
+ * live route table and the published OpenAPI document, so the two cannot drift.
+ *
+ * The vocabulary deliberately mirrors `ipollowork.plugin.json` resource actions
+ * (`id` / `title` / `description` / `effect` / `inputSchema`) so a module reads as the
+ * same species of component as an installable plugin package.
+ */
+
+export type JsonSchema = Record<string, unknown>;
+
+export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+/**
+ * Mirrors the plugin action effect vocabulary from `plugin-service-runtime.ts`.
+ * `read` operations skip the write gates; `write` and `destructive` require a
+ * writable server and a sufficient token scope.
+ */
+export type ApiEffect = "read" | "write" | "destructive";
+
+export type ApiStability = "stable" | "preview" | "experimental";
+
+export interface ApiResponseSpec {
+  description: string;
+  schema?: JsonSchema;
+  /** Content type override. Defaults to `application/json`, or `text/event-stream` when streaming. */
+  contentType?: string;
+}
+
+export interface ApiOperation {
+  /** Unique across all modules. Becomes the OpenAPI `operationId` and the SDK method name. */
+  operationId: string;
+  method: HttpMethod;
+  /** Route path in `addRoute` syntax, e.g. `/api/v1/workspaces/:id/sessions`. */
+  path: string;
+  summary: string;
+  description?: string;
+  effect: ApiEffect;
+  /** Route-level auth mode handed to `addRoute`. Defaults to `client`. */
+  auth?: AuthMode;
+  /**
+   * Minimum client token scope. Enforced before the handler runs.
+   * Defaults to `viewer` for `read` and `collaborator` for `write` / `destructive`,
+   * matching the convention in `routes/deepseek-harness.ts`.
+   */
+  scope?: TokenScope;
+  /** Marks the response as an SSE stream for documentation and SDK generation. */
+  streaming?: "sse";
+  requestBody?: JsonSchema;
+  query?: JsonSchema;
+  pathParams?: JsonSchema;
+  responses?: Record<number, ApiResponseSpec>;
+  /** Excludes the operation from the published OpenAPI document (still routed). */
+  internal?: boolean;
+  /** Marks a compatibility alias of another operation. */
+  deprecated?: boolean;
+  handler: (ctx: RequestContext) => Promise<Response>;
+}
+
+export interface ApiModuleContext {
+  config: ServerConfig;
+  /** Throws `403 read_only` when the server runs read-only. */
+  ensureWritable: (config: ServerConfig) => void;
+  /** Throws `401` / `403` when the actor's token scope is insufficient. */
+  requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
+  jsonResponse: (data: unknown, status?: number) => Response;
+  readJsonBody: (request: Request) => Promise<Record<string, unknown>>;
+  /** Resolves a workspace id from a route param, throwing `404` when unknown. */
+  resolveWorkspace: (config: ServerConfig, id: string) => Promise<unknown>;
+  /**
+   * Applies the caller's token policy — workspace binding and expiry — before the handler
+   * runs. Supplied by the composition root when the `policy` module is enabled.
+   *
+   * It belongs here, next to the scope and writability gates, rather than in each handler:
+   * a per-token restriction that only some routes remembered to check would be worse than
+   * no restriction, because the API reports it as being in force.
+   */
+  enforcePolicy?: (ctx: RequestContext) => Promise<void>;
+  /** Everything else a module needs is passed through here by `registerApiModules`. */
+  services: ApiModuleServices;
+}
+
+/**
+ * Late-bound services. Kept as a separate bag so adding a service does not force
+ * every module signature to change.
+ */
+export interface ApiModuleServices {
+  [key: string]: unknown;
+}
+
+export interface ApiModule {
+  /** Stable identifier, e.g. `sessions`. Used in config toggles and the docs. */
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  /** Module version, independent of the server version. */
+  readonly version: string;
+  readonly stability: ApiStability;
+  /** Module ids that must also be enabled. Enforced at registration time. */
+  readonly dependsOn?: readonly string[];
+  /** Returns every operation the module exposes. */
+  register(context: ApiModuleContext): ApiOperation[];
+}
+
+export interface RegisteredApiModule {
+  module: ApiModule;
+  operations: ApiOperation[];
+}
+
+export interface ApiModuleRegistryResult {
+  modules: RegisteredApiModule[];
+  operations: ApiOperation[];
+}
+
+const DEFAULT_SCOPE: Record<ApiEffect, TokenScope> = {
+  read: "viewer",
+  write: "collaborator",
+  destructive: "collaborator",
+};
+
+export function defaultScopeForEffect(effect: ApiEffect): TokenScope {
+  return DEFAULT_SCOPE[effect];
+}
+
+/**
+ * Resolves which modules are enabled.
+ *
+ * Every module is enabled by default; `IPOLLOWORK_API_MODULES` narrows the set to a
+ * comma-separated allowlist and `IPOLLOWORK_API_MODULES_DISABLED` removes individual
+ * modules. An unknown id in either list is a startup error rather than a silent no-op,
+ * so a typo cannot quietly drop an API surface.
+ */
+export function resolveEnabledModules(
+  available: readonly ApiModule[],
+  input: { enabled?: string | null; disabled?: string | null } = {},
+): ApiModule[] {
+  const ids = new Set(available.map((module) => module.id));
+  const parse = (value: string | null | undefined, label: string): string[] => {
+    const entries = (value ?? "")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    for (const entry of entries) {
+      if (!ids.has(entry)) {
+        throw new ApiError(500, "api_module_unknown", `Unknown API module in ${label}: ${entry}`, {
+          module: entry,
+          available: [...ids],
+        });
+      }
+    }
+    return entries;
+  };
+
+  const allowlist = parse(input.enabled, "IPOLLOWORK_API_MODULES");
+  const denylist = new Set(parse(input.disabled, "IPOLLOWORK_API_MODULES_DISABLED"));
+
+  const selected = allowlist.length > 0
+    ? available.filter((module) => allowlist.includes(module.id))
+    : available.slice();
+
+  return selected.filter((module) => !denylist.has(module.id));
+}
+
+/**
+ * Registers modules onto the shared route table.
+ *
+ * Wraps every handler so that scope and writability are enforced from the operation
+ * declaration rather than repeated in each handler, and so a module cannot accidentally
+ * expose a write without a gate.
+ */
+export function registerApiModules(
+  routes: Route[],
+  modules: readonly ApiModule[],
+  context: ApiModuleContext,
+): ApiModuleRegistryResult {
+  const enabledIds = new Set(modules.map((module) => module.id));
+  const seenModuleIds = new Set<string>();
+  const seenOperationIds = new Set<string>();
+  const seenRouteKeys = new Set<string>();
+
+  const registered: RegisteredApiModule[] = [];
+  const allOperations: ApiOperation[] = [];
+
+  for (const module of modules) {
+    if (seenModuleIds.has(module.id)) {
+      throw new ApiError(500, "api_module_duplicate", `Duplicate API module: ${module.id}`, { module: module.id });
+    }
+    seenModuleIds.add(module.id);
+
+    for (const dependency of module.dependsOn ?? []) {
+      if (!enabledIds.has(dependency)) {
+        throw new ApiError(
+          500,
+          "api_module_dependency_missing",
+          `API module ${module.id} requires ${dependency}, which is not enabled`,
+          { module: module.id, dependency },
+        );
+      }
+    }
+
+    const operations = module.register(context);
+
+    for (const operation of operations) {
+      if (seenOperationIds.has(operation.operationId)) {
+        throw new ApiError(
+          500,
+          "api_operation_duplicate",
+          `Duplicate API operationId: ${operation.operationId}`,
+          { operationId: operation.operationId, module: module.id },
+        );
+      }
+      seenOperationIds.add(operation.operationId);
+
+      // An unauthenticated mutation is never intended, and the mistake is invisible at
+      // review time: `auth: "none"` reads as "public", `effect: "write"` reads as
+      // "gated", and only together do they mean "anyone may change this".
+      if ((operation.auth ?? "client") === "none" && operation.effect !== "read") {
+        throw new ApiError(
+          500,
+          "api_operation_unauthenticated_write",
+          `API operation ${operation.operationId} declares auth "none" with a ${operation.effect} effect`,
+          { operationId: operation.operationId, module: module.id, effect: operation.effect },
+        );
+      }
+
+      const routeKey = `${operation.method} ${operation.path}`;
+      if (seenRouteKeys.has(routeKey)) {
+        throw new ApiError(500, "api_route_duplicate", `Duplicate API route: ${routeKey}`, {
+          route: routeKey,
+          module: module.id,
+        });
+      }
+      seenRouteKeys.add(routeKey);
+
+      addRoute(routes, operation.method, operation.path, operation.auth ?? "client", createGuardedHandler(operation, context));
+      allOperations.push(operation);
+    }
+
+    registered.push({ module, operations });
+  }
+
+  return { modules: registered, operations: allOperations };
+}
+
+function createGuardedHandler(operation: ApiOperation, context: ApiModuleContext): ApiOperation["handler"] {
+  const scope = operation.scope ?? defaultScopeForEffect(operation.effect);
+  const needsWriteGate = operation.effect !== "read";
+
+  return async (ctx: RequestContext) => {
+    if (needsWriteGate) {
+      context.ensureWritable(context.config);
+    }
+    // `host` and `host-token` routes authenticate as the host rather than as a
+    // scoped client token, so the client scope check does not apply to them.
+    const auth = operation.auth ?? "client";
+    if (auth === "client") {
+      context.requireClientScope(ctx, scope);
+      await context.enforcePolicy?.(ctx);
+    }
+    return operation.handler(ctx);
+  };
+}
+
+/** Serializable module descriptor, published at `GET /api/v1/modules`. */
+export function describeModules(result: ApiModuleRegistryResult) {
+  return result.modules.map(({ module, operations }) => ({
+    id: module.id,
+    title: module.title,
+    description: module.description,
+    version: module.version,
+    stability: module.stability,
+    dependsOn: module.dependsOn ?? [],
+    operations: operations.map((operation) => ({
+      operationId: operation.operationId,
+      method: operation.method,
+      path: operation.path,
+      effect: operation.effect,
+      scope: operation.scope ?? defaultScopeForEffect(operation.effect),
+      summary: operation.summary,
+      streaming: operation.streaming ?? null,
+      deprecated: operation.deprecated ?? false,
+    })),
+  }));
+}

--- a/apps/server/src/api/modules/compat/module.test.ts
+++ b/apps/server/src/api/modules/compat/module.test.ts
@@ -1,0 +1,460 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { isApiError } from "../../../errors.js";
+import { addRoute, type RequestContext, type Route } from "../../../routes/registry.js";
+import type { ServerConfig } from "../../../types.js";
+import { registerApiModules, type ApiModuleContext } from "../../module.js";
+import {
+  buildLegacyPath,
+  COMPAT_ALIASES,
+  COMPAT_EXCLUDED_LEGACY_ROUTES,
+  COMPAT_READ_ONLY_STRICTER,
+  COMPAT_RESERVED_V1_PREFIXES,
+  compatModule,
+  createCompatHandler,
+  extractPathParams,
+  toV1Path,
+  type CompatAlias,
+} from "./module.js";
+
+const SERVER_SRC = join(import.meta.dir, "..", "..", "..");
+
+const LEGACY_ROUTE_FILES = [
+  "server.ts",
+  "routes/core.ts",
+  "routes/files.ts",
+  "routes/sessions.ts",
+  "routes/workspaces.ts",
+  "routes/operations.ts",
+  "routes/deepseek-harness.ts",
+];
+
+interface LegacyRouteFact {
+  method: string;
+  path: string;
+  auth: string;
+  /** Calls `ensureWritable(config)` unconditionally, as its own statement. */
+  ensuresWritable: boolean;
+  /** Scope demanded unconditionally by the handler itself, if any. */
+  handlerScope: string | null;
+}
+
+/**
+ * Re-derives the legacy route table straight from the source files.
+ *
+ * The alias table hard-codes each legacy route's auth mode, write gate and scope; without
+ * this the two could silently drift, which is exactly the failure mode a compatibility
+ * layer must not have.
+ */
+function readLegacyRouteFacts(): LegacyRouteFact[] {
+  const facts: LegacyRouteFact[] = [];
+  for (const file of LEGACY_ROUTE_FILES) {
+    const text = readFileSync(join(SERVER_SRC, file), "utf8");
+    const pattern = /addRoute\(\s*routes\s*,\s*(?:"(\w+)"|(\w+))\s*,\s*"([^"]+)"\s*,\s*"([a-z-]+)"/g;
+    const hits: { index: number; method: string | null; path: string; auth: string }[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(text)) !== null) {
+      hits.push({ index: match.index, method: match[1] ?? null, path: match[3], auth: match[4] });
+    }
+    hits.forEach((hit, position) => {
+      const end = position + 1 < hits.length ? hits[position + 1].index : text.length;
+      // Four spaces is the top level of a handler body: `addRoute(` is always indented by
+      // two. Anchoring on it keeps a gate that only runs on some branches - such as the
+      // `if (persist) ensureWritable(config);` in `POST /workspaces/:id/activate` - from
+      // being read as an unconditional one.
+      const lines = text.slice(hit.index, end).split("\n");
+      const ensuresWritable = lines.some((line) => /^ {4}ensureWritable\(config\);$/.test(line));
+      let handlerScope: string | null = null;
+      for (const line of lines) {
+        const scopeMatch = line.match(/^ {4}requireClientScope\(ctx,\s*"(\w+)"\);$/);
+        if (scopeMatch) {
+          handlerScope = scopeMatch[1];
+          break;
+        }
+      }
+      // A single `addRoute` inside a `for (const method of [...])` loop registers one
+      // route per method; the only such loop is the MCP proxy.
+      const methods = hit.method ? [hit.method] : ["GET", "POST", "DELETE"];
+      for (const method of methods) {
+        facts.push({ method, path: hit.path, auth: hit.auth, ensuresWritable, handlerScope });
+      }
+    });
+  }
+  return facts;
+}
+
+const legacyFacts = readLegacyRouteFacts();
+const legacyKey = (method: string, path: string) => `${method} ${path}`;
+const legacyByKey = new Map(legacyFacts.map((fact) => [legacyKey(fact.method, fact.path), fact]));
+
+const config = { workspaces: [], readOnly: false } as unknown as ServerConfig;
+
+function moduleContext(legacyRoutes: () => Route[], overrides: Partial<ApiModuleContext> = {}): ApiModuleContext {
+  return {
+    config,
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+    readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+    resolveWorkspace: async () => ({ id: "w1" }),
+    services: { legacyRoutes },
+    ...overrides,
+  };
+}
+
+function requestContext(method: string, path: string, params: Record<string, string>, body?: string): RequestContext {
+  const url = new URL(`http://127.0.0.1:8787${path}`);
+  return {
+    request: new Request(url, body === undefined ? { method } : { method, body }),
+    url,
+    params,
+    config,
+    approvals: {} as RequestContext["approvals"],
+    reloadEvents: {} as RequestContext["reloadEvents"],
+    tokens: {} as RequestContext["tokens"],
+    actor: { type: "remote", scope: "collaborator" } as RequestContext["actor"],
+  };
+}
+
+function aliasFor(method: string, legacyPath: string): CompatAlias {
+  const alias = COMPAT_ALIASES.find((entry) => entry.method === method && entry.legacyPath === legacyPath);
+  if (!alias) throw new Error(`No alias for ${method} ${legacyPath}`);
+  return alias;
+}
+
+describe("compat alias table", () => {
+  test("every alias path follows the documented mapping rules", () => {
+    const wrong = COMPAT_ALIASES.filter((alias) => alias.path !== toV1Path(alias.legacyPath));
+    expect(wrong).toEqual([]);
+  });
+
+  test("maps a representative sample of legacy paths", () => {
+    const samples: [string, string, string][] = [
+      ["GET", "/workspaces", "/api/v1/workspaces"],
+      ["POST", "/workspaces/local", "/api/v1/workspaces/local"],
+      ["DELETE", "/workspaces/:id", "/api/v1/workspaces/:workspaceId"],
+      ["PATCH", "/workspaces/:id/display-name", "/api/v1/workspaces/:workspaceId/display-name"],
+      ["GET", "/workspace/:id/config", "/api/v1/workspaces/:workspaceId/config"],
+      ["DELETE", "/workspace/:id/mcp/:name", "/api/v1/workspaces/:workspaceId/mcp/:name"],
+      ["GET", "/health", "/api/v1/health"],
+      ["GET", "/status", "/api/v1/status"],
+      ["GET", "/capabilities", "/api/v1/capabilities"],
+      ["GET", "/tokens", "/api/v1/tokens"],
+      ["DELETE", "/tokens/:id", "/api/v1/tokens/:id"],
+      ["GET", "/approvals", "/api/v1/approvals"],
+      ["POST", "/approvals/:id", "/api/v1/approvals/:id"],
+      ["POST", "/files/sessions/:sessionId/read-batch", "/api/v1/files/sessions/:sessionId/read-batch"],
+      ["GET", "/files/sessions/:sessionId/catalog/snapshot", "/api/v1/files/sessions/:sessionId/catalog/snapshot"],
+    ];
+    for (const [method, legacyPath, expected] of samples) {
+      expect({ method, legacyPath, path: aliasFor(method, legacyPath).path }).toEqual({
+        method,
+        legacyPath,
+        path: expected,
+      });
+    }
+  });
+
+  test("route keys and operation ids are unique", () => {
+    const routeKeys = COMPAT_ALIASES.map((alias) => `${alias.method} ${alias.path}`);
+    const operationIds = COMPAT_ALIASES.map((alias) => alias.operationId);
+    expect(new Set(routeKeys).size).toBe(routeKeys.length);
+    expect(new Set(operationIds).size).toBe(operationIds.length);
+    expect(operationIds.every((id) => id.startsWith("compat"))).toBe(true);
+  });
+
+  test("alias and legacy templates carry the same parameters in the same order", () => {
+    for (const alias of COMPAT_ALIASES) {
+      const aliasParams = extractPathParams(alias.path);
+      const legacyParams = extractPathParams(alias.legacyPath);
+      expect({ path: alias.path, count: aliasParams.length }).toEqual({
+        path: alias.path,
+        count: legacyParams.length,
+      });
+    }
+  });
+
+  test("no alias falls inside a prefix owned by another module", () => {
+    const colliding = COMPAT_ALIASES.filter((alias) =>
+      COMPAT_RESERVED_V1_PREFIXES.some((prefix) => alias.path === prefix || alias.path.startsWith(`${prefix}/`)),
+    );
+    expect(colliding).toEqual([]);
+  });
+
+  test("template-sessions and blueprint routes are not mistaken for reserved session routes", () => {
+    expect(aliasFor("GET", "/workspace/:id/template-sessions").path).toBe(
+      "/api/v1/workspaces/:workspaceId/template-sessions",
+    );
+    expect(aliasFor("POST", "/workspace/:id/blueprint/sessions/materialize").path).toBe(
+      "/api/v1/workspaces/:workspaceId/blueprint/sessions/materialize",
+    );
+  });
+});
+
+describe("compat coverage of the legacy route table", () => {
+  test("every legacy route is either aliased or explicitly excluded", () => {
+    const aliased = new Set(COMPAT_ALIASES.map((alias) => legacyKey(alias.method, alias.legacyPath)));
+    const excluded = new Set(COMPAT_EXCLUDED_LEGACY_ROUTES.map((entry) => legacyKey(entry.method, entry.path)));
+    const unaccounted = legacyFacts
+      .map((fact) => legacyKey(fact.method, fact.path))
+      .filter((key) => !aliased.has(key) && !excluded.has(key));
+    expect(unaccounted).toEqual([]);
+    expect(aliased.size + excluded.size).toBe(legacyFacts.length);
+  });
+
+  test("every aliased and excluded entry refers to a real legacy route", () => {
+    const missing = [
+      ...COMPAT_ALIASES.map((alias) => legacyKey(alias.method, alias.legacyPath)),
+      ...COMPAT_EXCLUDED_LEGACY_ROUTES.map((entry) => legacyKey(entry.method, entry.path)),
+    ].filter((key) => !legacyByKey.has(key));
+    expect(missing).toEqual([]);
+  });
+
+  test("excluded routes really are excluded", () => {
+    const aliased = new Set(COMPAT_ALIASES.map((alias) => legacyKey(alias.method, alias.legacyPath)));
+    for (const excluded of COMPAT_EXCLUDED_LEGACY_ROUTES) {
+      const key = legacyKey(excluded.method, excluded.path);
+      expect({ key, aliased: aliased.has(key) }).toEqual({ key, aliased: false });
+    }
+    const excludedPaths = COMPAT_EXCLUDED_LEGACY_ROUTES.map((entry) => entry.path);
+    expect(excludedPaths).toContain("/ui");
+    expect(excludedPaths).toContain("/w/:id/ui");
+    expect(excludedPaths).toContain("/ui/assets/toy.js");
+    expect(excludedPaths).toContain("/mcp-proxy/:workspaceId/:name");
+    expect(excludedPaths).toContain("/whoami");
+    expect(excludedPaths).toContain("/workspace/:id/sessions");
+    // The `/opencode/*` proxy never reaches the route table at all.
+    expect(legacyFacts.some((fact) => fact.path.startsWith("/opencode"))).toBe(false);
+  });
+});
+
+describe("compat gating parity", () => {
+  test("auth mode is copied verbatim from the legacy route", () => {
+    const mismatches = COMPAT_ALIASES.filter(
+      (alias) => legacyByKey.get(legacyKey(alias.method, alias.legacyPath))?.auth !== alias.auth,
+    ).map((alias) => `${alias.method} ${alias.legacyPath}`);
+    expect(mismatches).toEqual([]);
+  });
+
+  test("declared scope is never stricter than the legacy handler's own check", () => {
+    const rank: Record<string, number> = { viewer: 1, collaborator: 2, owner: 3 };
+    const stricter = COMPAT_ALIASES.filter((alias) => {
+      const fact = legacyByKey.get(legacyKey(alias.method, alias.legacyPath));
+      if (!fact) return true;
+      if (fact.auth !== "client") return alias.scope !== "owner";
+      const legacyRequirement = fact.handlerScope ?? "viewer";
+      return rank[alias.scope] > rank[legacyRequirement];
+    }).map((alias) => `${alias.method} ${alias.legacyPath}`);
+    expect(stricter).toEqual([]);
+  });
+
+  test("the write gate is stricter than legacy only for the documented read-only cases", () => {
+    const stricter = COMPAT_ALIASES.filter((alias) => {
+      if (alias.effect === "read") return false;
+      return legacyByKey.get(legacyKey(alias.method, alias.legacyPath))?.ensuresWritable !== true;
+    }).map((alias) => `${alias.method} ${alias.legacyPath}`);
+    expect(stricter.sort()).toEqual([...COMPAT_READ_ONLY_STRICTER].sort());
+  });
+
+  test("every alias whose legacy handler gates writes declares a non-read effect", () => {
+    const understated = COMPAT_ALIASES.filter(
+      (alias) =>
+        alias.effect === "read" && legacyByKey.get(legacyKey(alias.method, alias.legacyPath))?.ensuresWritable === true,
+    ).map((alias) => `${alias.method} ${alias.legacyPath}`);
+    expect(understated).toEqual([]);
+  });
+
+  test("effect follows the HTTP method unless the alias is a documented read-shaped POST", () => {
+    for (const alias of COMPAT_ALIASES) {
+      if (alias.method === "GET") expect(alias.effect).toBe("read");
+      if (alias.method === "DELETE") expect(["destructive", "read"]).toContain(alias.effect);
+    }
+    expect(aliasFor("POST", "/workspace/:id/import/preview").effect).toBe("read");
+    expect(aliasFor("POST", "/workspace/:id/plugin-packages/validate").effect).toBe("read");
+    expect(aliasFor("POST", "/files/sessions/:sessionId/read-batch").effect).toBe("read");
+    expect(aliasFor("POST", "/workspace/:id/engine/deepseek-harness/rpc").effect).toBe("read");
+    expect(aliasFor("POST", "/files/sessions/:sessionId/write-batch").effect).toBe("write");
+    expect(aliasFor("POST", "/workspace/:id/skills").effect).toBe("write");
+    expect(aliasFor("DELETE", "/workspace/:id/skills/:name").effect).toBe("destructive");
+  });
+});
+
+describe("buildLegacyPath", () => {
+  test("renames :workspaceId back to the legacy :id", () => {
+    const alias = aliasFor("GET", "/workspace/:id/config");
+    expect(buildLegacyPath(alias, { workspaceId: "w1" })).toBe("/workspace/w1/config");
+  });
+
+  test("substitutes multiple parameters positionally and percent-encodes them", () => {
+    const alias = aliasFor("POST", "/workspace/:id/plugin-packages/:pluginId/authorization/:methodId/start");
+    expect(buildLegacyPath(alias, { workspaceId: "w 1", pluginId: "a/b", methodId: "oauth" })).toBe(
+      "/workspace/w%201/plugin-packages/a%2Fb/authorization/oauth/start",
+    );
+  });
+
+  test("throws 400 when a path parameter is missing", () => {
+    const alias = aliasFor("GET", "/workspace/:id/config");
+    try {
+      buildLegacyPath(alias, {});
+      throw new Error("expected buildLegacyPath to throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { status: number }).status).toBe(400);
+      expect((error as { code: string }).code).toBe("compat_missing_path_param");
+    }
+  });
+});
+
+describe("compat re-dispatch", () => {
+  function stubLegacyRoutes() {
+    const seen: { path: string; params: Record<string, string>; query: string; body: string; method: string }[] = [];
+    const routes: Route[] = [];
+    addRoute(routes, "GET", "/workspace/:id/config", "client", async (ctx) => {
+      seen.push({
+        path: ctx.url.pathname,
+        params: ctx.params,
+        query: ctx.url.search,
+        body: "",
+        method: ctx.request.method,
+      });
+      return Response.json({ route: "config", workspace: ctx.params.id });
+    });
+    addRoute(routes, "POST", "/workspace/:id/skills", "client", async (ctx) => {
+      seen.push({
+        path: ctx.url.pathname,
+        params: ctx.params,
+        query: ctx.url.search,
+        body: await ctx.request.text(),
+        method: ctx.request.method,
+      });
+      return Response.json({ route: "skills" }, { status: 201 });
+    });
+    addRoute(routes, "GET", "/workspace/:id/skills/:name", "client", async (ctx) =>
+      Response.json({ route: "skill", name: ctx.params.name }),
+    );
+    return { routes, seen };
+  }
+
+  test("re-dispatches to the matching legacy handler with params preserved", async () => {
+    const { routes, seen } = stubLegacyRoutes();
+    const handler = createCompatHandler(aliasFor("GET", "/workspace/:id/config"), () => routes);
+    const response = await handler(
+      requestContext("GET", "/api/v1/workspaces/w1/config?deep=true", { workspaceId: "w1" }),
+    );
+
+    expect(await response.json()).toEqual({ route: "config", workspace: "w1" });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].path).toBe("/workspace/w1/config");
+    expect(seen[0].params).toEqual({ id: "w1" });
+    expect(seen[0].query).toBe("?deep=true");
+  });
+
+  test("preserves method, status and request body", async () => {
+    const { routes, seen } = stubLegacyRoutes();
+    const handler = createCompatHandler(aliasFor("POST", "/workspace/:id/skills"), () => routes);
+    const response = await handler(
+      requestContext("POST", "/api/v1/workspaces/w1/skills", { workspaceId: "w1" }, JSON.stringify({ name: "demo" })),
+    );
+
+    expect(response.status).toBe(201);
+    expect(seen[0].method).toBe("POST");
+    expect(seen[0].body).toBe(JSON.stringify({ name: "demo" }));
+  });
+
+  test("picks the legacy route that matches the alias, not a sibling", async () => {
+    const { routes } = stubLegacyRoutes();
+    const handler = createCompatHandler(aliasFor("GET", "/workspace/:id/skills/:name"), () => routes);
+    const response = await handler(
+      requestContext("GET", "/api/v1/workspaces/w1/skills/demo", { workspaceId: "w1", name: "demo" }),
+    );
+    expect(await response.json()).toEqual({ route: "skill", name: "demo" });
+  });
+
+  test("decodes an encoded path parameter exactly as the legacy dispatcher would", async () => {
+    const { routes } = stubLegacyRoutes();
+    const handler = createCompatHandler(aliasFor("GET", "/workspace/:id/skills/:name"), () => routes);
+    const response = await handler(
+      requestContext("GET", "/api/v1/workspaces/w1/skills/a%2Fb", { workspaceId: "w1", name: "a/b" }),
+    );
+    expect(await response.json()).toEqual({ route: "skill", name: "a/b" });
+  });
+
+  test("fails loudly when the legacy route is gone", async () => {
+    const handler = createCompatHandler(aliasFor("GET", "/workspace/:id/config"), () => []);
+    try {
+      await handler(requestContext("GET", "/api/v1/workspaces/w1/config", { workspaceId: "w1" }));
+      throw new Error("expected the handler to throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { code: string }).code).toBe("compat_legacy_route_missing");
+      expect((error as { status: number }).status).toBe(500);
+    }
+  });
+
+  test("reads the legacy route table lazily, so it may be populated after registration", async () => {
+    const routes: Route[] = [];
+    const handler = createCompatHandler(aliasFor("GET", "/workspace/:id/config"), () => routes);
+    addRoute(routes, "GET", "/workspace/:id/config", "client", async (ctx) =>
+      Response.json({ late: true, workspace: ctx.params.id }),
+    );
+    const response = await handler(requestContext("GET", "/api/v1/workspaces/w1/config", { workspaceId: "w1" }));
+    expect(await response.json()).toEqual({ late: true, workspace: "w1" });
+  });
+});
+
+describe("compat module registration", () => {
+  test("registers one route per alias with the declared auth mode", () => {
+    const routes: Route[] = [];
+    const result = registerApiModules(routes, [compatModule], moduleContext(() => []));
+    expect(result.operations).toHaveLength(COMPAT_ALIASES.length);
+    expect(routes).toHaveLength(COMPAT_ALIASES.length);
+    const healthOperation = result.operations.find((operation) => operation.path === "/api/v1/health");
+    expect(healthOperation?.auth).toBe("none");
+    expect(healthOperation?.summary).toBe("Alias of GET /health");
+    const hostOperation = result.operations.find((operation) => operation.path === "/api/v1/tokens" && operation.method === "POST");
+    expect(hostOperation?.auth).toBe("host");
+  });
+
+  test("refuses to register without the legacy route table", () => {
+    try {
+      registerApiModules([], [compatModule], moduleContext(() => [], { services: {} }));
+      throw new Error("expected registration to throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { code: string }).code).toBe("compat_legacy_routes_unavailable");
+    }
+  });
+
+  test("the registry gates apply the declared scope and skip the write gate for read aliases", async () => {
+    const calls: string[] = [];
+    const legacy: Route[] = [];
+    addRoute(legacy, "POST", "/files/sessions/:sessionId/read-batch", "client", async () => Response.json({ ok: true }));
+    addRoute(legacy, "POST", "/files/sessions/:sessionId/write-batch", "client", async () => Response.json({ ok: true }));
+
+    const routes: Route[] = [];
+    registerApiModules(
+      routes,
+      [compatModule],
+      moduleContext(() => legacy, {
+        ensureWritable: () => {
+          calls.push("ensureWritable");
+        },
+        requireClientScope: (_ctx, required) => {
+          calls.push(`scope:${required}`);
+        },
+      }),
+    );
+
+    const readRoute = routes.find((route) => route.method === "POST" && route.regex.test("/api/v1/files/sessions/s1/read-batch"));
+    await readRoute?.handler(requestContext("POST", "/api/v1/files/sessions/s1/read-batch", { sessionId: "s1" }, "{}"));
+    expect(calls).toEqual(["scope:viewer"]);
+
+    calls.length = 0;
+    const writeRoute = routes.find((route) => route.method === "POST" && route.regex.test("/api/v1/files/sessions/s1/write-batch"));
+    await writeRoute?.handler(requestContext("POST", "/api/v1/files/sessions/s1/write-batch", { sessionId: "s1" }, "{}"));
+    expect(calls).toEqual(["ensureWritable", "scope:collaborator"]);
+  });
+});

--- a/apps/server/src/api/modules/compat/module.ts
+++ b/apps/server/src/api/modules/compat/module.ts
@@ -1,0 +1,421 @@
+import { ApiError } from "../../../errors.js";
+import { matchRoute, type AuthMode, type RequestContext, type Route } from "../../../routes/registry.js";
+import type { TokenScope } from "../../../types.js";
+import type { ApiEffect, ApiModule, ApiModuleContext, ApiOperation, HttpMethod } from "../../module.js";
+
+/**
+ * The `compat` module republishes the pre-existing (legacy) route table under the
+ * versioned `/api/v1` prefix, so an integrator has one coherent surface instead of a
+ * mix of old and new paths. Nothing is reimplemented: every alias re-dispatches into
+ * the very same legacy handler, so the two paths cannot drift.
+ *
+ * Path mapping rules
+ * ------------------
+ * - `/workspaces`            -> `/api/v1/workspaces`
+ * - `/workspaces/:id/...`    -> `/api/v1/workspaces/:workspaceId/...`
+ * - `/workspace/:id/...`     -> `/api/v1/workspaces/:workspaceId/...`  (singular becomes plural)
+ * - everything else `/x/...` -> `/api/v1/x/...`                        (`/tokens`, `/approvals`,
+ *   `/health`, `/status`, `/capabilities`, `/env`, `/files/sessions/...`, ...)
+ *
+ * Deliberately NOT aliased (see `COMPAT_EXCLUDED_LEGACY_ROUTES`)
+ * -------------------------------------------------------------
+ * - the toy UI (`/ui`, `/w/:id/ui`, `/ui/assets/*`) - a bundled demo page, not a contract;
+ * - the raw OpenCode proxy (`/opencode/*`, `/w/:id/opencode/*`) - it forwards an upstream
+ *   product's private surface verbatim and is intercepted in `server.ts` before the route
+ *   table is consulted, so it is not even a `Route` this module could alias;
+ * - the `/w/:id/...` mount aliases - a base-URL convenience that already duplicates the
+ *   unprefixed routes; a versioned surface should have exactly one spelling per operation;
+ * - browser redirect targets (`/mcp/oauth/callback`, the unauthenticated plugin
+ *   authorization callback) and the raw `/mcp-proxy/*` passthrough - these URLs are handed
+ *   to third parties or to an MCP transport, so a second spelling buys nothing;
+ * - `/dev/log` - an unauthenticated local development log sink.
+ *
+ * Reserved paths (owned by other modules, see `COMPAT_RESERVED_V1_PREFIXES`)
+ * -------------------------------------------------------------------------
+ * `registerApiModules` throws on a duplicate route, so the legacy session routes and
+ * `/whoami` are excluded here and re-published by the `sessions` / `policy` modules with
+ * first-class schemas.
+ *
+ * Gating: how double-gating is avoided
+ * ------------------------------------
+ * `registerApiModules` wraps every operation with `ensureWritable` (when `effect !== "read"`)
+ * and `requireClientScope(scope)` (when `auth === "client"`), while the legacy handlers run
+ * their own copies of those checks. Double-gating is only a problem if the wrapper is
+ * *stricter* than the legacy route, so each alias is declared to be at most as strict:
+ *
+ * - `auth` is copied verbatim from the legacy `addRoute` call, so the dispatcher performs
+ *   exactly the same authentication (`none` / `client` / `host` / `host-token`).
+ * - `scope` is the scope the legacy handler itself demands *unconditionally*
+ *   (`requireClientScope(ctx, "collaborator")` as the first statement); where the legacy
+ *   handler applies no check, or applies one only on some branches (e.g. the DeepSeek
+ *   Harness RPC only demands `collaborator` for non-read methods), the alias declares
+ *   `viewer` - the weakest scope any authenticated client token already has - and lets the
+ *   legacy handler perform its own, finer-grained check. For `host` / `host-token` routes
+ *   the wrapper skips the scope check entirely; `owner` is declared for documentation only.
+ * - `effect` follows the HTTP method (GET -> read, DELETE -> destructive, else write),
+ *   except for the non-GET legacy routes that never mutate anything (validate / preview /
+ *   export / package / batch-read / connectivity probe) or that decide read-vs-write from
+ *   the request payload inside the handler (`/experimental/extensions/call`, the DeepSeek
+ *   Harness RPC envelope). Those declare `read` so the alias does not reject on a read-only
+ *   server what the legacy path serves.
+ *
+ * `COMPAT_READ_ONLY_STRICTER` lists the 13 aliases that remain stricter than their legacy
+ * twin, and only when the server runs read-only: their legacy handler mutates state but
+ * forgot to call `ensureWritable`. The divergence is fail-closed (never fail-open) and is
+ * documented rather than silently papered over.
+ */
+
+export interface CompatAlias {
+  /** Unique across all modules; prefixed with `compat` so it cannot clash with a first-class module. */
+  operationId: string;
+  method: HttpMethod;
+  /** Path in the legacy route table, in `addRoute` syntax. */
+  legacyPath: string;
+  /** Path published under `/api/v1`, in `addRoute` syntax. */
+  path: string;
+  /** Copied verbatim from the legacy `addRoute` call. */
+  auth: AuthMode;
+  effect: ApiEffect;
+  /** Never stricter than the legacy handler's own unconditional check. */
+  scope: TokenScope;
+}
+
+/** Returns the assembled legacy route table. Late-bound: the table is built after modules register. */
+export type LegacyRoutesProvider = () => Route[];
+
+export interface CompatModuleServices {
+  legacyRoutes: LegacyRoutesProvider;
+}
+
+export const COMPAT_MODULE_ID = "compat";
+
+/** Path prefixes owned by other API modules. No alias may fall inside one of these. */
+export const COMPAT_RESERVED_V1_PREFIXES: readonly string[] = [
+  "/api/v1/workspaces/:workspaceId/sessions",
+  "/api/v1/tasks",
+  "/api/v1/webhooks",
+  "/api/v1/whoami",
+  "/api/v1/tokens/:tokenId/policy",
+];
+
+export type CompatExclusionReason =
+  | "toy-ui"
+  | "mount-alias"
+  | "dev-only"
+  | "browser-callback"
+  | "raw-proxy"
+  | "reserved-sessions"
+  | "reserved-policy";
+
+export interface CompatExcludedRoute {
+  method: string;
+  path: string;
+  reason: CompatExclusionReason;
+}
+
+/** Legacy routes intentionally left off `/api/v1`. */
+export const COMPAT_EXCLUDED_LEGACY_ROUTES: readonly CompatExcludedRoute[] = [
+  { method: "GET", path: "/workspace/:id/plugin-packages/:pluginId/authorization/callback", reason: "browser-callback" },
+  { method: "GET", path: "/mcp/oauth/callback", reason: "browser-callback" },
+  { method: "GET", path: "/mcp-proxy/:workspaceId/:name", reason: "raw-proxy" },
+  { method: "POST", path: "/mcp-proxy/:workspaceId/:name", reason: "raw-proxy" },
+  { method: "DELETE", path: "/mcp-proxy/:workspaceId/:name", reason: "raw-proxy" },
+  { method: "GET", path: "/w/:id/health", reason: "mount-alias" },
+  { method: "POST", path: "/dev/log", reason: "dev-only" },
+  { method: "GET", path: "/dev/log", reason: "dev-only" },
+  { method: "GET", path: "/ui", reason: "toy-ui" },
+  { method: "GET", path: "/w/:id/ui", reason: "mount-alias" },
+  { method: "GET", path: "/ui/assets/toy.css", reason: "toy-ui" },
+  { method: "GET", path: "/ui/assets/toy.js", reason: "toy-ui" },
+  { method: "GET", path: "/ui/assets/ipollowork-mark.svg", reason: "toy-ui" },
+  { method: "GET", path: "/w/:id/status", reason: "mount-alias" },
+  { method: "GET", path: "/w/:id/capabilities", reason: "mount-alias" },
+  { method: "GET", path: "/w/:id/workspaces", reason: "mount-alias" },
+  { method: "GET", path: "/w/:id/runtime/versions", reason: "mount-alias" },
+  { method: "POST", path: "/w/:id/runtime/upgrade", reason: "mount-alias" },
+  { method: "GET", path: "/whoami", reason: "reserved-policy" },
+  { method: "GET", path: "/workspace/:id/sessions", reason: "reserved-sessions" },
+  { method: "GET", path: "/workspace/:id/sessions/:sessionId", reason: "reserved-sessions" },
+  { method: "GET", path: "/workspace/:id/sessions/:sessionId/messages", reason: "reserved-sessions" },
+  { method: "GET", path: "/workspace/:id/sessions/:sessionId/snapshot", reason: "reserved-sessions" },
+  { method: "DELETE", path: "/workspace/:id/sessions/:sessionId", reason: "reserved-sessions" },
+];
+
+/**
+ * `"<METHOD> <legacyPath>"` for aliases whose write gate is stricter than the legacy route.
+ * Every entry mutates state but its legacy handler never calls `ensureWritable`, so the
+ * alias rejects with `403 read_only` on a read-only server where the legacy path succeeds.
+ */
+export const COMPAT_READ_ONLY_STRICTER: readonly string[] = [
+  "POST /runtime/upgrade",
+  "POST /experimental/google-workspace/connect/start",
+  "POST /experimental/google-workspace/disconnect",
+  "POST /experimental/google-workspace/active-account",
+  "PUT /env/status",
+  "POST /voice/realtime/session",
+  "POST /workspace/:id/files/sessions",
+  "POST /files/sessions/:sessionId/renew",
+  "DELETE /files/sessions/:sessionId",
+  "POST /workspaces/:id/activate",
+  "POST /workspace/:id/engine/reload",
+  "POST /approvals/:id",
+  "POST /workspace/:id/engine/deepseek-harness/respond",
+];
+
+/** The full legacy -> v1 alias table. */
+export const COMPAT_ALIASES: readonly CompatAlias[] = [
+  { operationId: "compatGetWorkspacesByWorkspaceIdTemplates", method: "GET", legacyPath: "/workspace/:id/templates", path: "/api/v1/workspaces/:workspaceId/templates", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdHyperframesCatalog", method: "GET", legacyPath: "/workspace/:id/hyperframes-catalog", path: "/api/v1/workspaces/:workspaceId/hyperframes-catalog", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdTemplatesByTemplateIdCover", method: "GET", legacyPath: "/workspace/:id/templates/:templateId/cover", path: "/api/v1/workspaces/:workspaceId/templates/:templateId/cover", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdTemplatesByTemplateIdPackage", method: "GET", legacyPath: "/workspace/:id/templates/:templateId/package", path: "/api/v1/workspaces/:workspaceId/templates/:templateId/package", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesImport", method: "POST", legacyPath: "/workspace/:id/templates/import", path: "/api/v1/workspaces/:workspaceId/templates/import", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesFromSessionPackage", method: "POST", legacyPath: "/workspace/:id/templates/from-session/package", path: "/api/v1/workspaces/:workspaceId/templates/from-session/package", auth: "client", effect: "read", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesFromSession", method: "POST", legacyPath: "/workspace/:id/templates/from-session", path: "/api/v1/workspaces/:workspaceId/templates/from-session", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesAuthoringSessions", method: "POST", legacyPath: "/workspace/:id/templates/authoring-sessions", path: "/api/v1/workspaces/:workspaceId/templates/authoring-sessions", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesFromSessionValidate", method: "POST", legacyPath: "/workspace/:id/templates/from-session/validate", path: "/api/v1/workspaces/:workspaceId/templates/from-session/validate", auth: "client", effect: "read", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesByTemplateIdInstall", method: "POST", legacyPath: "/workspace/:id/templates/:templateId/install", path: "/api/v1/workspaces/:workspaceId/templates/:templateId/install", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdTemplatesByTemplateId", method: "DELETE", legacyPath: "/workspace/:id/templates/:templateId", path: "/api/v1/workspaces/:workspaceId/templates/:templateId", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplatesByTemplateIdMaterialize", method: "POST", legacyPath: "/workspace/:id/templates/:templateId/materialize", path: "/api/v1/workspaces/:workspaceId/templates/:templateId/materialize", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdTemplateSessionsBySessionIdAdoptVideo", method: "POST", legacyPath: "/workspace/:id/template-sessions/:sessionId/adopt-video", path: "/api/v1/workspaces/:workspaceId/template-sessions/:sessionId/adopt-video", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdTemplateSessions", method: "GET", legacyPath: "/workspace/:id/template-sessions", path: "/api/v1/workspaces/:workspaceId/template-sessions", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdTemplateSessionsBySessionId", method: "GET", legacyPath: "/workspace/:id/template-sessions/:sessionId", path: "/api/v1/workspaces/:workspaceId/template-sessions/:sessionId", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdConfig", method: "GET", legacyPath: "/workspace/:id/config", path: "/api/v1/workspaces/:workspaceId/config", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdDesktopCloudSync", method: "GET", legacyPath: "/workspace/:id/desktop-cloud-sync", path: "/api/v1/workspaces/:workspaceId/desktop-cloud-sync", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdDesktopCloudSync", method: "POST", legacyPath: "/workspace/:id/desktop-cloud-sync", path: "/api/v1/workspaces/:workspaceId/desktop-cloud-sync", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdCloudPlugins", method: "GET", legacyPath: "/workspace/:id/cloud-plugins", path: "/api/v1/workspaces/:workspaceId/cloud-plugins", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdCloudPlugins", method: "POST", legacyPath: "/workspace/:id/cloud-plugins", path: "/api/v1/workspaces/:workspaceId/cloud-plugins", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdClaudePlugins", method: "POST", legacyPath: "/workspace/:id/claude-plugins", path: "/api/v1/workspaces/:workspaceId/claude-plugins", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdCloudPluginsByPluginId", method: "DELETE", legacyPath: "/workspace/:id/cloud-plugins/:pluginId", path: "/api/v1/workspaces/:workspaceId/cloud-plugins/:pluginId", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdPluginPackages", method: "GET", legacyPath: "/workspace/:id/plugin-packages", path: "/api/v1/workspaces/:workspaceId/plugin-packages", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdPluginPackagesCatalog", method: "GET", legacyPath: "/workspace/:id/plugin-packages/catalog", path: "/api/v1/workspaces/:workspaceId/plugin-packages/catalog", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesCatalogByPluginIdInstall", method: "POST", legacyPath: "/workspace/:id/plugin-packages/catalog/:pluginId/install", path: "/api/v1/workspaces/:workspaceId/plugin-packages/catalog/:pluginId/install", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesImportValidate", method: "POST", legacyPath: "/workspace/:id/plugin-packages/import/validate", path: "/api/v1/workspaces/:workspaceId/plugin-packages/import/validate", auth: "client", effect: "read", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesImport", method: "POST", legacyPath: "/workspace/:id/plugin-packages/import", path: "/api/v1/workspaces/:workspaceId/plugin-packages/import", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesValidate", method: "POST", legacyPath: "/workspace/:id/plugin-packages/validate", path: "/api/v1/workspaces/:workspaceId/plugin-packages/validate", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackages", method: "POST", legacyPath: "/workspace/:id/plugin-packages", path: "/api/v1/workspaces/:workspaceId/plugin-packages", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesByPluginIdUpdate", method: "POST", legacyPath: "/workspace/:id/plugin-packages/:pluginId/update", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/update", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesByPluginIdRollback", method: "POST", legacyPath: "/workspace/:id/plugin-packages/:pluginId/rollback", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/rollback", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPatchWorkspacesByWorkspaceIdPluginPackagesByPluginId", method: "PATCH", legacyPath: "/workspace/:id/plugin-packages/:pluginId", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPatchWorkspacesByWorkspaceIdPluginPackagesByPluginIdResourcesByResourceId", method: "PATCH", legacyPath: "/workspace/:id/plugin-packages/:pluginId/resources/:resourceId", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/resources/:resourceId", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdPluginPackagesByPluginId", method: "DELETE", legacyPath: "/workspace/:id/plugin-packages/:pluginId", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorization", method: "GET", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorizationByMethodIdCredentials", method: "POST", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization/:methodId/credentials", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization/:methodId/credentials", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorizationByMethodIdStart", method: "POST", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization/:methodId/start", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization/:methodId/start", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorizationCallback", method: "POST", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization/callback", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization/callback", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorizationDeviceByFlowIdPoll", method: "POST", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization/device/:flowId/poll", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization/device/:flowId/poll", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorizationFlowsByFlowId", method: "DELETE", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization/flows/:flowId", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization/flows/:flowId", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdPluginPackagesByPluginIdAuthorizationByAccountId", method: "DELETE", legacyPath: "/workspace/:id/plugin-packages/:pluginId/authorization/:accountId", path: "/api/v1/workspaces/:workspaceId/plugin-packages/:pluginId/authorization/:accountId", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdAuthorizedFolders", method: "GET", legacyPath: "/workspace/:id/authorized-folders", path: "/api/v1/workspaces/:workspaceId/authorized-folders", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPutWorkspacesByWorkspaceIdAuthorizedFolders", method: "PUT", legacyPath: "/workspace/:id/authorized-folders", path: "/api/v1/workspaces/:workspaceId/authorized-folders", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdRuntimeConfigMigrate", method: "POST", legacyPath: "/workspace/:id/runtime-config/migrate", path: "/api/v1/workspaces/:workspaceId/runtime-config/migrate", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdRuntimeConfig", method: "GET", legacyPath: "/workspace/:id/runtime-config", path: "/api/v1/workspaces/:workspaceId/runtime-config", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdOpencodeConfig", method: "GET", legacyPath: "/workspace/:id/opencode-config", path: "/api/v1/workspaces/:workspaceId/opencode-config", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdOpencodeConfig", method: "POST", legacyPath: "/workspace/:id/opencode-config", path: "/api/v1/workspaces/:workspaceId/opencode-config", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdAudit", method: "GET", legacyPath: "/workspace/:id/audit", path: "/api/v1/workspaces/:workspaceId/audit", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPatchWorkspacesByWorkspaceIdConfig", method: "PATCH", legacyPath: "/workspace/:id/config", path: "/api/v1/workspaces/:workspaceId/config", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdPlugins", method: "GET", legacyPath: "/workspace/:id/plugins", path: "/api/v1/workspaces/:workspaceId/plugins", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdPlugins", method: "POST", legacyPath: "/workspace/:id/plugins", path: "/api/v1/workspaces/:workspaceId/plugins", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdPluginsByName", method: "DELETE", legacyPath: "/workspace/:id/plugins/:name", path: "/api/v1/workspaces/:workspaceId/plugins/:name", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatGetHubSkills", method: "GET", legacyPath: "/hub/skills", path: "/api/v1/hub/skills", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdSkills", method: "GET", legacyPath: "/workspace/:id/skills", path: "/api/v1/workspaces/:workspaceId/skills", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdSkillsHubByName", method: "POST", legacyPath: "/workspace/:id/skills/hub/:name", path: "/api/v1/workspaces/:workspaceId/skills/hub/:name", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdSkillsByName", method: "GET", legacyPath: "/workspace/:id/skills/:name", path: "/api/v1/workspaces/:workspaceId/skills/:name", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdSkills", method: "POST", legacyPath: "/workspace/:id/skills", path: "/api/v1/workspaces/:workspaceId/skills", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdSkillsByName", method: "DELETE", legacyPath: "/workspace/:id/skills/:name", path: "/api/v1/workspaces/:workspaceId/skills/:name", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdMcp", method: "GET", legacyPath: "/workspace/:id/mcp", path: "/api/v1/workspaces/:workspaceId/mcp", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdExtensionsExport", method: "POST", legacyPath: "/workspace/:id/extensions/export", path: "/api/v1/workspaces/:workspaceId/extensions/export", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdMcp", method: "POST", legacyPath: "/workspace/:id/mcp", path: "/api/v1/workspaces/:workspaceId/mcp", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdMcpByName", method: "DELETE", legacyPath: "/workspace/:id/mcp/:name", path: "/api/v1/workspaces/:workspaceId/mcp/:name", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdMcpByNameEnabled", method: "POST", legacyPath: "/workspace/:id/mcp/:name/enabled", path: "/api/v1/workspaces/:workspaceId/mcp/:name/enabled", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdMcpByNameAuth", method: "DELETE", legacyPath: "/workspace/:id/mcp/:name/auth", path: "/api/v1/workspaces/:workspaceId/mcp/:name/auth", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdMcpByNameAuthStart", method: "POST", legacyPath: "/workspace/:id/mcp/:name/auth/start", path: "/api/v1/workspaces/:workspaceId/mcp/:name/auth/start", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdMcpByNameAuth", method: "GET", legacyPath: "/workspace/:id/mcp/:name/auth", path: "/api/v1/workspaces/:workspaceId/mcp/:name/auth", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdCommands", method: "GET", legacyPath: "/workspace/:id/commands", path: "/api/v1/workspaces/:workspaceId/commands", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdCommands", method: "POST", legacyPath: "/workspace/:id/commands", path: "/api/v1/workspaces/:workspaceId/commands", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceIdCommandsByName", method: "DELETE", legacyPath: "/workspace/:id/commands/:name", path: "/api/v1/workspaces/:workspaceId/commands/:name", auth: "client", effect: "destructive", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdExport", method: "GET", legacyPath: "/workspace/:id/export", path: "/api/v1/workspaces/:workspaceId/export", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdImportPreview", method: "POST", legacyPath: "/workspace/:id/import/preview", path: "/api/v1/workspaces/:workspaceId/import/preview", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdImport", method: "POST", legacyPath: "/workspace/:id/import", path: "/api/v1/workspaces/:workspaceId/import", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdBlueprintSessionsMaterialize", method: "POST", legacyPath: "/workspace/:id/blueprint/sessions/materialize", path: "/api/v1/workspaces/:workspaceId/blueprint/sessions/materialize", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetHealth", method: "GET", legacyPath: "/health", path: "/api/v1/health", auth: "none", effect: "read", scope: "owner" },
+  { operationId: "compatGetStatus", method: "GET", legacyPath: "/status", path: "/api/v1/status", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetRuntimeVersions", method: "GET", legacyPath: "/runtime/versions", path: "/api/v1/runtime/versions", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostRuntimeUpgrade", method: "POST", legacyPath: "/runtime/upgrade", path: "/api/v1/runtime/upgrade", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatGetCapabilities", method: "GET", legacyPath: "/capabilities", path: "/api/v1/capabilities", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetExperimentalConnectState", method: "GET", legacyPath: "/experimental/connect/state", path: "/api/v1/experimental/connect/state", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPutExperimentalConnectState", method: "PUT", legacyPath: "/experimental/connect/state", path: "/api/v1/experimental/connect/state", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatGetExperimentalExtensionsActions", method: "GET", legacyPath: "/experimental/extensions/actions", path: "/api/v1/experimental/extensions/actions", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostExperimentalExtensionsCall", method: "POST", legacyPath: "/experimental/extensions/call", path: "/api/v1/experimental/extensions/call", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetExperimentalGoogleWorkspaceStatus", method: "GET", legacyPath: "/experimental/google-workspace/status", path: "/api/v1/experimental/google-workspace/status", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostExperimentalGoogleWorkspaceConnectStart", method: "POST", legacyPath: "/experimental/google-workspace/connect/start", path: "/api/v1/experimental/google-workspace/connect/start", auth: "client", effect: "write", scope: "viewer" },
+  { operationId: "compatGetExperimentalGoogleWorkspaceConnectStatusByFlowId", method: "GET", legacyPath: "/experimental/google-workspace/connect/status/:flowId", path: "/api/v1/experimental/google-workspace/connect/status/:flowId", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostExperimentalGoogleWorkspaceDisconnect", method: "POST", legacyPath: "/experimental/google-workspace/disconnect", path: "/api/v1/experimental/google-workspace/disconnect", auth: "client", effect: "write", scope: "viewer" },
+  { operationId: "compatPostExperimentalGoogleWorkspaceActiveAccount", method: "POST", legacyPath: "/experimental/google-workspace/active-account", path: "/api/v1/experimental/google-workspace/active-account", auth: "client", effect: "write", scope: "viewer" },
+  { operationId: "compatPostExperimentalGoogleWorkspaceTest", method: "POST", legacyPath: "/experimental/google-workspace/test", path: "/api/v1/experimental/google-workspace/test", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostExperimentalGoogleWorkspaceSmokeTest", method: "POST", legacyPath: "/experimental/google-workspace/smoke-test", path: "/api/v1/experimental/google-workspace/smoke-test", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspaces", method: "GET", legacyPath: "/workspaces", path: "/api/v1/workspaces", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetTokens", method: "GET", legacyPath: "/tokens", path: "/api/v1/tokens", auth: "host", effect: "read", scope: "owner" },
+  { operationId: "compatPostTokens", method: "POST", legacyPath: "/tokens", path: "/api/v1/tokens", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatDeleteTokensById", method: "DELETE", legacyPath: "/tokens/:id", path: "/api/v1/tokens/:id", auth: "host", effect: "destructive", scope: "owner" },
+  { operationId: "compatGetEnv", method: "GET", legacyPath: "/env", path: "/api/v1/env", auth: "host-token", effect: "read", scope: "owner" },
+  { operationId: "compatGetEnvKeys", method: "GET", legacyPath: "/env/keys", path: "/api/v1/env/keys", auth: "host-token", effect: "read", scope: "owner" },
+  { operationId: "compatGetEnvStatus", method: "GET", legacyPath: "/env/status", path: "/api/v1/env/status", auth: "host-token", effect: "read", scope: "owner" },
+  { operationId: "compatPutEnvStatus", method: "PUT", legacyPath: "/env/status", path: "/api/v1/env/status", auth: "host-token", effect: "write", scope: "owner" },
+  { operationId: "compatGetEnvByKey", method: "GET", legacyPath: "/env/:key", path: "/api/v1/env/:key", auth: "host-token", effect: "read", scope: "owner" },
+  { operationId: "compatPutEnv", method: "PUT", legacyPath: "/env", path: "/api/v1/env", auth: "host-token", effect: "write", scope: "owner" },
+  { operationId: "compatDeleteEnvByKey", method: "DELETE", legacyPath: "/env/:key", path: "/api/v1/env/:key", auth: "host-token", effect: "destructive", scope: "owner" },
+  { operationId: "compatGetAuthorizationServices", method: "GET", legacyPath: "/authorization-services", path: "/api/v1/authorization-services", auth: "host-token", effect: "read", scope: "owner" },
+  { operationId: "compatPutAuthorizationServicesByServiceIdCredentials", method: "PUT", legacyPath: "/authorization-services/:serviceId/credentials", path: "/api/v1/authorization-services/:serviceId/credentials", auth: "host-token", effect: "write", scope: "owner" },
+  { operationId: "compatPostAuthorizationServicesByServiceIdTest", method: "POST", legacyPath: "/authorization-services/:serviceId/test", path: "/api/v1/authorization-services/:serviceId/test", auth: "host-token", effect: "read", scope: "owner" },
+  { operationId: "compatPostVoiceRealtimeSession", method: "POST", legacyPath: "/voice/realtime/session", path: "/api/v1/voice/realtime/session", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdInbox", method: "GET", legacyPath: "/workspace/:id/inbox", path: "/api/v1/workspaces/:workspaceId/inbox", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdInboxByInboxId", method: "GET", legacyPath: "/workspace/:id/inbox/:inboxId", path: "/api/v1/workspaces/:workspaceId/inbox/:inboxId", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdInbox", method: "POST", legacyPath: "/workspace/:id/inbox", path: "/api/v1/workspaces/:workspaceId/inbox", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdArtifacts", method: "GET", legacyPath: "/workspace/:id/artifacts", path: "/api/v1/workspaces/:workspaceId/artifacts", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdArtifactsByArtifactId", method: "GET", legacyPath: "/workspace/:id/artifacts/:artifactId", path: "/api/v1/workspaces/:workspaceId/artifacts/:artifactId", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdArtifactsResolve", method: "POST", legacyPath: "/workspace/:id/artifacts/resolve", path: "/api/v1/workspaces/:workspaceId/artifacts/resolve", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdFilesSessions", method: "POST", legacyPath: "/workspace/:id/files/sessions", path: "/api/v1/workspaces/:workspaceId/files/sessions", auth: "client", effect: "write", scope: "viewer" },
+  { operationId: "compatPostFilesSessionsBySessionIdRenew", method: "POST", legacyPath: "/files/sessions/:sessionId/renew", path: "/api/v1/files/sessions/:sessionId/renew", auth: "client", effect: "write", scope: "viewer" },
+  { operationId: "compatDeleteFilesSessionsBySessionId", method: "DELETE", legacyPath: "/files/sessions/:sessionId", path: "/api/v1/files/sessions/:sessionId", auth: "client", effect: "destructive", scope: "viewer" },
+  { operationId: "compatGetFilesSessionsBySessionIdCatalogSnapshot", method: "GET", legacyPath: "/files/sessions/:sessionId/catalog/snapshot", path: "/api/v1/files/sessions/:sessionId/catalog/snapshot", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetFilesSessionsBySessionIdCatalogEvents", method: "GET", legacyPath: "/files/sessions/:sessionId/catalog/events", path: "/api/v1/files/sessions/:sessionId/catalog/events", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostFilesSessionsBySessionIdReadBatch", method: "POST", legacyPath: "/files/sessions/:sessionId/read-batch", path: "/api/v1/files/sessions/:sessionId/read-batch", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostFilesSessionsBySessionIdWriteBatch", method: "POST", legacyPath: "/files/sessions/:sessionId/write-batch", path: "/api/v1/files/sessions/:sessionId/write-batch", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostFilesSessionsBySessionIdOps", method: "POST", legacyPath: "/files/sessions/:sessionId/ops", path: "/api/v1/files/sessions/:sessionId/ops", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdFilesContent", method: "GET", legacyPath: "/workspace/:id/files/content", path: "/api/v1/workspaces/:workspaceId/files/content", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdFilesStat", method: "GET", legacyPath: "/workspace/:id/files/stat", path: "/api/v1/workspaces/:workspaceId/files/stat", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdFilesRaw", method: "GET", legacyPath: "/workspace/:id/files/raw", path: "/api/v1/workspaces/:workspaceId/files/raw", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdFilesRaw", method: "POST", legacyPath: "/workspace/:id/files/raw", path: "/api/v1/workspaces/:workspaceId/files/raw", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdFilesContent", method: "POST", legacyPath: "/workspace/:id/files/content", path: "/api/v1/workspaces/:workspaceId/files/content", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatPostWorkspacesLocal", method: "POST", legacyPath: "/workspaces/local", path: "/api/v1/workspaces/local", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatPostWorkspacesRemote", method: "POST", legacyPath: "/workspaces/remote", path: "/api/v1/workspaces/remote", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatPatchWorkspacesByWorkspaceIdDisplayName", method: "PATCH", legacyPath: "/workspaces/:id/display-name", path: "/api/v1/workspaces/:workspaceId/display-name", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdActivate", method: "POST", legacyPath: "/workspaces/:id/activate", path: "/api/v1/workspaces/:workspaceId/activate", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatDeleteWorkspacesByWorkspaceId", method: "DELETE", legacyPath: "/workspaces/:id", path: "/api/v1/workspaces/:workspaceId", auth: "host", effect: "destructive", scope: "owner" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdEvents", method: "GET", legacyPath: "/workspace/:id/events", path: "/api/v1/workspaces/:workspaceId/events", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdEngineReload", method: "POST", legacyPath: "/workspace/:id/engine/reload", path: "/api/v1/workspaces/:workspaceId/engine/reload", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetApprovals", method: "GET", legacyPath: "/approvals", path: "/api/v1/approvals", auth: "host", effect: "read", scope: "owner" },
+  { operationId: "compatPostApprovalsById", method: "POST", legacyPath: "/approvals/:id", path: "/api/v1/approvals/:id", auth: "host", effect: "write", scope: "owner" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdEngineDeepseekHarnessRpc", method: "POST", legacyPath: "/workspace/:id/engine/deepseek-harness/rpc", path: "/api/v1/workspaces/:workspaceId/engine/deepseek-harness/rpc", auth: "client", effect: "read", scope: "viewer" },
+  { operationId: "compatPostWorkspacesByWorkspaceIdEngineDeepseekHarnessRespond", method: "POST", legacyPath: "/workspace/:id/engine/deepseek-harness/respond", path: "/api/v1/workspaces/:workspaceId/engine/deepseek-harness/respond", auth: "client", effect: "write", scope: "collaborator" },
+  { operationId: "compatGetWorkspacesByWorkspaceIdEngineDeepseekHarnessEventsByStream", method: "GET", legacyPath: "/workspace/:id/engine/deepseek-harness/events/:stream", path: "/api/v1/workspaces/:workspaceId/engine/deepseek-harness/events/:stream", auth: "client", effect: "read", scope: "viewer" },
+];
+
+/**
+ * Applies the path mapping rules to a legacy path. Exported so the alias table can be
+ * checked against the rules rather than trusted.
+ */
+export function toV1Path(legacyPath: string): string {
+  if (legacyPath === "/workspaces") return "/api/v1/workspaces";
+  if (legacyPath.startsWith("/workspaces/")) {
+    return `/api/v1/workspaces/${legacyPath.slice("/workspaces/".length).replace(/^:id\b/, ":workspaceId")}`;
+  }
+  if (legacyPath.startsWith("/workspace/:id")) {
+    return `/api/v1/workspaces/:workspaceId${legacyPath.slice("/workspace/:id".length)}`;
+  }
+  return `/api/v1${legacyPath}`;
+}
+
+/** Ordered `:param` names of a route path. */
+export function extractPathParams(path: string): string[] {
+  return [...path.matchAll(/:([A-Za-z0-9_]+)/g)].map((match) => match[1]);
+}
+
+/**
+ * Rebuilds the concrete legacy path for a request that arrived on the alias.
+ *
+ * The two templates always carry the same parameters in the same order (the v1 path is
+ * derived from the legacy one), so parameters are substituted positionally; that keeps the
+ * `:id` -> `:workspaceId` rename from needing a per-route lookup table.
+ */
+export function buildLegacyPath(alias: CompatAlias, params: Record<string, string>): string {
+  const aliasParams = extractPathParams(alias.path);
+  let index = 0;
+  return alias.legacyPath.replace(/:([A-Za-z0-9_]+)/g, () => {
+    const name = aliasParams[index];
+    index += 1;
+    const value = name === undefined ? undefined : params[name];
+    if (value === undefined) {
+      throw new ApiError(400, "compat_missing_path_param", `Missing path parameter: ${name ?? "?"}`, {
+        operationId: alias.operationId,
+        path: alias.path,
+      });
+    }
+    return encodeURIComponent(value);
+  });
+}
+
+/**
+ * Re-dispatches a `/api/v1` request into the legacy route table.
+ *
+ * Method, headers and body travel on the original `Request` object, which is passed through
+ * untouched (no clone, so a streamed body is not buffered). Only `url` and `params` are
+ * rebuilt for the legacy path; the query string is preserved verbatim. Authentication has
+ * already happened in the dispatcher against the alias' own `auth` mode, which is identical
+ * to the legacy route's, so `ctx.actor` is exactly what the legacy handler would have seen.
+ */
+export function createCompatHandler(
+  alias: CompatAlias,
+  legacyRoutes: LegacyRoutesProvider,
+): (ctx: RequestContext) => Promise<Response> {
+  return async (ctx: RequestContext) => {
+    const legacyPath = buildLegacyPath(alias, ctx.params);
+    const matched = matchRoute(legacyRoutes(), alias.method, legacyPath);
+    if (!matched) {
+      throw new ApiError(500, "compat_legacy_route_missing", "Legacy route for this alias is not registered", {
+        operationId: alias.operationId,
+        method: alias.method,
+        legacyPath,
+      });
+    }
+    const legacyUrl = new URL(ctx.url.href);
+    legacyUrl.pathname = legacyPath;
+    return matched.handler({ ...ctx, url: legacyUrl, params: matched.params });
+  };
+}
+
+function resolveLegacyRoutes(context: ApiModuleContext): LegacyRoutesProvider {
+  const provider = (context.services as Partial<CompatModuleServices>).legacyRoutes;
+  if (typeof provider !== "function") {
+    throw new ApiError(
+      500,
+      "compat_legacy_routes_unavailable",
+      "The compat module requires services.legacyRoutes: () => Route[]",
+      { module: COMPAT_MODULE_ID },
+    );
+  }
+  return provider;
+}
+
+export const compatModule: ApiModule = {
+  id: COMPAT_MODULE_ID,
+  title: "Legacy compatibility",
+  description:
+    "Republishes every legacy iPolloWork route under /api/v1 by re-dispatching into the legacy "
+    + "route table. Mapping: /workspaces -> /api/v1/workspaces, /workspace/:id/... and "
+    + "/workspaces/:id/... -> /api/v1/workspaces/:workspaceId/..., everything else keeps its path "
+    + "under the /api/v1 prefix. The toy UI (/ui, /w/:id/ui, /ui/assets/*), the raw /opencode/* "
+    + "proxy, the /w/:id/* mount aliases, browser OAuth callbacks, /mcp-proxy/* and /dev/log are "
+    + "deliberately not aliased: they are not part of a stable public contract. Routes owned by the "
+    + "sessions and policy modules are excluded to avoid duplicate registrations. Each alias copies "
+    + "the legacy route's auth mode and declares a scope no stricter than the legacy handler's own "
+    + "check, so the module gates never reject a request the legacy path would accept.",
+  version: "1.0.0",
+  stability: "stable",
+  register(context: ApiModuleContext): ApiOperation[] {
+    const legacyRoutes = resolveLegacyRoutes(context);
+    return COMPAT_ALIASES.map((alias) => ({
+      operationId: alias.operationId,
+      method: alias.method,
+      path: alias.path,
+      summary: `Alias of ${alias.method} ${alias.legacyPath}`,
+      description:
+        `Compatibility alias. Re-dispatches to the legacy route ${alias.method} ${alias.legacyPath}, `
+        + "which stays available at its original path.",
+      effect: alias.effect,
+      auth: alias.auth,
+      scope: alias.scope,
+      handler: createCompatHandler(alias, legacyRoutes),
+    }));
+  },
+};

--- a/apps/server/src/api/modules/openapi/module.ts
+++ b/apps/server/src/api/modules/openapi/module.ts
@@ -1,0 +1,534 @@
+import { ApiError } from "../../../errors.js";
+import {
+  describeModules,
+  type ApiModule,
+  type ApiModuleContext,
+  type ApiModuleRegistryResult,
+  type ApiOperation,
+  type JsonSchema,
+} from "../../module.js";
+import { buildOpenApiDocument, type OpenApiDocument } from "../../openapi.js";
+
+/**
+ * The `openapi` module publishes the API's own description.
+ *
+ * It is the one module that has to read the registry it is registered into, so it takes a
+ * late-bound accessor from the services bag rather than a snapshot: at `register()` time the
+ * other modules have not necessarily been registered yet, and a snapshot would document a
+ * half-built API.
+ */
+
+export const OPENAPI_SPEC_PATH = "/api/v1/openapi.json";
+export const API_DOCS_PATH = "/api/v1/docs";
+export const API_MODULES_PATH = "/api/v1/modules";
+
+export interface OpenApiModuleServices {
+  /**
+   * Resolves the completed registry. Called per request, never at registration time.
+   * Returning `null` (registration still in flight) surfaces as a 500 rather than a
+   * document that quietly omits half the API.
+   */
+  getApiRegistry?: () => ApiModuleRegistryResult | null | undefined;
+  /** Version reported in `info.version`. Defaults to `0.0.0`. */
+  serverVersion?: string;
+}
+
+/** Response schema for `listApiModules`, matching `describeModules` exactly. */
+const MODULE_CATALOGUE_SCHEMA: JsonSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    required: ["id", "title", "description", "version", "stability", "dependsOn", "operations"],
+    properties: {
+      id: { type: "string" },
+      title: { type: "string" },
+      description: { type: "string" },
+      version: { type: "string" },
+      stability: { type: "string", enum: ["stable", "preview", "experimental"] },
+      dependsOn: { type: "array", items: { type: "string" } },
+      operations: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["operationId", "method", "path", "effect", "scope", "summary", "streaming", "deprecated"],
+          properties: {
+            operationId: { type: "string" },
+            method: { type: "string", enum: ["GET", "POST", "PUT", "PATCH", "DELETE"] },
+            path: { type: "string" },
+            effect: { type: "string", enum: ["read", "write", "destructive"] },
+            scope: { type: "string", enum: ["viewer", "collaborator", "owner"] },
+            summary: { type: "string" },
+            streaming: { type: ["string", "null"], enum: ["sse", null] },
+            deprecated: { type: "boolean" },
+          },
+        },
+      },
+    },
+  },
+};
+
+export function createOpenApiModule(): ApiModule {
+  return {
+    id: "openapi",
+    title: "API description",
+    description:
+      "Publishes the OpenAPI 3.1 document, a dependency-free HTML reference, and the enabled module catalogue.",
+    version: "1.0.0",
+    stability: "stable",
+    register(context: ApiModuleContext): ApiOperation[] {
+      const services = context.services as OpenApiModuleServices;
+      // Built documents are cached per registry identity: the generator is deterministic,
+      // so the only reason to rebuild is a registry that was actually replaced.
+      let cache: { registry: ApiModuleRegistryResult; document: OpenApiDocument } | null = null;
+
+      const resolveRegistry = (): ApiModuleRegistryResult => {
+        const registry = services.getApiRegistry?.();
+        if (!registry) {
+          throw new ApiError(
+            500,
+            "openapi_registry_unavailable",
+            "The API module registry is not available yet, so no description can be produced.",
+          );
+        }
+        return registry;
+      };
+
+      const resolveDocument = (): OpenApiDocument => {
+        const registry = resolveRegistry();
+        if (cache && cache.registry === registry) return cache.document;
+        const document = buildOpenApiDocument({
+          operations: registry.operations,
+          modules: registry.modules,
+          serverVersion: services.serverVersion ?? "0.0.0",
+        });
+        cache = { registry, document };
+        return document;
+      };
+
+      return [
+        {
+          operationId: "getOpenApiDocument",
+          method: "GET",
+          path: OPENAPI_SPEC_PATH,
+          summary: "Get the OpenAPI document",
+          description:
+            "Returns the OpenAPI 3.1 description of every enabled, non-internal operation. The output is deterministic: identical input produces byte-identical JSON, so the document can be committed and diffed in CI.",
+          effect: "read",
+          responses: {
+            200: {
+              description: "The OpenAPI 3.1 document.",
+              schema: { type: "object", additionalProperties: true },
+            },
+          },
+          handler: async () => context.jsonResponse(resolveDocument()),
+        },
+        {
+          operationId: "getApiDocs",
+          method: "GET",
+          path: API_DOCS_PATH,
+          summary: "Browse the API reference",
+          description:
+            "A self-contained HTML reference for the OpenAPI document. The page ships no external assets and works offline; the document is embedded so the page renders without a second authenticated request, and a refresh control re-fetches it from the spec endpoint.",
+          effect: "read",
+          responses: {
+            200: {
+              description: "The HTML reference page.",
+              contentType: "text/html",
+              schema: { type: "string" },
+            },
+          },
+          handler: async () =>
+            new Response(
+              renderApiDocsHtml({ document: resolveDocument(), specUrl: OPENAPI_SPEC_PATH }),
+              {
+                status: 200,
+                headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+              },
+            ),
+        },
+        {
+          operationId: "listApiModules",
+          method: "GET",
+          path: API_MODULES_PATH,
+          summary: "List the enabled API modules",
+          description:
+            "The catalogue of enabled modules and the operations each one contributes, including operations marked internal (which the OpenAPI document omits).",
+          effect: "read",
+          responses: {
+            200: {
+              description: "The enabled modules, in registration order.",
+              schema: MODULE_CATALOGUE_SCHEMA,
+            },
+          },
+          handler: async () => context.jsonResponse(describeModules(resolveRegistry())),
+        },
+      ];
+    },
+  };
+}
+
+/** The module instance registered by the server. */
+export const openApiModule: ApiModule = createOpenApiModule();
+
+export interface ApiDocsHtmlInput {
+  /** The OpenAPI document to embed. */
+  document: unknown;
+  /** Where the refresh control re-fetches the document from. */
+  specUrl: string;
+  /** Page title. Defaults to `iPolloWork API`. */
+  title?: string;
+}
+
+/**
+ * Renders the offline API reference.
+ *
+ * No CDN, no bundler, no dependency: the server has to work on a disconnected machine, and a
+ * docs page that blanks out without network access is worse than no docs page. Everything the
+ * page needs is in the string this function returns.
+ *
+ * Two escaping rules make untrusted text safe here. The embedded document is JSON with `<`,
+ * `>` and `&` escaped as `\uXXXX`, which is valid JSON and cannot terminate the script block
+ * — a summary containing `</script>` stays inert. Everything the page then renders goes in
+ * through `textContent`, never `innerHTML`, so a hostile string cannot become markup.
+ */
+export function renderApiDocsHtml(input: ApiDocsHtmlInput): string {
+  const title = input.title ?? "iPolloWork API";
+  const embedded = embedJson(input.document);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>${DOCS_CSS}</style>
+</head>
+<body>
+<header class="top">
+  <div class="titles"><h1 id="doc-title">${escapeHtml(title)}</h1><p id="doc-version" class="muted"></p></div>
+  <div class="controls">
+    <input id="filter" type="search" placeholder="Filter operations" autocomplete="off" spellcheck="false">
+    <button id="expand" type="button">Expand all</button>
+    <button id="collapse" type="button">Collapse all</button>
+    <button id="refresh" type="button">Refresh</button>
+  </div>
+</header>
+<p id="status" class="status" hidden></p>
+<p id="doc-description" class="description muted"></p>
+<main id="app"></main>
+<script type="application/json" id="openapi-document">${embedded}</script>
+<script id="spec-url" type="application/json">${embedJson(input.specUrl)}</script>
+<script>${DOCS_SCRIPT}</script>
+</body>
+</html>
+`;
+}
+
+/**
+ * JSON for embedding in a `<script type="application/json">` block.
+ *
+ * `<`, `>` and `&` can only occur inside JSON string literals, where `\uXXXX` is an exact
+ * equivalent — so this is a lossless transform that removes every byte sequence able to
+ * close the element. U+2028/U+2029 are escaped because they are literal line terminators to
+ * a JavaScript parser.
+ */
+function embedJson(value: unknown): string {
+  const json = JSON.stringify(value ?? null);
+  return json
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const DOCS_CSS = `
+:root {
+  color-scheme: light dark;
+  --bg: #ffffff; --fg: #14171a; --muted: #5b6570; --line: #dfe3e8; --panel: #f6f7f9;
+  --get: #0b6bcb; --post: #1a7f37; --put: #9a6700; --patch: #9a6700; --delete: #b42318;
+}
+@media (prefers-color-scheme: dark) {
+  :root { --bg: #11141a; --fg: #e6e9ef; --muted: #9aa4b2; --line: #2a303a; --panel: #171b22;
+    --get: #63a4ff; --post: #4ac26b; --put: #d4a72c; --patch: #d4a72c; --delete: #ff6b6b; }
+}
+* { box-sizing: border-box; }
+body { margin: 0; padding: 0 24px 64px; background: var(--bg); color: var(--fg);
+  font: 14px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; }
+h1 { font-size: 18px; margin: 0; }
+h2 { font-size: 15px; margin: 32px 0 4px; }
+.top { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; justify-content: space-between;
+  padding: 16px 0 12px; border-bottom: 1px solid var(--line); position: sticky; top: 0; background: var(--bg); z-index: 2; }
+.titles p { margin: 2px 0 0; font-size: 12px; }
+.controls { display: flex; gap: 8px; flex-wrap: wrap; }
+.controls input, .controls button { font: inherit; font-size: 13px; padding: 5px 10px;
+  border: 1px solid var(--line); border-radius: 6px; background: var(--panel); color: var(--fg); }
+.controls button { cursor: pointer; }
+.muted { color: var(--muted); }
+.description { white-space: pre-wrap; margin: 16px 0 0; max-width: 76ch; font-size: 13px; }
+.status { margin: 12px 0 0; padding: 8px 12px; border: 1px solid var(--line); border-radius: 6px; background: var(--panel); font-size: 13px; }
+.tag-desc { margin: 0 0 8px; font-size: 13px; }
+details.op { border: 1px solid var(--line); border-radius: 8px; margin: 8px 0; background: var(--panel); }
+details.op > summary { cursor: pointer; padding: 10px 12px; display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap; }
+details.op > summary::-webkit-details-marker { display: none; }
+.method { font-weight: 700; font-size: 11px; letter-spacing: .06em; min-width: 52px; }
+.method.get { color: var(--get); } .method.post { color: var(--post); }
+.method.put { color: var(--put); } .method.patch { color: var(--patch); } .method.delete { color: var(--delete); }
+.path { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+.op-summary { color: var(--muted); font-size: 13px; }
+.op-body { padding: 0 12px 14px; border-top: 1px solid var(--line); }
+.chips { display: flex; gap: 6px; flex-wrap: wrap; margin: 10px 0; }
+.chip { font-size: 11px; padding: 2px 7px; border: 1px solid var(--line); border-radius: 999px; background: var(--bg); }
+.chip.warn { border-color: var(--delete); color: var(--delete); }
+h3 { font-size: 12px; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); margin: 14px 0 6px; }
+table { border-collapse: collapse; width: 100%; font-size: 13px; }
+th, td { text-align: left; padding: 5px 8px; border-bottom: 1px solid var(--line); vertical-align: top; }
+th { font-weight: 600; color: var(--muted); font-size: 12px; }
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+pre { background: var(--bg); border: 1px solid var(--line); border-radius: 6px; padding: 8px 10px;
+  overflow: auto; font-size: 12px; margin: 4px 0 0; max-height: 340px; }
+.op-desc { white-space: pre-wrap; margin: 10px 0 0; font-size: 13px; }
+.deprecated .path { text-decoration: line-through; }
+.empty { color: var(--muted); font-size: 13px; margin: 24px 0; }
+`;
+
+/**
+ * The page script. Plain ES2015, no build step, no globals leaked.
+ * Every value derived from the document is inserted with `textContent`.
+ */
+const DOCS_SCRIPT = `
+(function () {
+  "use strict";
+  var METHODS = ["get", "put", "post", "delete", "patch"];
+  var specUrl = readJson("spec-url") || "/api/v1/openapi.json";
+  var app = document.getElementById("app");
+  var statusEl = document.getElementById("status");
+
+  function readJson(id) {
+    var el = document.getElementById(id);
+    if (!el) return null;
+    try { return JSON.parse(el.textContent || "null"); } catch (err) { return null; }
+  }
+
+  function el(tag, className, text) {
+    var node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined && text !== null) node.textContent = String(text);
+    return node;
+  }
+
+  function setStatus(message) {
+    if (!message) { statusEl.hidden = true; statusEl.textContent = ""; return; }
+    statusEl.hidden = false;
+    statusEl.textContent = message;
+  }
+
+  function pretty(value) {
+    try { return JSON.stringify(value, null, 2); } catch (err) { return String(value); }
+  }
+
+  function schemaBlock(schema) {
+    if (schema === undefined) return null;
+    if (schema && schema.$ref) return el("p", "muted", "Schema: " + schema.$ref);
+    if (schema && Object.keys(schema).length === 0) return el("p", "muted", "Any JSON value.");
+    return el("pre", null, pretty(schema));
+  }
+
+  function collect(doc) {
+    var rows = [];
+    var paths = (doc && doc.paths) || {};
+    Object.keys(paths).forEach(function (path) {
+      var item = paths[path] || {};
+      Object.keys(item).forEach(function (method) {
+        if (METHODS.indexOf(method) === -1) return;
+        rows.push({ path: path, method: method, op: item[method] || {} });
+      });
+    });
+    return rows;
+  }
+
+  function tagIndex(doc) {
+    var index = {};
+    ((doc && doc.tags) || []).forEach(function (tag) {
+      if (tag && tag.name) index[tag.name] = tag;
+    });
+    return index;
+  }
+
+  function renderParams(op) {
+    var params = op.parameters || [];
+    if (!params.length) return null;
+    var wrap = document.createDocumentFragment();
+    wrap.appendChild(el("h3", null, "Parameters"));
+    var table = el("table");
+    var head = el("tr");
+    ["Name", "In", "Required", "Type", "Description"].forEach(function (label) {
+      head.appendChild(el("th", null, label));
+    });
+    table.appendChild(head);
+    params.forEach(function (param) {
+      var row = el("tr");
+      var name = el("td");
+      name.appendChild(el("code", null, param.name));
+      row.appendChild(name);
+      row.appendChild(el("td", null, param.in));
+      row.appendChild(el("td", null, param.required ? "yes" : "no"));
+      var schema = param.schema || {};
+      var type = Array.isArray(schema.type) ? schema.type.join(" | ") : (schema.type || (schema.$ref ? schema.$ref : "any"));
+      row.appendChild(el("td", null, type));
+      row.appendChild(el("td", null, param.description || ""));
+      table.appendChild(row);
+    });
+    wrap.appendChild(table);
+    return wrap;
+  }
+
+  function renderBody(op) {
+    if (!op.requestBody) return null;
+    var wrap = document.createDocumentFragment();
+    wrap.appendChild(el("h3", null, "Request body" + (op.requestBody.required ? " (required)" : "")));
+    var content = op.requestBody.content || {};
+    Object.keys(content).forEach(function (type) {
+      wrap.appendChild(el("p", "muted", type));
+      var block = schemaBlock((content[type] || {}).schema);
+      if (block) wrap.appendChild(block);
+    });
+    return wrap;
+  }
+
+  function renderResponses(op) {
+    var responses = op.responses || {};
+    var codes = Object.keys(responses).sort();
+    if (!codes.length) return null;
+    var wrap = document.createDocumentFragment();
+    wrap.appendChild(el("h3", null, "Responses"));
+    codes.forEach(function (code) {
+      var response = responses[code] || {};
+      var line = el("p");
+      var strong = el("strong", null, code);
+      line.appendChild(strong);
+      line.appendChild(document.createTextNode(" "));
+      if (response.$ref) {
+        line.appendChild(el("span", "muted", response.$ref));
+        wrap.appendChild(line);
+        return;
+      }
+      line.appendChild(el("span", "muted", response.description || ""));
+      wrap.appendChild(line);
+      var content = response.content || {};
+      Object.keys(content).forEach(function (type) {
+        wrap.appendChild(el("p", "muted", type));
+        var block = schemaBlock((content[type] || {}).schema);
+        if (block) wrap.appendChild(block);
+      });
+    });
+    return wrap;
+  }
+
+  function renderOperation(row) {
+    var op = row.op;
+    var details = el("details", "op" + (op.deprecated ? " deprecated" : ""));
+    details.dataset.search = [row.method, row.path, op.operationId || "", op.summary || ""].join(" ").toLowerCase();
+
+    var summary = el("summary");
+    summary.appendChild(el("span", "method " + row.method, row.method.toUpperCase()));
+    summary.appendChild(el("span", "path", row.path));
+    summary.appendChild(el("span", "op-summary", op.summary || ""));
+    details.appendChild(summary);
+
+    var body = el("div", "op-body");
+    var chips = el("div", "chips");
+    function chip(text, warn) { if (text) chips.appendChild(el("span", warn ? "chip warn" : "chip", text)); }
+    chip(op.operationId);
+    chip(op["x-ipollowork-module"] ? "module: " + op["x-ipollowork-module"] : null);
+    chip(op["x-ipollowork-effect"] ? "effect: " + op["x-ipollowork-effect"] : null);
+    chip(op["x-ipollowork-scope"] ? "scope: " + op["x-ipollowork-scope"] : null);
+    chip(op["x-ipollowork-auth"] ? "auth: " + op["x-ipollowork-auth"] : null);
+    chip(op["x-ipollowork-streaming"] ? "streaming: " + op["x-ipollowork-streaming"] : null);
+    if (op.deprecated) chip("deprecated", true);
+    body.appendChild(chips);
+
+    if (op.description) body.appendChild(el("p", "op-desc", op.description));
+    [renderParams(op), renderBody(op), renderResponses(op)].forEach(function (section) {
+      if (section) body.appendChild(section);
+    });
+    details.appendChild(body);
+    return details;
+  }
+
+  function render(doc) {
+    var info = (doc && doc.info) || {};
+    document.getElementById("doc-title").textContent = info.title || "API";
+    document.getElementById("doc-version").textContent = info.version ? "version " + info.version : "";
+    document.getElementById("doc-description").textContent = info.description || "";
+
+    app.replaceChildren();
+    var rows = collect(doc);
+    if (!rows.length) {
+      app.appendChild(el("p", "empty", "This document contains no operations."));
+      return;
+    }
+
+    var tags = tagIndex(doc);
+    var groups = {};
+    var order = [];
+    rows.forEach(function (row) {
+      var tag = (row.op.tags && row.op.tags[0]) || "other";
+      if (!groups[tag]) { groups[tag] = []; order.push(tag); }
+      groups[tag].push(row);
+    });
+    order.sort();
+
+    order.forEach(function (tag) {
+      var section = el("section");
+      section.appendChild(el("h2", null, tag));
+      var meta = tags[tag];
+      if (meta && meta.description) section.appendChild(el("p", "tag-desc muted", meta.description));
+      groups[tag]
+        .slice()
+        .sort(function (a, b) { return a.path === b.path ? a.method.localeCompare(b.method) : a.path.localeCompare(b.path); })
+        .forEach(function (row) { section.appendChild(renderOperation(row)); });
+      app.appendChild(section);
+    });
+  }
+
+  document.getElementById("filter").addEventListener("input", function (event) {
+    var needle = String(event.target.value || "").trim().toLowerCase();
+    var nodes = app.querySelectorAll("details.op");
+    for (var i = 0; i < nodes.length; i++) {
+      var node = nodes[i];
+      node.hidden = needle !== "" && (node.dataset.search || "").indexOf(needle) === -1;
+    }
+  });
+
+  document.getElementById("expand").addEventListener("click", function () { toggleAll(true); });
+  document.getElementById("collapse").addEventListener("click", function () { toggleAll(false); });
+  function toggleAll(open) {
+    var nodes = app.querySelectorAll("details.op");
+    for (var i = 0; i < nodes.length; i++) { nodes[i].open = open; }
+  }
+
+  document.getElementById("refresh").addEventListener("click", function () {
+    setStatus("Fetching " + specUrl + " ...");
+    fetch(specUrl, { headers: { accept: "application/json" }, credentials: "same-origin" })
+      .then(function (res) {
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      })
+      .then(function (doc) { render(doc); setStatus(""); })
+      .catch(function (err) {
+        setStatus("Could not refresh from " + specUrl + " (" + err.message + "). Showing the embedded document.");
+      });
+  });
+
+  render(readJson("openapi-document"));
+})();
+`;

--- a/apps/server/src/api/modules/policy/module.test.ts
+++ b/apps/server/src/api/modules/policy/module.test.ts
@@ -1,0 +1,474 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { isApiError } from "../../../errors.js";
+import type { RequestContext, Route } from "../../../routes/registry.js";
+import { matchRoute } from "../../../routes/registry.js";
+import type { TokenService } from "../../../tokens.js";
+import type { Actor, ServerConfig } from "../../../types.js";
+import { registerApiModules, type ApiModuleContext, type ApiOperation } from "../../module.js";
+import {
+  TokenPolicyStore,
+  assertPolicyAllowsWorkspace,
+  createPolicyModule,
+  policyModule,
+  resolveTokenPolicyStorePath,
+} from "./module.js";
+
+type StoredToken = { id: string; scope: "owner" | "collaborator" | "viewer"; createdAt: number; label?: string; hash?: string };
+
+const TOKENS: StoredToken[] = [
+  { id: "tok_ci", scope: "collaborator", createdAt: 1_000, label: "ci", hash: "hash-ci" },
+  { id: "tok_view", scope: "viewer", createdAt: 2_000, hash: "hash-view" },
+];
+
+function fakeTokenService(records: StoredToken[] = TOKENS): TokenService {
+  return {
+    list: async () => records.map(({ hash: _hash, ...rest }) => rest),
+    findByHash: async (hash: string) => {
+      const found = records.find((record) => record.hash === hash);
+      if (!found) return null;
+      const { hash: _hash, ...rest } = found;
+      return rest;
+    },
+  } as unknown as TokenService;
+}
+
+function serverConfig(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    workspaces: [
+      { id: "w1", name: "Alpha" },
+      { id: "w2", name: "Beta" },
+    ],
+    approval: { mode: "manual", timeoutMs: 1_000 },
+    readOnly: false,
+    ...overrides,
+  } as unknown as ServerConfig;
+}
+
+let storeDir: string;
+let store: TokenPolicyStore;
+let config: ServerConfig;
+
+function moduleContext(overrides: Partial<ApiModuleContext> = {}): ApiModuleContext {
+  return {
+    config,
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+    readJsonBody: async (request) => {
+      try {
+        return (await request.json()) as Record<string, unknown>;
+      } catch {
+        return {};
+      }
+    },
+    resolveWorkspace: async () => ({ id: "w1" }),
+    services: { tokenPolicies: store },
+    ...overrides,
+  };
+}
+
+function operations(context: ApiModuleContext = moduleContext()): ApiOperation[] {
+  return createPolicyModule().register(context);
+}
+
+function operation(operationId: string, context: ApiModuleContext = moduleContext()): ApiOperation {
+  const found = operations(context).find((op) => op.operationId === operationId);
+  if (!found) throw new Error(`missing operation ${operationId}`);
+  return found;
+}
+
+function requestContext(
+  request: Request,
+  params: Record<string, string> = {},
+  extra: { actor?: Actor; tokens?: TokenService; config?: ServerConfig } = {},
+): RequestContext {
+  return {
+    request,
+    url: new URL(request.url),
+    params,
+    config: extra.config ?? config,
+    approvals: {} as never,
+    reloadEvents: {} as never,
+    tokens: extra.tokens ?? fakeTokenService(),
+    actor: extra.actor,
+  };
+}
+
+async function json(response: Response): Promise<Record<string, unknown>> {
+  return (await response.json()) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  storeDir = mkdtempSync(join(tmpdir(), "ipollowork-policy-"));
+  store = new TokenPolicyStore(serverConfig(), { path: join(storeDir, "token-policies.json") });
+  config = serverConfig();
+});
+
+afterEach(() => {
+  delete process.env.IPOLLOWORK_TOKEN_POLICY_STORE;
+  delete process.env.IPOLLOWORK_TOKEN_STORE;
+});
+
+describe("module declaration", () => {
+  test("identifies itself", () => {
+    expect(policyModule.id).toBe("policy");
+    expect(policyModule.version).toBe("1.0.0");
+    expect(policyModule.stability).toBe("preview");
+  });
+
+  test("declares exactly the three phase-1 operations", () => {
+    expect(operations().map((op) => `${op.method} ${op.path}`)).toEqual([
+      "GET /api/v1/tokens/:tokenId/policy",
+      "PUT /api/v1/tokens/:tokenId/policy",
+      "GET /api/v1/whoami",
+    ]);
+    expect(operations().map((op) => op.operationId)).toEqual([
+      "getTokenPolicy",
+      "setTokenPolicy",
+      "getCurrentIdentity",
+    ]);
+  });
+
+  test("policy mutation is host-authenticated, matching how /tokens is protected", () => {
+    expect(operation("getTokenPolicy").auth).toBe("host");
+    expect(operation("setTokenPolicy").auth).toBe("host");
+  });
+
+  test("whoami is a client-scoped read any token may call", () => {
+    const whoami = operation("getCurrentIdentity");
+    expect(whoami.auth ?? "client").toBe("client");
+    expect(whoami.effect).toBe("read");
+    expect(whoami.scope).toBe("viewer");
+  });
+
+  test("effects match the read/write split", () => {
+    expect(operation("getTokenPolicy").effect).toBe("read");
+    expect(operation("setTokenPolicy").effect).toBe("write");
+  });
+
+  test("every operation documents its request and response shapes", () => {
+    for (const op of operations()) {
+      expect(op.summary.length).toBeGreaterThan(0);
+      expect(op.responses?.[200]).toBeDefined();
+    }
+    expect(operation("setTokenPolicy").requestBody).toBeDefined();
+    expect(operation("getTokenPolicy").pathParams).toBeDefined();
+  });
+
+  test("registers onto the shared route table", () => {
+    const routes: Route[] = [];
+    const result = registerApiModules(routes, [createPolicyModule()], moduleContext());
+    expect(result.operations).toHaveLength(3);
+    expect(matchRoute(routes, "GET", "/api/v1/whoami")).not.toBeNull();
+    expect(matchRoute(routes, "PUT", "/api/v1/tokens/tok_ci/policy")?.params).toEqual({ tokenId: "tok_ci" });
+    expect(routes.filter((route) => route.auth === "host")).toHaveLength(2);
+  });
+});
+
+describe("getTokenPolicy", () => {
+  test("returns resolved defaults for a token with no stored policy", async () => {
+    const response = await operation("getTokenPolicy").handler(
+      requestContext(new Request("http://localhost/api/v1/tokens/tok_ci/policy"), { tokenId: "tok_ci" }),
+    );
+    expect(response.status).toBe(200);
+    expect(await json(response)).toEqual({
+      tokenId: "tok_ci",
+      scope: "collaborator",
+      label: "ci",
+      createdAt: 1_000,
+      policy: {
+        workspaces: null,
+        approvals: { mode: "inherit", autoApprove: [], denyDestructive: false },
+        expiresAt: null,
+        expired: false,
+      },
+    });
+  });
+
+  test("404s for an unknown token", async () => {
+    try {
+      await operation("getTokenPolicy").handler(
+        requestContext(new Request("http://localhost/api/v1/tokens/nope/policy"), { tokenId: "nope" }),
+      );
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { status: number }).status).toBe(404);
+      expect((error as { code: string }).code).toBe("token_not_found");
+    }
+  });
+
+  test("400s when the path param is blank", async () => {
+    try {
+      await operation("getTokenPolicy").handler(
+        requestContext(new Request("http://localhost/api/v1/tokens/%20/policy"), { tokenId: " " }),
+      );
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { code: string }).code).toBe("invalid_token_id");
+    }
+  });
+});
+
+describe("setTokenPolicy", () => {
+  function putRequest(body: unknown): Request {
+    return new Request("http://localhost/api/v1/tokens/tok_ci/policy", {
+      method: "PUT",
+      body: JSON.stringify(body),
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  test("stores a normalized policy and reads it back", async () => {
+    const written = await operation("setTokenPolicy").handler(
+      requestContext(
+        putRequest({
+          workspaces: [" w1 ", "w1"],
+          approvals: { mode: "manual", autoApprove: ["session.*"], denyDestructive: true },
+          expiresAt: 4_000_000_000_000,
+        }),
+        { tokenId: "tok_ci" },
+      ),
+    );
+    expect((await json(written)).policy).toEqual({
+      workspaces: ["w1"],
+      approvals: { mode: "manual", autoApprove: ["session.*"], denyDestructive: true },
+      expiresAt: 4_000_000_000_000,
+      expired: false,
+    });
+
+    const read = await operation("getTokenPolicy").handler(
+      requestContext(new Request("http://localhost/api/v1/tokens/tok_ci/policy"), { tokenId: "tok_ci" }),
+    );
+    expect((await json(read)).policy).toEqual({
+      workspaces: ["w1"],
+      approvals: { mode: "manual", autoApprove: ["session.*"], denyDestructive: true },
+      expiresAt: 4_000_000_000_000,
+      expired: false,
+    });
+  });
+
+  test("accepts the policy wrapped in a policy key", async () => {
+    await operation("setTokenPolicy").handler(
+      requestContext(putRequest({ policy: { workspaces: ["w2"] } }), { tokenId: "tok_ci" }),
+    );
+    expect(await store.get("tok_ci")).toEqual({ workspaces: ["w2"] });
+  });
+
+  test("an empty body clears the policy", async () => {
+    await store.set("tok_ci", { workspaces: ["w1"] });
+    await operation("setTokenPolicy").handler(requestContext(putRequest({}), { tokenId: "tok_ci" }));
+    expect(await store.get("tok_ci")).toEqual({});
+  });
+
+  test("replaces rather than merges", async () => {
+    await operation("setTokenPolicy").handler(
+      requestContext(putRequest({ workspaces: ["w1"], approvals: { mode: "auto" } }), { tokenId: "tok_ci" }),
+    );
+    await operation("setTokenPolicy").handler(
+      requestContext(putRequest({ approvals: { mode: "manual" } }), { tokenId: "tok_ci" }),
+    );
+    expect(await store.get("tok_ci")).toEqual({ approvals: { mode: "manual" } });
+  });
+
+  test("rejects an invalid policy with a field-scoped 400", async () => {
+    try {
+      await operation("setTokenPolicy").handler(
+        requestContext(putRequest({ approvals: { mode: "always" } }), { tokenId: "tok_ci" }),
+      );
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { status: number }).status).toBe(400);
+      expect((error as { code: string }).code).toBe("invalid_token_policy");
+      expect((error as { details: { field: string } }).details.field).toBe("approvals.mode");
+    }
+  });
+
+  test("rejects an unknown field instead of silently dropping it", async () => {
+    try {
+      await operation("setTokenPolicy").handler(
+        requestContext(putRequest({ workspace: ["w1"] }), { tokenId: "tok_ci" }),
+      );
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { details: { field: string } }).details.field).toBe("workspace");
+    }
+  });
+
+  test("does not write a policy for an unknown token", async () => {
+    await expect(
+      operation("setTokenPolicy").handler(
+        requestContext(
+          new Request("http://localhost/api/v1/tokens/nope/policy", {
+            method: "PUT",
+            body: JSON.stringify({ workspaces: ["w1"] }),
+          }),
+          { tokenId: "nope" },
+        ),
+      ),
+    ).rejects.toThrow(/Token not found/);
+    expect(await store.all()).toEqual({});
+  });
+});
+
+describe("getCurrentIdentity", () => {
+  const actor: Actor = { type: "remote", clientId: "cli-1", tokenHash: "hash-ci", scope: "collaborator" };
+
+  test("reports scope, token, policy, server mode and every workspace when unconstrained", async () => {
+    const response = await operation("getCurrentIdentity").handler(
+      requestContext(new Request("http://localhost/api/v1/whoami"), {}, { actor }),
+    );
+    expect(await json(response)).toEqual({
+      actor: { type: "remote", clientId: "cli-1", scope: "collaborator" },
+      token: { id: "tok_ci", scope: "collaborator", label: "ci", createdAt: 1_000 },
+      policy: {
+        workspaces: null,
+        approvals: { mode: "inherit", autoApprove: [], denyDestructive: false },
+        expiresAt: null,
+        expired: false,
+      },
+      server: { approvalMode: "manual", readOnly: false },
+      workspaces: [{ id: "w1", name: "Alpha" }, { id: "w2", name: "Beta" }],
+    });
+  });
+
+  test("narrows the workspace list to the policy allowlist", async () => {
+    await store.set("tok_ci", { workspaces: ["w2"] });
+    const response = await operation("getCurrentIdentity").handler(
+      requestContext(new Request("http://localhost/api/v1/whoami"), {}, { actor }),
+    );
+    const body = await json(response);
+    expect(body.workspaces).toEqual([{ id: "w2", name: "Beta" }]);
+    expect((body.policy as { workspaces: string[] }).workspaces).toEqual(["w2"]);
+  });
+
+  test("reports an expired token as expired", async () => {
+    await store.set("tok_ci", { expiresAt: 1 });
+    const response = await operation("getCurrentIdentity").handler(
+      requestContext(new Request("http://localhost/api/v1/whoami"), {}, { actor }),
+    );
+    expect((await json(response)).policy).toMatchObject({ expired: true, expiresAt: 1 });
+  });
+
+  test("handles the shared config token, which has no stored record", async () => {
+    const response = await operation("getCurrentIdentity").handler(
+      requestContext(
+        new Request("http://localhost/api/v1/whoami"),
+        {},
+        { actor: { type: "remote", tokenHash: "unknown-hash", scope: "collaborator" } },
+      ),
+    );
+    const body = await json(response);
+    expect(body.token).toBeNull();
+    expect(body.actor).toEqual({ type: "remote", clientId: null, scope: "collaborator" });
+    expect(body.workspaces).toHaveLength(2);
+  });
+
+  test("401s when there is no actor on the request", async () => {
+    try {
+      await operation("getCurrentIdentity").handler(requestContext(new Request("http://localhost/api/v1/whoami")));
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { status: number }).status).toBe(401);
+    }
+  });
+});
+
+describe("TokenPolicyStore", () => {
+  test("persists to disk and reloads from it", async () => {
+    const path = join(storeDir, "roundtrip.json");
+    const first = new TokenPolicyStore(config, { path });
+    await first.set("tok_ci", { workspaces: ["w1"], approvals: { mode: "manual" } });
+
+    const raw = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    expect(raw.schemaVersion).toBe(1);
+    expect(raw.policies).toEqual({ tok_ci: { workspaces: ["w1"], approvals: { mode: "manual" } } });
+
+    const second = new TokenPolicyStore(config, { path });
+    expect(await second.get("tok_ci")).toEqual({ workspaces: ["w1"], approvals: { mode: "manual" } });
+    expect(await second.get("tok_view")).toEqual({});
+  });
+
+  test("an empty policy removes the entry instead of storing noise", async () => {
+    await store.set("tok_ci", { workspaces: ["w1"] });
+    await store.set("tok_ci", {});
+    expect(await store.all()).toEqual({});
+  });
+
+  test("remove reports whether anything was there", async () => {
+    await store.set("tok_ci", { workspaces: ["w1"] });
+    expect(await store.remove("tok_ci")).toBe(true);
+    expect(await store.remove("tok_ci")).toBe(false);
+  });
+
+  test("a missing file reads as no policies", async () => {
+    const fresh = new TokenPolicyStore(config, { path: join(storeDir, "absent.json") });
+    expect(await fresh.all()).toEqual({});
+  });
+
+  test("a corrupt file degrades to no policies rather than crashing", async () => {
+    const path = join(storeDir, "corrupt.json");
+    await Bun.write(path, "{not json");
+    expect(await new TokenPolicyStore(config, { path }).all()).toEqual({});
+  });
+
+  test("an invalid entry is dropped while valid siblings survive", async () => {
+    const path = join(storeDir, "mixed.json");
+    await Bun.write(
+      path,
+      JSON.stringify({
+        schemaVersion: 1,
+        policies: { tok_ci: { workspaces: ["w1"] }, tok_bad: { approvals: { mode: "always" } } },
+      }),
+    );
+    expect(await new TokenPolicyStore(config, { path }).all()).toEqual({ tok_ci: { workspaces: ["w1"] } });
+  });
+});
+
+describe("resolveTokenPolicyStorePath", () => {
+  test("honours the explicit override", () => {
+    process.env.IPOLLOWORK_TOKEN_POLICY_STORE = "/tmp/custom-policies.json";
+    expect(resolveTokenPolicyStorePath(config)).toBe("/tmp/custom-policies.json");
+  });
+
+  test("sits next to the token store when that is overridden", () => {
+    process.env.IPOLLOWORK_TOKEN_STORE = "/tmp/store/tokens.json";
+    expect(resolveTokenPolicyStorePath(config)).toBe("/tmp/store/token-policies.json");
+  });
+
+  test("sits next to the config file otherwise", () => {
+    expect(resolveTokenPolicyStorePath(serverConfig({ configPath: "/tmp/cfg/ipollowork.json" })))
+      .toBe("/tmp/cfg/token-policies.json");
+  });
+});
+
+describe("assertPolicyAllowsWorkspace", () => {
+  test("passes for an unconstrained policy", () => {
+    expect(() => assertPolicyAllowsWorkspace({}, "w1", 1_000)).not.toThrow();
+  });
+
+  test("403s on a workspace outside the allowlist", () => {
+    try {
+      assertPolicyAllowsWorkspace({ workspaces: ["w2"] }, "w1", 1_000);
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { status: number }).status).toBe(403);
+      expect((error as { code: string }).code).toBe("workspace_forbidden");
+      expect((error as { details: { reason: string } }).details.reason).toBe("workspace_not_allowed");
+    }
+  });
+
+  test("403s on an expired token before checking the workspace", () => {
+    try {
+      assertPolicyAllowsWorkspace({ expiresAt: 500, workspaces: ["w1"] }, "w1", 1_000);
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { code: string }).code).toBe("token_expired");
+    }
+  });
+});

--- a/apps/server/src/api/modules/policy/module.ts
+++ b/apps/server/src/api/modules/policy/module.ts
@@ -1,0 +1,438 @@
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+
+import { ApiError } from "../../../errors.js";
+import type { RequestContext } from "../../../routes/registry.js";
+import type { ServerConfig } from "../../../types.js";
+import { ensureDir, exists } from "../../../utils.js";
+import type { ApiModule, ApiModuleContext, ApiOperation, JsonSchema } from "../../module.js";
+import {
+  accessibleWorkspaces,
+  describeTokenPolicy,
+  evaluateWorkspaceAccess,
+  isEmptyTokenPolicy,
+  isTokenExpired,
+  parseTokenPolicy,
+  type ApiTokenPolicy,
+} from "./policy.js";
+
+/**
+ * The `policy` module binds a token to a blast radius.
+ *
+ * The server already has three token scopes and one global approval mode. That pair is
+ * too coarse for unattended callers: a CI token either auto-approves everything or waits
+ * forever for a human. A per-token policy narrows the workspaces a token may touch and
+ * says, per token, which effects may proceed without asking.
+ *
+ * Policy mutation is an owner-level action, so `getTokenPolicy` / `setTokenPolicy` use
+ * `auth: "host"` - exactly how `/tokens` is protected in `routes/core.ts`. `whoami` is
+ * the one client-facing operation: a caller may always read its own identity.
+ */
+
+export const POLICY_MODULE_ID = "policy";
+
+const POLICY_STORE_FILENAME = "token-policies.json";
+
+interface TokenPolicyStoreFile {
+  schemaVersion: number;
+  updatedAt: number;
+  policies: Record<string, ApiTokenPolicy>;
+}
+
+/**
+ * Where per-token policies live.
+ *
+ * `TokenService` owns `tokens.json` and its record shape has no room for a policy blob,
+ * so policies go in a sibling file next to it, resolved with the same precedence:
+ * an explicit env override first, then the token store's directory, then the config
+ * directory, then `~/.config/ipollowork`.
+ */
+export function resolveTokenPolicyStorePath(config: ServerConfig): string {
+  const override = (process.env.IPOLLOWORK_TOKEN_POLICY_STORE ?? "").trim();
+  if (override) return resolve(override);
+
+  const tokenStore = (process.env.IPOLLOWORK_TOKEN_STORE ?? "").trim();
+  if (tokenStore) return join(dirname(resolve(tokenStore)), POLICY_STORE_FILENAME);
+
+  const configPath = config.configPath?.trim();
+  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "ipollowork");
+  return join(configDir, POLICY_STORE_FILENAME);
+}
+
+/** JSON-file store, mirroring `TokenService`'s load-once / write-through approach. */
+export class TokenPolicyStore {
+  private path: string;
+  private loaded = false;
+  private policies = new Map<string, ApiTokenPolicy>();
+
+  constructor(config: ServerConfig, options?: { path?: string }) {
+    const explicit = options?.path?.trim();
+    this.path = explicit ? resolve(explicit) : resolveTokenPolicyStorePath(config);
+  }
+
+  get storePath(): string {
+    return this.path;
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    this.policies = await readPolicyStore(this.path);
+    this.loaded = true;
+  }
+
+  async get(tokenId: string): Promise<ApiTokenPolicy> {
+    await this.ensureLoaded();
+    return this.policies.get(tokenId) ?? {};
+  }
+
+  async all(): Promise<Record<string, ApiTokenPolicy>> {
+    await this.ensureLoaded();
+    return Object.fromEntries(this.policies.entries());
+  }
+
+  async set(tokenId: string, policy: ApiTokenPolicy): Promise<ApiTokenPolicy> {
+    await this.ensureLoaded();
+    if (isEmptyTokenPolicy(policy)) {
+      this.policies.delete(tokenId);
+    } else {
+      this.policies.set(tokenId, policy);
+    }
+    await this.flush();
+    return policy;
+  }
+
+  async remove(tokenId: string): Promise<boolean> {
+    await this.ensureLoaded();
+    const removed = this.policies.delete(tokenId);
+    if (removed) await this.flush();
+    return removed;
+  }
+
+  private async flush(): Promise<void> {
+    await ensureDir(dirname(this.path));
+    const payload: TokenPolicyStoreFile = {
+      schemaVersion: 1,
+      updatedAt: Date.now(),
+      policies: Object.fromEntries(this.policies.entries()),
+    };
+    await writeFile(this.path, JSON.stringify(payload, null, 2) + "\n", "utf8");
+  }
+}
+
+async function readPolicyStore(path: string): Promise<Map<string, ApiTokenPolicy>> {
+  const out = new Map<string, ApiTokenPolicy>();
+  if (!(await exists(path))) return out;
+  let parsed: Partial<TokenPolicyStoreFile>;
+  try {
+    parsed = JSON.parse(await readFile(path, "utf8")) as Partial<TokenPolicyStoreFile>;
+  } catch {
+    return out;
+  }
+  const policies = parsed.policies;
+  if (!policies || typeof policies !== "object" || Array.isArray(policies)) return out;
+  for (const [tokenId, value] of Object.entries(policies)) {
+    if (!tokenId) continue;
+    try {
+      // A hand-edited or corrupted entry is dropped rather than crashing startup;
+      // dropping it falls back to "no policy", which the scope checks still gate.
+      const policy = parseTokenPolicy(value);
+      if (!isEmptyTokenPolicy(policy)) out.set(tokenId, policy);
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+const POLICY_SCHEMA: JsonSchema = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    workspaces: {
+      description: "Workspace id allowlist. null means every workspace; [] means none.",
+      anyOf: [{ type: "null" }, { type: "array", items: { type: "string" }, maxItems: 256 }],
+    },
+    approvals: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["inherit", "auto", "manual"],
+          description: "inherit defers to IPOLLOWORK_APPROVAL_MODE; manual asks even when the server is in auto mode.",
+        },
+        autoApprove: {
+          type: "array",
+          maxItems: 128,
+          items: { type: "string", maxLength: 200 },
+          description: "Exact effect/action strings, or a single trailing-* prefix such as session.*.",
+        },
+        denyDestructive: {
+          type: "boolean",
+          description: "Denies destructive effects outright; overrides autoApprove and mode auto.",
+        },
+      },
+    },
+    expiresAt: {
+      description: "Epoch milliseconds, or null for no expiry.",
+      anyOf: [{ type: "null" }, { type: "number" }],
+    },
+  },
+};
+
+const RESOLVED_POLICY_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    workspaces: { anyOf: [{ type: "null" }, { type: "array", items: { type: "string" } }] },
+    approvals: {
+      type: "object",
+      properties: {
+        mode: { type: "string", enum: ["inherit", "auto", "manual"] },
+        autoApprove: { type: "array", items: { type: "string" } },
+        denyDestructive: { type: "boolean" },
+      },
+    },
+    expiresAt: { anyOf: [{ type: "null" }, { type: "number" }] },
+    expired: { type: "boolean" },
+  },
+};
+
+const TOKEN_POLICY_RESPONSE_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    tokenId: { type: "string" },
+    scope: { type: "string", enum: ["owner", "collaborator", "viewer"] },
+    label: { anyOf: [{ type: "null" }, { type: "string" }] },
+    createdAt: { type: "number" },
+    policy: RESOLVED_POLICY_SCHEMA,
+  },
+};
+
+const IDENTITY_RESPONSE_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    actor: {
+      type: "object",
+      properties: {
+        type: { type: "string", enum: ["remote", "host"] },
+        clientId: { anyOf: [{ type: "null" }, { type: "string" }] },
+        scope: { anyOf: [{ type: "null" }, { type: "string", enum: ["owner", "collaborator", "viewer"] }] },
+      },
+    },
+    token: {
+      anyOf: [
+        { type: "null" },
+        {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            scope: { type: "string" },
+            label: { anyOf: [{ type: "null" }, { type: "string" }] },
+            createdAt: { type: "number" },
+          },
+        },
+      ],
+    },
+    policy: RESOLVED_POLICY_SCHEMA,
+    server: {
+      type: "object",
+      properties: {
+        approvalMode: { type: "string", enum: ["manual", "auto"] },
+        readOnly: { type: "boolean" },
+      },
+    },
+    workspaces: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { id: { type: "string" }, name: { type: "string" } },
+      },
+    },
+  },
+};
+
+const TOKEN_ID_PARAMS: JsonSchema = {
+  type: "object",
+  required: ["tokenId"],
+  properties: { tokenId: { type: "string", description: "Token id as returned by POST /tokens." } },
+};
+
+const NOT_FOUND_RESPONSE = { description: "No token with that id." };
+
+function requireTokenId(ctx: RequestContext): string {
+  const tokenId = (ctx.params.tokenId ?? "").trim();
+  if (!tokenId) {
+    throw new ApiError(400, "invalid_token_id", "Token id is required");
+  }
+  return tokenId;
+}
+
+async function requireTokenRecord(ctx: RequestContext, tokenId: string) {
+  const records = await ctx.tokens.list();
+  const record = records.find((entry) => entry.id === tokenId);
+  if (!record) {
+    throw new ApiError(404, "token_not_found", "Token not found", { tokenId });
+  }
+  return record;
+}
+
+/**
+ * Creates the module. The store is injectable through `services.tokenPolicies` so tests
+ * (and any future in-memory deployment) do not have to touch the real config directory.
+ */
+export function createPolicyModule(): ApiModule {
+  return {
+    id: POLICY_MODULE_ID,
+    title: "Token policy",
+    description:
+      "Per-token workspace binding, approval policy, and expiry, plus the caller's own resolved identity.",
+    version: "1.0.0",
+    stability: "preview",
+
+    register(context: ApiModuleContext): ApiOperation[] {
+      const store = (context.services.tokenPolicies as TokenPolicyStore | undefined)
+        ?? new TokenPolicyStore(context.config);
+
+      return [
+        {
+          operationId: "getTokenPolicy",
+          method: "GET",
+          path: "/api/v1/tokens/:tokenId/policy",
+          summary: "Read the policy bound to a token",
+          description:
+            "Returns the stored policy with every default resolved. A token with no stored policy reports the unconstrained defaults.",
+          effect: "read",
+          auth: "host",
+          pathParams: TOKEN_ID_PARAMS,
+          responses: {
+            200: { description: "The token's resolved policy.", schema: TOKEN_POLICY_RESPONSE_SCHEMA },
+            404: NOT_FOUND_RESPONSE,
+          },
+          handler: async (ctx) => {
+            const tokenId = requireTokenId(ctx);
+            const record = await requireTokenRecord(ctx, tokenId);
+            const policy = await store.get(tokenId);
+            return context.jsonResponse({
+              tokenId: record.id,
+              scope: record.scope,
+              label: record.label ?? null,
+              createdAt: record.createdAt,
+              policy: describeTokenPolicy(policy, Date.now()),
+            });
+          },
+        },
+        {
+          operationId: "setTokenPolicy",
+          method: "PUT",
+          path: "/api/v1/tokens/:tokenId/policy",
+          summary: "Replace the policy bound to a token",
+          description:
+            "Full replacement, not a merge. The body is the policy object itself, or `{ \"policy\": { ... } }`. An empty object clears the policy.",
+          effect: "write",
+          auth: "host",
+          pathParams: TOKEN_ID_PARAMS,
+          requestBody: POLICY_SCHEMA,
+          responses: {
+            200: { description: "The stored policy.", schema: TOKEN_POLICY_RESPONSE_SCHEMA },
+            400: { description: "The policy failed validation." },
+            404: NOT_FOUND_RESPONSE,
+          },
+          handler: async (ctx) => {
+            const tokenId = requireTokenId(ctx);
+            const record = await requireTokenRecord(ctx, tokenId);
+            const body = await context.readJsonBody(ctx.request);
+            const raw = Object.prototype.hasOwnProperty.call(body, "policy") ? body.policy : body;
+            const policy = parseTokenPolicy(raw);
+            await store.set(tokenId, policy);
+            return context.jsonResponse({
+              tokenId: record.id,
+              scope: record.scope,
+              label: record.label ?? null,
+              createdAt: record.createdAt,
+              policy: describeTokenPolicy(policy, Date.now()),
+            });
+          },
+        },
+        {
+          operationId: "getCurrentIdentity",
+          method: "GET",
+          path: "/api/v1/whoami",
+          summary: "Describe the calling token",
+          description:
+            "Returns the caller's scope, its resolved policy, and the workspaces that policy allows. Callers use this to discover their own blast radius before attempting work.",
+          effect: "read",
+          scope: "viewer",
+          responses: {
+            200: { description: "The caller's identity and effective policy.", schema: IDENTITY_RESPONSE_SCHEMA },
+          },
+          handler: async (ctx) => {
+            const actor = ctx.actor;
+            if (!actor) {
+              throw new ApiError(401, "unauthorized", "Missing actor");
+            }
+            const record = actor.tokenHash ? await ctx.tokens.findByHash(actor.tokenHash) : null;
+            const policy = record ? await store.get(record.id) : {};
+            const now = Date.now();
+            const allowedIds = new Set(
+              accessibleWorkspaces(policy, ctx.config.workspaces.map((workspace) => workspace.id)),
+            );
+
+            return context.jsonResponse({
+              actor: {
+                type: actor.type,
+                clientId: actor.clientId ?? null,
+                scope: actor.scope ?? null,
+              },
+              token: record
+                ? {
+                  id: record.id,
+                  scope: record.scope,
+                  label: record.label ?? null,
+                  createdAt: record.createdAt,
+                }
+                : null,
+              policy: describeTokenPolicy(policy, now),
+              server: {
+                approvalMode: ctx.config.approval.mode,
+                readOnly: ctx.config.readOnly,
+              },
+              workspaces: ctx.config.workspaces
+                .filter((workspace) => allowedIds.has(workspace.id))
+                .map((workspace) => ({ id: workspace.id, name: workspace.name })),
+            });
+          },
+        },
+      ];
+    },
+  };
+}
+
+export const policyModule: ApiModule = createPolicyModule();
+
+/**
+ * Convenience gate for other modules: throws when the caller's policy excludes the
+ * workspace or the token has expired. Kept here so the enforcement wording lives with
+ * the policy module rather than being retyped per call site.
+ */
+export function assertPolicyAllowsWorkspace(
+  policy: ApiTokenPolicy | null | undefined,
+  workspaceId: string,
+  now: number = Date.now(),
+  options: { skipWorkspaceCheck?: boolean } = {},
+): void {
+  if (isTokenExpired(policy, now)) {
+    throw new ApiError(403, "token_expired", "This token has expired", { expiresAt: policy?.expiresAt ?? null });
+  }
+  // Expiry applies to every route; the workspace binding only means something on a route
+  // that names one, and treating "no workspace in the path" as a denied workspace would
+  // lock a bound token out of `/api/v1/whoami`.
+  if (options.skipWorkspaceCheck) return;
+  const access = evaluateWorkspaceAccess(policy, workspaceId);
+  if (!access.allowed) {
+    throw new ApiError(403, "workspace_forbidden", "This token may not access that workspace", {
+      workspaceId,
+      reason: access.reason,
+    });
+  }
+}

--- a/apps/server/src/api/modules/policy/policy.test.ts
+++ b/apps/server/src/api/modules/policy/policy.test.ts
@@ -1,0 +1,440 @@
+import { describe, expect, test } from "bun:test";
+
+import { isApiError } from "../../../errors.js";
+import type { ApiEffect } from "../../module.js";
+import {
+  accessibleWorkspaces,
+  describeTokenPolicy,
+  evaluateApproval,
+  evaluateWorkspaceAccess,
+  isEmptyTokenPolicy,
+  isTokenExpired,
+  matchesApprovalPattern,
+  overridesGlobalAutoApproval,
+  parseTokenPolicy,
+  type ApiTokenPolicy,
+} from "./policy.js";
+
+describe("evaluateWorkspaceAccess", () => {
+  const cases: Array<{
+    name: string;
+    policy: ApiTokenPolicy | null | undefined;
+    workspaceId: string;
+    allowed: boolean;
+    reason?: string;
+  }> = [
+    { name: "no policy at all allows everything", policy: undefined, workspaceId: "w1", allowed: true },
+    { name: "null policy allows everything", policy: null, workspaceId: "w1", allowed: true },
+    { name: "absent allowlist allows everything", policy: {}, workspaceId: "w1", allowed: true },
+    { name: "explicit null allowlist allows everything", policy: { workspaces: null }, workspaceId: "w1", allowed: true },
+    { name: "allowlist hit", policy: { workspaces: ["w1", "w2"] }, workspaceId: "w2", allowed: true },
+    {
+      name: "allowlist miss",
+      policy: { workspaces: ["w1", "w2"] },
+      workspaceId: "w3",
+      allowed: false,
+      reason: "workspace_not_allowed",
+    },
+    {
+      name: "empty allowlist denies everything",
+      policy: { workspaces: [] },
+      workspaceId: "w1",
+      allowed: false,
+      reason: "workspace_allowlist_empty",
+    },
+    {
+      name: "an empty workspace id is never allowed under an allowlist",
+      policy: { workspaces: ["w1"] },
+      workspaceId: "",
+      allowed: false,
+      reason: "workspace_required",
+    },
+    {
+      name: "a whitespace-only workspace id is never allowed under an allowlist",
+      policy: { workspaces: ["w1"] },
+      workspaceId: "   ",
+      allowed: false,
+      reason: "workspace_required",
+    },
+    { name: "entries and inputs are trimmed", policy: { workspaces: [" w1 "] }, workspaceId: " w1 ", allowed: true },
+    {
+      name: "matching is case-sensitive",
+      policy: { workspaces: ["w1"] },
+      workspaceId: "W1",
+      allowed: false,
+      reason: "workspace_not_allowed",
+    },
+    {
+      name: "a wildcard is not a workspace glob",
+      policy: { workspaces: ["*"] },
+      workspaceId: "w1",
+      allowed: false,
+      reason: "workspace_not_allowed",
+    },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      const result = evaluateWorkspaceAccess(testCase.policy, testCase.workspaceId);
+      expect(result.allowed).toBe(testCase.allowed);
+      expect(result.reason).toBe(testCase.reason as string | undefined);
+    });
+  }
+
+  test("an empty workspace id is still allowed when the policy has no allowlist", () => {
+    expect(evaluateWorkspaceAccess({}, "").allowed).toBe(true);
+  });
+});
+
+describe("accessibleWorkspaces", () => {
+  test("returns every id when unconstrained", () => {
+    expect(accessibleWorkspaces({}, ["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  test("filters by the allowlist and preserves input order", () => {
+    expect(accessibleWorkspaces({ workspaces: ["b", "c"] }, ["a", "b", "c"])).toEqual(["b", "c"]);
+  });
+
+  test("an empty allowlist yields nothing", () => {
+    expect(accessibleWorkspaces({ workspaces: [] }, ["a", "b"])).toEqual([]);
+  });
+});
+
+describe("matchesApprovalPattern", () => {
+  const cases: Array<{ pattern: string; candidate: string; expected: boolean; note: string }> = [
+    { pattern: "session.prompt", candidate: "session.prompt", expected: true, note: "exact" },
+    { pattern: "session.prompt", candidate: "session.promptx", expected: false, note: "exact is not a prefix" },
+    { pattern: "*", candidate: "anything", expected: true, note: "bare star" },
+    { pattern: "session.*", candidate: "session.prompt", expected: true, note: "trailing glob" },
+    { pattern: "session.*", candidate: "session.", expected: true, note: "glob allows an empty tail" },
+    { pattern: "session.*", candidate: "sessions.prompt", expected: false, note: "prefix must match exactly" },
+    { pattern: "session.*", candidate: "file.edit", expected: false, note: "no match" },
+    { pattern: "", candidate: "anything", expected: false, note: "empty pattern matches nothing" },
+    { pattern: "   ", candidate: "anything", expected: false, note: "blank pattern matches nothing" },
+    { pattern: "read", candidate: "", expected: false, note: "empty candidate matches nothing" },
+    { pattern: " read ", candidate: "read", expected: true, note: "patterns are trimmed" },
+    { pattern: "se*ion", candidate: "session", expected: false, note: "a mid-string star is inert" },
+    { pattern: "**", candidate: "anything", expected: false, note: "a double star is inert" },
+    { pattern: "*.prompt", candidate: "session.prompt", expected: false, note: "leading star is not supported" },
+    // Regex-looking input is treated as literal text, never compiled.
+    { pattern: ".*", candidate: "session.prompt", expected: false, note: "regex any is a literal dot prefix" },
+    { pattern: ".*", candidate: ".danger", expected: true, note: "regex any only matches a literal leading dot" },
+    { pattern: "^(.*)$", candidate: "session.prompt", expected: false, note: "anchored regex matches nothing" },
+    { pattern: "(a|b)*", candidate: "a", expected: false, note: "alternation is literal" },
+    { pattern: "[a-z]+", candidate: "session", expected: false, note: "character class is literal" },
+    { pattern: ".*", candidate: "anything", expected: false, note: "regex any does not become a wildcard" },
+  ];
+
+  for (const testCase of cases) {
+    test(`${testCase.note}: "${testCase.pattern}" vs "${testCase.candidate}"`, () => {
+      expect(matchesApprovalPattern(testCase.pattern, testCase.candidate)).toBe(testCase.expected);
+    });
+  }
+});
+
+describe("evaluateApproval", () => {
+  const request = (effect: ApiEffect, action: string) => ({ effect, action });
+
+  const cases: Array<{
+    name: string;
+    policy: ApiTokenPolicy | null | undefined;
+    effect: ApiEffect;
+    action: string;
+    expected: "auto-approve" | "auto-deny" | "ask";
+  }> = [
+    { name: "no policy asks", policy: undefined, effect: "write", action: "session.prompt", expected: "ask" },
+    { name: "empty policy asks", policy: {}, effect: "write", action: "session.prompt", expected: "ask" },
+    {
+      name: "inherit asks so the global mode decides",
+      policy: { approvals: { mode: "inherit" } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "ask",
+    },
+    {
+      name: "auto approves",
+      policy: { approvals: { mode: "auto" } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "auto-approve",
+    },
+    {
+      name: "auto approves destructive too when denyDestructive is off",
+      policy: { approvals: { mode: "auto" } },
+      effect: "destructive",
+      action: "workspace.delete",
+      expected: "auto-approve",
+    },
+    {
+      name: "manual asks",
+      policy: { approvals: { mode: "manual" } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "ask",
+    },
+    {
+      name: "an exact autoApprove entry carves out of manual",
+      policy: { approvals: { mode: "manual", autoApprove: ["session.prompt"] } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "auto-approve",
+    },
+    {
+      name: "a non-matching autoApprove entry leaves manual asking",
+      policy: { approvals: { mode: "manual", autoApprove: ["file.edit"] } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "ask",
+    },
+    {
+      name: "an empty autoApprove list changes nothing",
+      policy: { approvals: { mode: "manual", autoApprove: [] } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "ask",
+    },
+    {
+      name: "a glob entry matches by action prefix",
+      policy: { approvals: { mode: "manual", autoApprove: ["session.*"] } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "auto-approve",
+    },
+    {
+      name: "an effect name is a valid pattern",
+      policy: { approvals: { mode: "manual", autoApprove: ["write"] } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "auto-approve",
+    },
+    {
+      name: "the effect: prefix form is also accepted",
+      policy: { approvals: { mode: "manual", autoApprove: ["effect:read"] } },
+      effect: "read",
+      action: "session.list",
+      expected: "auto-approve",
+    },
+    {
+      name: "an effect pattern does not leak across effects",
+      policy: { approvals: { mode: "manual", autoApprove: ["read"] } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "ask",
+    },
+    {
+      name: "denyDestructive overrides an exact autoApprove entry",
+      policy: { approvals: { mode: "manual", autoApprove: ["workspace.delete"], denyDestructive: true } },
+      effect: "destructive",
+      action: "workspace.delete",
+      expected: "auto-deny",
+    },
+    {
+      name: "denyDestructive overrides a star pattern",
+      policy: { approvals: { mode: "manual", autoApprove: ["*"], denyDestructive: true } },
+      effect: "destructive",
+      action: "workspace.delete",
+      expected: "auto-deny",
+    },
+    {
+      name: "denyDestructive overrides mode auto",
+      policy: { approvals: { mode: "auto", denyDestructive: true } },
+      effect: "destructive",
+      action: "workspace.delete",
+      expected: "auto-deny",
+    },
+    {
+      name: "denyDestructive leaves non-destructive effects alone",
+      policy: { approvals: { mode: "auto", denyDestructive: true } },
+      effect: "write",
+      action: "session.prompt",
+      expected: "auto-approve",
+    },
+    {
+      name: "a regex-looking pattern does not auto-approve",
+      policy: { approvals: { mode: "manual", autoApprove: [".*"] } },
+      effect: "destructive",
+      action: "workspace.delete",
+      expected: "ask",
+    },
+    {
+      name: "a mid-string star pattern does not auto-approve",
+      policy: { approvals: { mode: "manual", autoApprove: ["work*delete"] } },
+      effect: "destructive",
+      action: "workspace.delete",
+      expected: "ask",
+    },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      expect(evaluateApproval(testCase.policy, request(testCase.effect, testCase.action))).toBe(testCase.expected);
+    });
+  }
+
+  test("an empty action still matches on effect", () => {
+    expect(evaluateApproval({ approvals: { mode: "manual", autoApprove: ["write"] } }, request("write", "")))
+      .toBe("auto-approve");
+  });
+
+  test("an empty action never matches an action pattern", () => {
+    expect(evaluateApproval({ approvals: { mode: "manual", autoApprove: ["session.prompt"] } }, request("write", "")))
+      .toBe("ask");
+  });
+});
+
+describe("overridesGlobalAutoApproval", () => {
+  test("only manual overrides the global auto mode", () => {
+    expect(overridesGlobalAutoApproval({ approvals: { mode: "manual" } })).toBe(true);
+    expect(overridesGlobalAutoApproval({ approvals: { mode: "inherit" } })).toBe(false);
+    expect(overridesGlobalAutoApproval({ approvals: { mode: "auto" } })).toBe(false);
+    expect(overridesGlobalAutoApproval({})).toBe(false);
+    expect(overridesGlobalAutoApproval(null)).toBe(false);
+  });
+});
+
+describe("isTokenExpired", () => {
+  const now = 1_700_000_000_000;
+  const cases: Array<{ name: string; policy: ApiTokenPolicy | null | undefined; now: number; expected: boolean }> = [
+    { name: "no policy never expires", policy: undefined, now, expected: false },
+    { name: "null policy never expires", policy: null, now, expected: false },
+    { name: "absent expiresAt never expires", policy: {}, now, expected: false },
+    { name: "null expiresAt never expires", policy: { expiresAt: null }, now, expected: false },
+    { name: "future expiry is live", policy: { expiresAt: now + 1 }, now, expected: false },
+    { name: "past expiry is expired", policy: { expiresAt: now - 1 }, now, expected: true },
+    { name: "expiry exactly at now is expired", policy: { expiresAt: now }, now, expected: true },
+    { name: "NaN expiry is treated as no expiry", policy: { expiresAt: Number.NaN }, now, expected: false },
+    { name: "Infinity expiry is treated as no expiry", policy: { expiresAt: Number.POSITIVE_INFINITY }, now, expected: false },
+    { name: "a NaN clock never expires a token", policy: { expiresAt: now - 1 }, now: Number.NaN, expected: false },
+  ];
+
+  for (const testCase of cases) {
+    test(testCase.name, () => {
+      expect(isTokenExpired(testCase.policy, testCase.now)).toBe(testCase.expected);
+    });
+  }
+});
+
+describe("parseTokenPolicy", () => {
+  test("accepts an empty object", () => {
+    expect(parseTokenPolicy({})).toEqual({});
+  });
+
+  test("treats null and undefined as an empty policy", () => {
+    expect(parseTokenPolicy(null)).toEqual({});
+    expect(parseTokenPolicy(undefined)).toEqual({});
+  });
+
+  test("normalizes a full policy", () => {
+    expect(parseTokenPolicy({
+      workspaces: [" w1 ", "w2", "w1"],
+      approvals: { mode: "manual", autoApprove: [" session.* ", "session.*"], denyDestructive: true },
+      expiresAt: 1_700_000_000_000.7,
+    })).toEqual({
+      workspaces: ["w1", "w2"],
+      approvals: { mode: "manual", autoApprove: ["session.*"], denyDestructive: true },
+      expiresAt: 1_700_000_000_000,
+    });
+  });
+
+  test("defaults approvals.mode to inherit", () => {
+    expect(parseTokenPolicy({ approvals: { autoApprove: ["read"] } }))
+      .toEqual({ approvals: { mode: "inherit", autoApprove: ["read"] } });
+  });
+
+  test("keeps an explicit null workspaces allowlist distinguishable from absent", () => {
+    expect(parseTokenPolicy({ workspaces: null })).toEqual({ workspaces: null });
+    expect(parseTokenPolicy({})).toEqual({});
+  });
+
+  test("keeps an empty workspaces allowlist as a real lockout", () => {
+    expect(parseTokenPolicy({ workspaces: [] })).toEqual({ workspaces: [] });
+  });
+
+  const rejections: Array<{ name: string; input: unknown; field: string }> = [
+    { name: "an array body", input: ["w1"], field: "policy" },
+    { name: "a string body", input: "everything", field: "policy" },
+    { name: "an unknown top-level field", input: { scopes: ["owner"] }, field: "scopes" },
+    { name: "an unknown approvals field", input: { approvals: { allowAll: true } }, field: "approvals.allowAll" },
+    { name: "a bad approvals mode", input: { approvals: { mode: "always" } }, field: "approvals.mode" },
+    { name: "a non-object approvals", input: { approvals: "auto" }, field: "approvals" },
+    { name: "a non-array workspaces", input: { workspaces: "w1" }, field: "workspaces" },
+    { name: "a non-string workspace entry", input: { workspaces: [1] }, field: "workspaces" },
+    { name: "an empty workspace entry", input: { workspaces: [" "] }, field: "workspaces" },
+    { name: "a non-array autoApprove", input: { approvals: { autoApprove: "*" } }, field: "approvals.autoApprove" },
+    { name: "a non-string autoApprove entry", input: { approvals: { autoApprove: [{}] } }, field: "approvals.autoApprove" },
+    { name: "an empty autoApprove entry", input: { approvals: { autoApprove: [""] } }, field: "approvals.autoApprove" },
+    {
+      name: "an over-long autoApprove entry",
+      input: { approvals: { autoApprove: ["a".repeat(201)] } },
+      field: "approvals.autoApprove",
+    },
+    {
+      name: "a non-boolean denyDestructive",
+      input: { approvals: { denyDestructive: "yes" } },
+      field: "approvals.denyDestructive",
+    },
+    { name: "a string expiresAt", input: { expiresAt: "2026-01-01" }, field: "expiresAt" },
+    { name: "a NaN expiresAt", input: { expiresAt: Number.NaN }, field: "expiresAt" },
+    { name: "a zero expiresAt", input: { expiresAt: 0 }, field: "expiresAt" },
+    { name: "a negative expiresAt", input: { expiresAt: -1 }, field: "expiresAt" },
+    { name: "too many workspaces", input: { workspaces: Array.from({ length: 257 }, (_, i) => `w${i}`) }, field: "workspaces" },
+    {
+      name: "too many autoApprove entries",
+      input: { approvals: { autoApprove: Array.from({ length: 129 }, (_, i) => `a${i}`) } },
+      field: "approvals.autoApprove",
+    },
+  ];
+
+  for (const rejection of rejections) {
+    test(`rejects ${rejection.name}`, () => {
+      try {
+        parseTokenPolicy(rejection.input);
+        throw new Error("expected a throw");
+      } catch (error) {
+        expect(isApiError(error)).toBe(true);
+        expect((error as { status: number }).status).toBe(400);
+        expect((error as { code: string }).code).toBe("invalid_token_policy");
+        expect((error as { details: { field: string } }).details.field).toBe(rejection.field);
+      }
+    });
+  }
+
+  test("a regex-shaped autoApprove entry is stored verbatim, not compiled", () => {
+    const policy = parseTokenPolicy({ approvals: { autoApprove: ["^(.*)$"] } });
+    expect(policy.approvals?.autoApprove).toEqual(["^(.*)$"]);
+    expect(evaluateApproval(policy, { effect: "destructive", action: "workspace.delete" })).toBe("ask");
+  });
+});
+
+describe("isEmptyTokenPolicy", () => {
+  test("recognizes policies that constrain nothing", () => {
+    expect(isEmptyTokenPolicy({})).toBe(true);
+    expect(isEmptyTokenPolicy({ approvals: { mode: "inherit" } })).toBe(true);
+    expect(isEmptyTokenPolicy({ approvals: { mode: "inherit", autoApprove: [], denyDestructive: false } })).toBe(true);
+  });
+
+  test("recognizes policies that do constrain something", () => {
+    expect(isEmptyTokenPolicy({ workspaces: null })).toBe(false);
+    expect(isEmptyTokenPolicy({ workspaces: [] })).toBe(false);
+    expect(isEmptyTokenPolicy({ expiresAt: null })).toBe(false);
+    expect(isEmptyTokenPolicy({ approvals: { mode: "auto" } })).toBe(false);
+    expect(isEmptyTokenPolicy({ approvals: { mode: "inherit", autoApprove: ["read"] } })).toBe(false);
+    expect(isEmptyTokenPolicy({ approvals: { mode: "inherit", denyDestructive: true } })).toBe(false);
+  });
+});
+
+describe("describeTokenPolicy", () => {
+  test("resolves every default", () => {
+    expect(describeTokenPolicy({}, 1_000)).toEqual({
+      workspaces: null,
+      approvals: { mode: "inherit", autoApprove: [], denyDestructive: false },
+      expiresAt: null,
+      expired: false,
+    });
+  });
+
+  test("reports expiry against the supplied clock", () => {
+    expect(describeTokenPolicy({ expiresAt: 500 }, 1_000).expired).toBe(true);
+    expect(describeTokenPolicy({ expiresAt: 5_000 }, 1_000).expired).toBe(false);
+  });
+});

--- a/apps/server/src/api/modules/policy/policy.ts
+++ b/apps/server/src/api/modules/policy/policy.ts
@@ -1,0 +1,340 @@
+import { ApiError } from "../../../errors.js";
+import type { ApiEffect } from "../../module.js";
+
+/**
+ * Per-token policy: the fine-grained counterpart to the three global token scopes.
+ *
+ * A scope answers "how much may this token do at all"; a policy answers "where may it
+ * do it, and what may it do without a human in the loop". Everything in this file is
+ * pure: no clock, no filesystem, no request context. The module wires it to storage.
+ */
+
+export type ApiTokenApprovalMode = "inherit" | "auto" | "manual";
+
+export interface ApiTokenApprovalPolicy {
+  /**
+   * `inherit` defers to the server-wide `IPOLLOWORK_APPROVAL_MODE`.
+   * `auto` approves without asking. `manual` always asks, even when the server runs
+   * in global auto mode (see `overridesGlobalAutoApproval`).
+   */
+  mode: ApiTokenApprovalMode;
+  /** Effect or action patterns approved without asking. See `matchesApprovalPattern`. */
+  autoApprove?: string[];
+  /** When true, a `destructive` effect is denied outright and no pattern can re-allow it. */
+  denyDestructive?: boolean;
+}
+
+export interface ApiTokenPolicy {
+  /** `null` or absent means every workspace. An array is an exact-match allowlist. */
+  workspaces?: string[] | null;
+  approvals?: ApiTokenApprovalPolicy;
+  /** Epoch milliseconds. `null` or absent means the token never expires. */
+  expiresAt?: number | null;
+}
+
+export interface WorkspaceAccessResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+export interface ApprovalEvaluationInput {
+  effect: ApiEffect;
+  action: string;
+}
+
+export type ApprovalDecision = "auto-approve" | "auto-deny" | "ask";
+
+/** A policy that constrains nothing. Used whenever a token has no stored policy. */
+export const EMPTY_TOKEN_POLICY: ApiTokenPolicy = Object.freeze({});
+
+const APPROVAL_MODES: readonly ApiTokenApprovalMode[] = ["inherit", "auto", "manual"];
+
+const MAX_WORKSPACE_ENTRIES = 256;
+const MAX_AUTO_APPROVE_ENTRIES = 128;
+const MAX_PATTERN_LENGTH = 200;
+
+/**
+ * Workspace allowlist check.
+ *
+ * - absent / `null` allowlist -> every workspace is allowed
+ * - empty array -> nothing is allowed (a deliberate lockout, not a synonym for "all")
+ * - otherwise -> exact, case-sensitive, trimmed match. No globs here: a workspace id is
+ *   an identifier, and a prefix wildcard over identifiers is an easy way to leak access.
+ */
+export function evaluateWorkspaceAccess(
+  policy: ApiTokenPolicy | null | undefined,
+  workspaceId: string,
+): WorkspaceAccessResult {
+  const allowlist = policy?.workspaces;
+  if (allowlist === undefined || allowlist === null) {
+    return { allowed: true };
+  }
+
+  const id = typeof workspaceId === "string" ? workspaceId.trim() : "";
+  if (!id) {
+    return { allowed: false, reason: "workspace_required" };
+  }
+  if (!Array.isArray(allowlist) || allowlist.length === 0) {
+    return { allowed: false, reason: "workspace_allowlist_empty" };
+  }
+  const hit = allowlist.some((entry) => typeof entry === "string" && entry.trim() === id);
+  return hit ? { allowed: true } : { allowed: false, reason: "workspace_not_allowed" };
+}
+
+/** Filters a set of workspace ids down to the ones the policy allows. */
+export function accessibleWorkspaces(
+  policy: ApiTokenPolicy | null | undefined,
+  workspaceIds: readonly string[],
+): string[] {
+  return workspaceIds.filter((id) => evaluateWorkspaceAccess(policy, id).allowed);
+}
+
+/**
+ * Approval-pattern matching.
+ *
+ * The grammar is deliberately tiny and implemented with string operations only, so a
+ * stored pattern can never become a regular expression:
+ *   - `*`            matches everything
+ *   - `session.prompt` exact match
+ *   - `session.*`    prefix match (a single `*`, only ever as the last character)
+ * Anything else - a `*` in the middle, two stars, an empty pattern - matches nothing.
+ * A regex-looking string such as `.*` is treated as the literal prefix `.`, and
+ * `^(.*)$` matches nothing at all.
+ */
+export function matchesApprovalPattern(pattern: string, candidate: string): boolean {
+  if (typeof pattern !== "string" || typeof candidate !== "string") return false;
+  const p = pattern.trim();
+  const c = candidate.trim();
+  if (!p || !c) return false;
+
+  const star = p.indexOf("*");
+  if (star === -1) return p === c;
+  // Only a single trailing `*` is a wildcard; every other placement is inert.
+  if (star !== p.length - 1) return false;
+
+  const prefix = p.slice(0, -1);
+  if (!prefix) return true;
+  return c.startsWith(prefix);
+}
+
+/** The strings an autoApprove pattern is tested against. */
+export function approvalCandidates(request: ApprovalEvaluationInput): string[] {
+  const action = typeof request.action === "string" ? request.action.trim() : "";
+  const effect = request.effect;
+  const candidates = [action, effect, `effect:${effect}`];
+  return candidates.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+/**
+ * Decides what happens to an approval request for this token.
+ *
+ * Order matters:
+ *   1. `denyDestructive` wins over everything, including an `autoApprove` pattern and
+ *      `mode: "auto"`. A destructive call on such a token is never silently allowed.
+ *   2. an `autoApprove` match approves, which is what makes carve-outs on top of
+ *      `mode: "manual"` possible.
+ *   3. otherwise the mode decides: `auto` approves, `manual` and `inherit` ask.
+ *
+ * `manual` and `inherit` both return `"ask"`; they differ in what the caller may do
+ * with the ambient global approval mode - see `overridesGlobalAutoApproval`.
+ */
+export function evaluateApproval(
+  policy: ApiTokenPolicy | null | undefined,
+  request: ApprovalEvaluationInput,
+): ApprovalDecision {
+  const approvals = policy?.approvals;
+
+  if (approvals?.denyDestructive === true && request.effect === "destructive") {
+    return "auto-deny";
+  }
+
+  const patterns = approvals?.autoApprove ?? [];
+  if (patterns.length > 0) {
+    const candidates = approvalCandidates(request);
+    const approved = patterns.some((pattern) =>
+      candidates.some((candidate) => matchesApprovalPattern(pattern, candidate)),
+    );
+    if (approved) return "auto-approve";
+  }
+
+  const mode = approvals?.mode ?? "inherit";
+  if (mode === "auto") return "auto-approve";
+  return "ask";
+}
+
+/**
+ * True when an `"ask"` decision must reach a human even though the server runs with
+ * `IPOLLOWORK_APPROVAL_MODE=auto`. Only `mode: "manual"` does that.
+ */
+export function overridesGlobalAutoApproval(policy: ApiTokenPolicy | null | undefined): boolean {
+  return (policy?.approvals?.mode ?? "inherit") === "manual";
+}
+
+/** Expiry check. Absent, `null` and non-finite values all mean "never expires". */
+export function isTokenExpired(policy: ApiTokenPolicy | null | undefined, now: number): boolean {
+  const expiresAt = policy?.expiresAt;
+  if (expiresAt === undefined || expiresAt === null) return false;
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return false;
+  if (typeof now !== "number" || !Number.isFinite(now)) return false;
+  return now >= expiresAt;
+}
+
+/** True when the policy constrains nothing, so storing it would be pure noise. */
+export function isEmptyTokenPolicy(policy: ApiTokenPolicy): boolean {
+  if (policy.workspaces !== undefined) return false;
+  if (policy.expiresAt !== undefined) return false;
+  const approvals = policy.approvals;
+  if (!approvals) return true;
+  if (approvals.mode !== "inherit") return false;
+  if (approvals.autoApprove && approvals.autoApprove.length > 0) return false;
+  if (approvals.denyDestructive) return false;
+  return true;
+}
+
+function invalid(message: string, field: string): ApiError {
+  return new ApiError(400, "invalid_token_policy", message, { field });
+}
+
+function parsePatternList(value: unknown, field: string, max: number): string[] {
+  if (!Array.isArray(value)) {
+    throw invalid(`${field} must be an array of strings`, field);
+  }
+  if (value.length > max) {
+    throw invalid(`${field} accepts at most ${max} entries`, field);
+  }
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      throw invalid(`${field} must contain only strings`, field);
+    }
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      throw invalid(`${field} must not contain empty entries`, field);
+    }
+    if (trimmed.length > MAX_PATTERN_LENGTH) {
+      throw invalid(`${field} entries must be at most ${MAX_PATTERN_LENGTH} characters`, field);
+    }
+    if (!out.includes(trimmed)) out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Validates and normalizes untrusted policy input.
+ *
+ * Unknown fields are rejected rather than ignored: a typo in a security policy that
+ * silently does nothing is worse than a 400.
+ */
+export function parseTokenPolicy(input: unknown): ApiTokenPolicy {
+  if (input === undefined || input === null) return {};
+  if (typeof input !== "object" || Array.isArray(input)) {
+    throw invalid("Policy must be an object", "policy");
+  }
+
+  const raw = input as Record<string, unknown>;
+  for (const key of Object.keys(raw)) {
+    if (key !== "workspaces" && key !== "approvals" && key !== "expiresAt") {
+      throw invalid(`Unknown policy field: ${key}`, key);
+    }
+  }
+
+  const policy: ApiTokenPolicy = {};
+
+  if ("workspaces" in raw) {
+    const value = raw.workspaces;
+    if (value === null) {
+      policy.workspaces = null;
+    } else if (Array.isArray(value)) {
+      if (value.length > MAX_WORKSPACE_ENTRIES) {
+        throw invalid(`workspaces accepts at most ${MAX_WORKSPACE_ENTRIES} entries`, "workspaces");
+      }
+      const ids: string[] = [];
+      for (const entry of value) {
+        if (typeof entry !== "string") {
+          throw invalid("workspaces must contain only strings", "workspaces");
+        }
+        const trimmed = entry.trim();
+        if (!trimmed) {
+          throw invalid("workspaces must not contain empty entries", "workspaces");
+        }
+        if (!ids.includes(trimmed)) ids.push(trimmed);
+      }
+      policy.workspaces = ids;
+    } else if (value !== undefined) {
+      throw invalid("workspaces must be an array of workspace ids or null", "workspaces");
+    }
+  }
+
+  if ("approvals" in raw && raw.approvals !== undefined && raw.approvals !== null) {
+    const value = raw.approvals;
+    if (typeof value !== "object" || Array.isArray(value)) {
+      throw invalid("approvals must be an object", "approvals");
+    }
+    const approvalsRaw = value as Record<string, unknown>;
+    for (const key of Object.keys(approvalsRaw)) {
+      if (key !== "mode" && key !== "autoApprove" && key !== "denyDestructive") {
+        throw invalid(`Unknown approvals field: ${key}`, `approvals.${key}`);
+      }
+    }
+
+    const modeRaw = approvalsRaw.mode;
+    let mode: ApiTokenApprovalMode = "inherit";
+    if (modeRaw !== undefined && modeRaw !== null) {
+      if (typeof modeRaw !== "string" || !APPROVAL_MODES.includes(modeRaw as ApiTokenApprovalMode)) {
+        throw invalid("approvals.mode must be inherit, auto, or manual", "approvals.mode");
+      }
+      mode = modeRaw as ApiTokenApprovalMode;
+    }
+
+    const approvals: ApiTokenApprovalPolicy = { mode };
+
+    if (approvalsRaw.autoApprove !== undefined && approvalsRaw.autoApprove !== null) {
+      approvals.autoApprove = parsePatternList(
+        approvalsRaw.autoApprove,
+        "approvals.autoApprove",
+        MAX_AUTO_APPROVE_ENTRIES,
+      );
+    }
+
+    if (approvalsRaw.denyDestructive !== undefined && approvalsRaw.denyDestructive !== null) {
+      if (typeof approvalsRaw.denyDestructive !== "boolean") {
+        throw invalid("approvals.denyDestructive must be a boolean", "approvals.denyDestructive");
+      }
+      approvals.denyDestructive = approvalsRaw.denyDestructive;
+    }
+
+    policy.approvals = approvals;
+  }
+
+  if ("expiresAt" in raw) {
+    const value = raw.expiresAt;
+    if (value === null) {
+      policy.expiresAt = null;
+    } else if (value !== undefined) {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        throw invalid("expiresAt must be epoch milliseconds or null", "expiresAt");
+      }
+      if (value <= 0) {
+        throw invalid("expiresAt must be a positive epoch timestamp", "expiresAt");
+      }
+      policy.expiresAt = Math.floor(value);
+    }
+  }
+
+  return policy;
+}
+
+/** Serializable view of a policy, with every default made explicit. */
+export function describeTokenPolicy(policy: ApiTokenPolicy | null | undefined, now: number) {
+  const resolved = policy ?? EMPTY_TOKEN_POLICY;
+  return {
+    workspaces: resolved.workspaces ?? null,
+    approvals: {
+      mode: resolved.approvals?.mode ?? "inherit",
+      autoApprove: resolved.approvals?.autoApprove ?? [],
+      denyDestructive: resolved.approvals?.denyDestructive ?? false,
+    },
+    expiresAt: resolved.expiresAt ?? null,
+    expired: isTokenExpired(resolved, now),
+  };
+}

--- a/apps/server/src/api/modules/sessions/module.test.ts
+++ b/apps/server/src/api/modules/sessions/module.test.ts
@@ -1,0 +1,624 @@
+import { describe, expect, test } from "bun:test";
+
+import { isApiError } from "../../../errors.js";
+import type { RequestContext, Route } from "../../../routes/registry.js";
+import { matchRoute } from "../../../routes/registry.js";
+import type { ServerConfig } from "../../../types.js";
+import type {
+  EngineAdapter,
+  EngineAdapterRegistry,
+  EngineCapabilities,
+  EngineConnection,
+  EngineEvent,
+  EnginePermission,
+  EnginePromptInput,
+  EngineQuestion,
+  EngineSession,
+  EngineSubscribeInput,
+} from "../../engine/types.js";
+import { registerApiModules, type ApiModuleContext, type ApiOperation } from "../../module.js";
+import {
+  buildPromptParts,
+  formatSessionEventFrame,
+  sessionEventToSseFrame,
+  sessionsModule,
+  SESSIONS_OPERATION_IDS,
+} from "./module.js";
+
+const config = { workspaces: [], readOnly: false } as unknown as ServerConfig;
+
+const FULL_CAPABILITIES: EngineCapabilities = {
+  streaming: true,
+  resumableStreaming: true,
+  permissions: true,
+  questions: true,
+  interrupt: true,
+  wait: true,
+  promptOptions: { system: true, reasoningEffort: true, variant: true },
+};
+
+interface StubCall {
+  name: string;
+  args: unknown;
+}
+
+interface StubConnection {
+  connection: EngineConnection;
+  calls: StubCall[];
+  /** Events the stubbed `subscribe` replays before resolving. */
+  events: EngineEvent[];
+  subscribed: EngineSubscribeInput[];
+}
+
+function session(overrides: Partial<EngineSession> = {}): EngineSession {
+  return { id: "s1", title: "Session one", ...overrides };
+}
+
+function createStubConnection(
+  capabilities: Partial<EngineCapabilities> = {},
+  engineId = "opencode",
+): StubConnection {
+  const calls: StubCall[] = [];
+  const events: EngineEvent[] = [];
+  const subscribed: EngineSubscribeInput[] = [];
+  const record = (name: string, args: unknown) => {
+    calls.push({ name, args });
+  };
+
+  const connection: EngineConnection = {
+    engineId,
+    // `promptOptions` is nested, so a spread alone would hand every stub the same object
+    // and let one test's mutation leak into the next.
+    capabilities: {
+      ...FULL_CAPABILITIES,
+      ...capabilities,
+      promptOptions: { ...FULL_CAPABILITIES.promptOptions, ...capabilities.promptOptions },
+    },
+    async createSession(input) {
+      record("createSession", input);
+      return session({ id: "created-1", title: input.title ?? "Untitled" });
+    },
+    async getSession(sessionId) {
+      record("getSession", sessionId);
+      return session({ id: sessionId, title: "Renamed" });
+    },
+    async deleteSession(sessionId) {
+      record("deleteSession", sessionId);
+    },
+    async renameSession(sessionId, title) {
+      record("renameSession", { sessionId, title });
+    },
+    async prompt(input: EnginePromptInput) {
+      record("prompt", input);
+      return { messageId: "msg-1" };
+    },
+    async interrupt(sessionId) {
+      record("interrupt", sessionId);
+      return true;
+    },
+    async wait(sessionId) {
+      record("wait", sessionId);
+    },
+    async listPermissions(sessionId) {
+      record("listPermissions", sessionId);
+      const permission: EnginePermission = {
+        id: "p1",
+        sessionId,
+        kind: "bash",
+        resources: ["ls"],
+        remember: ["session"],
+        metadata: {},
+        receivedAt: 1,
+      };
+      return [permission];
+    },
+    async replyPermission(input) {
+      record("replyPermission", input);
+    },
+    async listQuestions(sessionId) {
+      record("listQuestions", sessionId);
+      const question: EngineQuestion = {
+        id: "q1",
+        sessionId,
+        questions: [{ question: "Proceed?", options: [{ label: "Yes" }, { label: "No" }] }],
+        receivedAt: 2,
+      };
+      return [question];
+    },
+    async replyQuestion(input) {
+      record("replyQuestion", input);
+    },
+    async subscribe(input) {
+      record("subscribe", { sessionId: input.sessionId, after: input.after });
+      subscribed.push(input);
+      for (const event of events) input.onEvent(event);
+    },
+  };
+
+  return { connection, calls, events, subscribed };
+}
+
+function createRegistry(connection: EngineConnection, engineId = "opencode"): EngineAdapterRegistry {
+  const adapter: EngineAdapter = { id: engineId, connect: () => connection };
+  return {
+    get: () => adapter,
+    has: () => true,
+    ids: () => [engineId],
+  } as unknown as EngineAdapterRegistry;
+}
+
+function createContext(connection: EngineConnection, overrides: Partial<ApiModuleContext> = {}): ApiModuleContext {
+  return {
+    config,
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+    readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+    resolveWorkspace: async (_config, id) => ({ id, engineId: connection.engineId }),
+    services: { engines: createRegistry(connection, connection.engineId) },
+    ...overrides,
+  };
+}
+
+function requestContext(request: Request, params: Record<string, string>): RequestContext {
+  return {
+    request,
+    url: new URL(request.url),
+    params,
+    config,
+    approvals: {} as never,
+    reloadEvents: {} as never,
+    tokens: {} as never,
+  };
+}
+
+function operations(context: ApiModuleContext): Map<string, ApiOperation> {
+  return new Map(sessionsModule.register(context).map((operation) => [operation.operationId, operation]));
+}
+
+interface InvokeInput {
+  body?: unknown;
+  params?: Record<string, string>;
+  search?: string;
+  signal?: AbortSignal;
+}
+
+async function invoke(
+  operationId: string,
+  connection: EngineConnection,
+  input: InvokeInput = {},
+  contextOverrides: Partial<ApiModuleContext> = {},
+): Promise<Response> {
+  const context = createContext(connection, contextOverrides);
+  const operation = operations(context).get(operationId);
+  if (!operation) throw new Error(`Unknown operation: ${operationId}`);
+  const params = { workspaceId: "w1", sessionId: "s1", ...input.params };
+  const url = `http://localhost/api/v1/workspaces/w1/sessions/s1${input.search ?? ""}`;
+  const request = new Request(url, {
+    method: operation.method,
+    ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
+    ...(input.signal ? { signal: input.signal } : {}),
+  });
+  return operation.handler(requestContext(request, params));
+}
+
+async function expectApiError(promise: Promise<unknown>): Promise<{ status: number; code: string; details?: unknown }> {
+  try {
+    await promise;
+  } catch (error) {
+    if (!isApiError(error)) throw error;
+    return { status: error.status, code: error.code, details: error.details };
+  }
+  throw new Error("Expected the handler to throw an ApiError");
+}
+
+describe("sessionsModule declaration", () => {
+  test("registers exactly the documented operation ids, in order", () => {
+    const stub = createStubConnection();
+    const ids = sessionsModule.register(createContext(stub.connection)).map((operation) => operation.operationId);
+    expect(ids).toEqual([...SESSIONS_OPERATION_IDS]);
+  });
+
+  test("identifies itself as a stable 1.0.0 module", () => {
+    expect(sessionsModule.id).toBe("sessions");
+    expect(sessionsModule.version).toBe("1.0.0");
+    expect(sessionsModule.stability).toBe("stable");
+  });
+
+  test("every operation carries a summary, a v1 path and at least one documented response", () => {
+    const stub = createStubConnection();
+    for (const operation of sessionsModule.register(createContext(stub.connection))) {
+      expect(operation.summary.length).toBeGreaterThan(0);
+      expect(operation.description?.length ?? 0).toBeGreaterThan(0);
+      expect(operation.path.startsWith("/api/v1/workspaces/:workspaceId/sessions")).toBe(true);
+      const responses = Object.entries(operation.responses ?? {});
+      expect(responses.length).toBeGreaterThan(0);
+      for (const [, spec] of responses) {
+        expect(spec.description.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("documents a request body for every operation that reads one", () => {
+    const stub = createStubConnection();
+    const byId = operations(createContext(stub.connection));
+    for (const id of ["createSession", "updateSession", "promptSession", "replySessionPermission", "replySessionQuestion"]) {
+      expect(byId.get(id)?.requestBody).toBeDefined();
+    }
+    expect(byId.get("streamSessionEvents")?.query).toBeDefined();
+    expect(byId.get("streamSessionEvents")?.streaming).toBe("sse");
+    expect(byId.get("deleteSession")?.effect).toBe("destructive");
+  });
+
+  test("registers routable paths on the shared route table", () => {
+    const stub = createStubConnection();
+    const routes: Route[] = [];
+    const result = registerApiModules(routes, [sessionsModule], createContext(stub.connection));
+    expect(result.operations).toHaveLength(SESSIONS_OPERATION_IDS.length);
+
+    const matched = matchRoute(routes, "POST", "/api/v1/workspaces/w1/sessions/s1/permissions/perm-9");
+    expect(matched).not.toBeNull();
+    expect(matched?.params).toEqual({ workspaceId: "w1", sessionId: "s1", permissionId: "perm-9" });
+  });
+});
+
+describe("engine-backed handlers", () => {
+  test("createSession forwards the body and answers 201", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("createSession", stub.connection, {
+      body: { title: "Nightly run", agent: "build", model: { providerID: "anthropic", modelID: "claude" } },
+      params: { sessionId: "" },
+    });
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({
+      session: { id: "created-1", title: "Nightly run" },
+      engine: "opencode",
+      capabilities: FULL_CAPABILITIES,
+    });
+    expect(stub.calls[0]).toEqual({
+      name: "createSession",
+      args: { title: "Nightly run", agent: "build", model: { providerID: "anthropic", modelID: "claude" } },
+    });
+  });
+
+  test("promptSession folds `text` into a leading text part and answers 202", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("promptSession", stub.connection, {
+      body: {
+        text: "hello",
+        parts: [{ type: "file", mime: "image/png", url: "https://example.test/a.png" }],
+        delivery: "queue",
+      },
+    });
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ accepted: true, sessionId: "s1", messageId: "msg-1" });
+    expect(stub.calls[0]?.name).toBe("prompt");
+    expect(stub.calls[0]?.args).toEqual({
+      sessionId: "s1",
+      parts: [
+        { type: "text", text: "hello" },
+        { type: "file", mime: "image/png", url: "https://example.test/a.png" },
+      ],
+      delivery: "queue",
+    });
+  });
+
+  test("promptSession rejects a prompt option the engine would silently drop", async () => {
+    const stub = createStubConnection();
+    stub.connection.capabilities.promptOptions.system = false;
+
+    const error = await expectApiError(
+      invoke("promptSession", stub.connection, { body: { text: "hi", system: "be terse" } }),
+    );
+
+    expect(error.status).toBe(501);
+    expect(error.code).toBe("engine_prompt_option_unsupported");
+    expect(error.details).toMatchObject({ unsupported: ["system"] });
+    // The turn must not reach the engine at all, or the caller would be billed for a run
+    // whose system prompt was never applied.
+    expect(stub.calls).toEqual([]);
+  });
+
+  test("promptSession names every unsupported option, not just the first", async () => {
+    const stub = createStubConnection();
+    stub.connection.capabilities.promptOptions.system = false;
+    stub.connection.capabilities.promptOptions.reasoningEffort = false;
+
+    const error = await expectApiError(
+      invoke("promptSession", stub.connection, {
+        body: { text: "hi", system: "be terse", reasoningEffort: "high", variant: "thinking" },
+      }),
+    );
+
+    expect(error.details).toMatchObject({ unsupported: ["system", "reasoningEffort"] });
+  });
+
+  test("promptSession passes supported options through", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("promptSession", stub.connection, {
+      body: { text: "hi", system: "be terse", reasoningEffort: "high", variant: "thinking" },
+    });
+
+    expect(response.status).toBe(202);
+    expect(stub.calls[0]?.args).toMatchObject({
+      system: "be terse",
+      reasoningEffort: "high",
+      variant: "thinking",
+    });
+  });
+
+  test("interruptSession reports the engine result", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("interruptSession", stub.connection);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ interrupted: true, sessionId: "s1" });
+    expect(stub.calls).toEqual([{ name: "interrupt", args: "s1" }]);
+  });
+
+  test("updateSession renames then re-reads the session", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("updateSession", stub.connection, { body: { title: "Renamed" } });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ session: { id: "s1", title: "Renamed" } });
+    expect(stub.calls.map((call) => call.name)).toEqual(["renameSession", "getSession"]);
+  });
+
+  test("deleteSession reports the deleted id", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("deleteSession", stub.connection);
+    expect(await response.json()).toEqual({ deleted: true, sessionId: "s1" });
+    expect(stub.calls).toEqual([{ name: "deleteSession", args: "s1" }]);
+  });
+
+  test("permission and question replies pass the path ids through", async () => {
+    const stub = createStubConnection();
+    const permission = await invoke("replySessionPermission", stub.connection, {
+      body: { reply: "always" },
+      params: { permissionId: "perm-9" },
+    });
+    expect(await permission.json()).toEqual({ ok: true, permissionId: "perm-9", reply: "always" });
+
+    const question = await invoke("replySessionQuestion", stub.connection, {
+      body: { answers: [["Yes"]] },
+      params: { questionId: "q-3" },
+    });
+    expect(await question.json()).toEqual({ ok: true, questionId: "q-3" });
+
+    expect(stub.calls).toEqual([
+      { name: "replyPermission", args: { sessionId: "s1", permissionId: "perm-9", reply: "always" } },
+      { name: "replyQuestion", args: { sessionId: "s1", questionId: "q-3", answers: [["Yes"]] } },
+    ]);
+  });
+
+  test("list endpoints wrap the engine collections", async () => {
+    const stub = createStubConnection();
+    expect(await (await invoke("listSessionPermissions", stub.connection)).json()).toMatchObject({
+      permissions: [{ id: "p1", kind: "bash" }],
+    });
+    expect(await (await invoke("listSessionQuestions", stub.connection)).json()).toMatchObject({
+      questions: [{ id: "q1" }],
+    });
+  });
+
+  test("a missing engine registry is a 500 rather than a crash", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(
+      invoke("getSession", stub.connection, {}, { services: {} }),
+    );
+    expect(error.status).toBe(500);
+    expect(error.code).toBe("engine_registry_unavailable");
+  });
+});
+
+describe("request validation", () => {
+  test("rejects a non-string title with 400 invalid_payload and issue details", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(invoke("createSession", stub.connection, { body: { title: 42 } }));
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("invalid_payload");
+    expect((error.details as { issues: Array<{ path: string }> }).issues[0]?.path).toBe("title");
+  });
+
+  test("rejects unknown body properties", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(invoke("createSession", stub.connection, { body: { nope: true } }));
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("invalid_payload");
+  });
+
+  test("rejects a prompt with neither text nor parts", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(invoke("promptSession", stub.connection, { body: { delivery: "steer" } }));
+    expect(error.status).toBe(400);
+    expect((error.details as { issues: Array<{ message: string }> }).issues[0]?.message).toContain("non-empty `parts`");
+    expect(stub.calls).toEqual([]);
+  });
+
+  test("rejects an unknown prompt part type", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(
+      invoke("promptSession", stub.connection, { body: { parts: [{ type: "video", url: "x" }] } }),
+    );
+    expect(error.status).toBe(400);
+  });
+
+  test("rejects an unknown permission reply", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(
+      invoke("replySessionPermission", stub.connection, { body: { reply: "maybe" }, params: { permissionId: "p" } }),
+    );
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("invalid_payload");
+  });
+
+  test("rejects an empty answers array", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(
+      invoke("replySessionQuestion", stub.connection, { body: { answers: [] }, params: { questionId: "q" } }),
+    );
+    expect(error.status).toBe(400);
+  });
+
+  test("rejects a blank path parameter", async () => {
+    const stub = createStubConnection();
+    const error = await expectApiError(invoke("getSession", stub.connection, { params: { sessionId: "  " } }));
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("invalid_request");
+  });
+
+  test("buildPromptParts keeps text first and preserves part order", () => {
+    expect(
+      buildPromptParts({ text: "a", parts: [{ type: "agent", name: "build" }, { type: "text", text: "b" }] }),
+    ).toEqual([
+      { type: "text", text: "a" },
+      { type: "agent", name: "build" },
+      { type: "text", text: "b" },
+    ]);
+  });
+});
+
+describe("capability gating", () => {
+  test("interrupt is 501 when the engine cannot interrupt", async () => {
+    const stub = createStubConnection({ interrupt: false }, "deepseek-harness");
+    const error = await expectApiError(invoke("interruptSession", stub.connection));
+    expect(error.status).toBe(501);
+    expect(error.code).toBe("engine_capability_unsupported");
+    expect(error.details).toEqual({
+      engine: "deepseek-harness",
+      capability: "interrupt",
+      operationId: "interruptSession",
+    });
+    expect(stub.calls).toEqual([]);
+  });
+
+  test("permissions and questions are 501 when unsupported", async () => {
+    const noPermissions = createStubConnection({ permissions: false }, "deepseek-harness");
+    expect((await expectApiError(invoke("listSessionPermissions", noPermissions.connection))).status).toBe(501);
+    const noQuestions = createStubConnection({ questions: false }, "deepseek-harness");
+    expect((await expectApiError(invoke("listSessionQuestions", noQuestions.connection))).status).toBe(501);
+  });
+
+  test("streaming is 501 when the engine cannot stream", async () => {
+    const stub = createStubConnection({ streaming: false }, "deepseek-harness");
+    const error = await expectApiError(invoke("streamSessionEvents", stub.connection));
+    expect(error.status).toBe(501);
+    expect((error.details as { capability: string }).capability).toBe("streaming");
+  });
+
+  test("`?after=` is 501 when the engine stream is not resumable", async () => {
+    const stub = createStubConnection({ resumableStreaming: false }, "deepseek-harness");
+    const error = await expectApiError(invoke("streamSessionEvents", stub.connection, { search: "?after=42" }));
+    expect(error.status).toBe(501);
+    expect((error.details as { capability: string }).capability).toBe("resumableStreaming");
+  });
+
+  test("a non-resumable engine still streams without `?after=`", async () => {
+    const stub = createStubConnection({ resumableStreaming: false }, "deepseek-harness");
+    const response = await invoke("streamSessionEvents", stub.connection);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+    await response.body?.cancel();
+  });
+});
+
+describe("SSE framing", () => {
+  test("maps an event type onto the event line and seq onto the id line", () => {
+    const event: EngineEvent = {
+      type: "message.delta",
+      sessionId: "s1",
+      messageId: "m1",
+      partId: "p1",
+      kind: "text",
+      delta: "hi",
+      seq: "17",
+    };
+    expect(sessionEventToSseFrame(event)).toEqual({
+      event: "message.delta",
+      id: "17",
+      data: { type: "message.delta", sessionId: "s1", messageId: "m1", partId: "p1", kind: "text", delta: "hi" },
+    });
+    expect(formatSessionEventFrame(event)).toBe(
+      'id: 17\nevent: message.delta\ndata: {"type":"message.delta","sessionId":"s1","messageId":"m1","partId":"p1","kind":"text","delta":"hi"}\n\n',
+    );
+  });
+
+  test("omits the id line when the engine reports no cursor", () => {
+    const frame = formatSessionEventFrame({ type: "session.idle", sessionId: "s1" });
+    expect(frame).toBe('event: session.idle\ndata: {"type":"session.idle","sessionId":"s1"}\n\n');
+    expect(frame.includes("id:")).toBe(false);
+  });
+
+  test("every frame ends with a blank line and has exactly one event line", () => {
+    const frame = formatSessionEventFrame({
+      type: "tool.called",
+      sessionId: "s1",
+      messageId: "m1",
+      callId: "c1",
+      tool: "bash",
+      input: { command: "ls" },
+      seq: "3",
+    });
+    expect(frame.endsWith("\n\n")).toBe(true);
+    expect(frame.split("\n").filter((line) => line.startsWith("event:"))).toHaveLength(1);
+    expect(frame.split("\n").filter((line) => line.startsWith("data:"))).toHaveLength(1);
+  });
+});
+
+describe("streamSessionEvents", () => {
+  test("opens with a hello frame, replays engine events, and closes", async () => {
+    const stub = createStubConnection();
+    stub.events.push(
+      { type: "session.status", sessionId: "s1", status: { type: "busy" }, seq: "1" },
+      { type: "session.idle", sessionId: "s1", seq: "2" },
+    );
+    const response = await invoke("streamSessionEvents", stub.connection, { search: "?after=0" });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-cache, no-transform");
+
+    const body = await new Response(response.body).text();
+    expect(body).toContain("event: stream.open");
+    expect(body).toContain('"after":"0"');
+    expect(body).toContain("id: 1\nevent: session.status\n");
+    expect(body).toContain("id: 2\nevent: session.idle\n");
+
+    const subscribe = stub.calls.find((call) => call.name === "subscribe");
+    expect(subscribe?.args).toEqual({ sessionId: "s1", after: "0" });
+  });
+
+  test("resolves the session before opening the stream", async () => {
+    const stub = createStubConnection();
+    const response = await invoke("streamSessionEvents", stub.connection);
+    expect(stub.calls[0]?.name).toBe("getSession");
+    await response.body?.cancel();
+  });
+
+  test("a client abort aborts the engine subscription and ends the stream", async () => {
+    const stub = createStubConnection();
+    let resolveSubscribe: (() => void) | undefined;
+    const connection: EngineConnection = {
+      ...stub.connection,
+      async subscribe(input) {
+        stub.subscribed.push(input);
+        await new Promise<void>((resolve) => {
+          resolveSubscribe = resolve;
+          input.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    };
+
+    const controller = new AbortController();
+    const response = await invoke("streamSessionEvents", connection, { signal: controller.signal });
+    const reader = response.body!.getReader();
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toContain("event: stream.open");
+
+    controller.abort();
+    // The producer's inner signal is what stops the upstream subscription.
+    await Promise.resolve();
+    expect(stub.subscribed[0]?.signal.aborted).toBe(true);
+    resolveSubscribe?.();
+
+    const rest = await reader.read();
+    expect(rest.done).toBe(true);
+  });
+});

--- a/apps/server/src/api/modules/sessions/module.ts
+++ b/apps/server/src/api/modules/sessions/module.ts
@@ -1,0 +1,925 @@
+/**
+ * Sessions API module.
+ *
+ * The one place the public API talks to a conversation engine. Every operation resolves
+ * the workspace, looks the engine adapter up by `workspace.engineId`, and then speaks only
+ * the `EngineConnection` contract from `../../engine/types.js` — so OpenCode and DeepSeek
+ * Harness are reachable through a single set of URLs, and adding a third engine adds no
+ * routes here.
+ *
+ * Two rules shape the handlers. Scope and writability are enforced by
+ * `registerApiModules` from the operation declaration, so a handler never re-checks them.
+ * And a capability an engine does not have is reported as `501 engine_capability_unsupported`
+ * naming the engine and the capability, rather than as a confusing upstream failure.
+ */
+
+import { z } from "zod";
+
+import { ApiError } from "../../../errors.js";
+import type { RequestContext } from "../../../routes/registry.js";
+import {
+  ENGINE_EVENT_TYPES,
+  ENGINE_PROMPT_OPTIONS,
+  type EngineAdapterRegistry,
+  type EngineCapabilities,
+  type EngineConnection,
+  type EngineEvent,
+  type EnginePromptPart,
+} from "../../engine/types.js";
+import type { ApiModule, ApiModuleContext, ApiOperation, JsonSchema } from "../../module.js";
+import { createSseResponse, formatSseFrame, type SseFrame } from "../../sse.js";
+
+/* -------------------------------------------------------------------------- */
+/* Request schemas                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Exported so the OpenAPI module can derive request documentation from the same
+ * definitions the handlers validate against, instead of a hand-kept copy.
+ */
+export const engineModelRefSchema = z.strictObject({
+  providerID: z.string().min(1),
+  modelID: z.string().min(1),
+});
+
+export const createSessionBodySchema = z.strictObject({
+  title: z.string().min(1).max(500).optional(),
+  agent: z.string().min(1).optional(),
+  model: engineModelRefSchema.optional(),
+});
+
+export const updateSessionBodySchema = z.strictObject({
+  title: z.string().min(1).max(500),
+});
+
+export const promptPartSchema = z.discriminatedUnion("type", [
+  z.strictObject({ type: z.literal("text"), text: z.string().min(1) }),
+  z.strictObject({
+    type: z.literal("file"),
+    mime: z.string().min(1),
+    url: z.string().min(1),
+    filename: z.string().min(1).optional(),
+  }),
+  z.strictObject({ type: z.literal("agent"), name: z.string().min(1) }),
+]);
+
+export const promptSessionBodySchema = z
+  .strictObject({
+    text: z.string().min(1).optional(),
+    parts: z.array(promptPartSchema).optional(),
+    model: engineModelRefSchema.optional(),
+    agent: z.string().min(1).optional(),
+    system: z.string().min(1).optional(),
+    reasoningEffort: z.string().min(1).optional(),
+    variant: z.string().min(1).optional(),
+    delivery: z.enum(["steer", "queue"]).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.text === undefined && (value.parts === undefined || value.parts.length === 0)) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Provide `text`, or a non-empty `parts` array",
+        path: ["text"],
+      });
+    }
+  });
+
+export const replyPermissionBodySchema = z.strictObject({
+  reply: z.enum(["once", "always", "reject"]),
+});
+
+export const replyQuestionBodySchema = z.strictObject({
+  answers: z.array(z.array(z.string())).min(1),
+});
+
+export const streamSessionEventsQuerySchema = z.strictObject({
+  after: z.string().min(1).optional(),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Response schemas (OpenAPI)                                                  */
+/* -------------------------------------------------------------------------- */
+
+const errorSchema: JsonSchema = {
+  type: "object",
+  required: ["code", "message"],
+  properties: {
+    code: { type: "string", description: "Stable machine-readable error code." },
+    message: { type: "string" },
+    details: { description: "Optional structured context; shape depends on `code`." },
+  },
+};
+
+const sessionSchema: JsonSchema = {
+  type: "object",
+  required: ["id", "title"],
+  properties: {
+    id: { type: "string" },
+    title: { type: "string" },
+    parentId: { type: ["string", "null"], description: "Parent session for a fork." },
+    directory: { type: ["string", "null"] },
+    createdAt: { type: ["number", "null"], description: "Epoch milliseconds." },
+    updatedAt: { type: ["number", "null"], description: "Epoch milliseconds." },
+    archivedAt: { type: ["number", "null"], description: "Epoch milliseconds." },
+  },
+};
+
+const capabilitiesSchema: JsonSchema = {
+  type: "object",
+  description: "What the workspace engine supports. Unsupported operations answer 501.",
+  required: ["streaming", "resumableStreaming", "permissions", "questions", "interrupt", "wait", "promptOptions"],
+  properties: {
+    streaming: { type: "boolean" },
+    resumableStreaming: { type: "boolean", description: "`?after=` resumption is honoured." },
+    permissions: { type: "boolean" },
+    questions: { type: "boolean" },
+    interrupt: { type: "boolean" },
+    wait: { type: "boolean" },
+    promptOptions: {
+      type: "object",
+      description:
+        "Optional `prompt` fields this engine applies. A field reported `false` is rejected "
+        + "with 501 rather than accepted and silently ignored.",
+      required: ["system", "reasoningEffort", "variant"],
+      properties: {
+        system: { type: "boolean" },
+        reasoningEffort: { type: "boolean" },
+        variant: { type: "boolean" },
+      },
+    },
+  },
+};
+
+const sessionEnvelopeSchema: JsonSchema = {
+  type: "object",
+  required: ["session", "engine", "capabilities"],
+  properties: {
+    session: sessionSchema,
+    engine: { type: "string", description: "Engine id that owns the session." },
+    capabilities: capabilitiesSchema,
+  },
+};
+
+const permissionSchema: JsonSchema = {
+  type: "object",
+  required: ["id", "sessionId", "kind", "resources", "remember", "metadata", "receivedAt"],
+  properties: {
+    id: { type: "string" },
+    sessionId: { type: "string" },
+    kind: { type: "string", description: "Engine-specific permission kind, e.g. a tool name." },
+    resources: { type: "array", items: { type: "string" } },
+    remember: {
+      type: "array",
+      items: { type: "string" },
+      description: "Scopes an answer may be persisted for.",
+    },
+    metadata: { type: "object", additionalProperties: true },
+    receivedAt: { type: "number", description: "Epoch milliseconds." },
+  },
+};
+
+const questionSchema: JsonSchema = {
+  type: "object",
+  required: ["id", "sessionId", "questions", "receivedAt"],
+  properties: {
+    id: { type: "string" },
+    sessionId: { type: "string" },
+    questions: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["question", "options"],
+        properties: {
+          header: { type: "string" },
+          question: { type: "string" },
+          options: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["label"],
+              properties: { label: { type: "string" }, description: { type: "string" } },
+            },
+          },
+          multiple: { type: "boolean" },
+          custom: { type: "boolean", description: "A free-form answer is accepted." },
+        },
+      },
+    },
+    receivedAt: { type: "number", description: "Epoch milliseconds." },
+  },
+};
+
+const engineEventSchema: JsonSchema = {
+  type: "object",
+  description: "One normalized engine event, delivered as the `data` of an SSE frame.",
+  required: ["type"],
+  properties: {
+    type: { type: "string", enum: [...ENGINE_EVENT_TYPES] },
+    sessionId: { type: "string" },
+  },
+  additionalProperties: true,
+};
+
+const workspacePathParams: JsonSchema = {
+  type: "object",
+  required: ["workspaceId"],
+  properties: { workspaceId: { type: "string", description: "Workspace id." } },
+};
+
+const sessionPathParams: JsonSchema = {
+  type: "object",
+  required: ["workspaceId", "sessionId"],
+  properties: {
+    workspaceId: { type: "string", description: "Workspace id." },
+    sessionId: { type: "string", description: "Session id." },
+  },
+};
+
+function pathParamsWith(name: string, description: string): JsonSchema {
+  return {
+    type: "object",
+    required: ["workspaceId", "sessionId", name],
+    properties: {
+      workspaceId: { type: "string", description: "Workspace id." },
+      sessionId: { type: "string", description: "Session id." },
+      [name]: { type: "string", description },
+    },
+  };
+}
+
+const badRequest = { description: "The request body or query failed validation.", schema: errorSchema };
+const notFound = { description: "Unknown workspace or session.", schema: errorSchema };
+const engineNotRegistered = {
+  description: "The workspace names an engine that is not registered on this server.",
+  schema: errorSchema,
+};
+const capabilityUnsupported = {
+  description: "The workspace engine does not support this operation.",
+  schema: errorSchema,
+};
+const engineFailed = { description: "The engine rejected or failed the request.", schema: errorSchema };
+
+/* -------------------------------------------------------------------------- */
+/* SSE framing                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Turns one engine event into an SSE frame.
+ *
+ * `seq` becomes the `id:` line rather than staying in the payload: that is exactly what a
+ * client echoes back as `?after=` (or `Last-Event-ID`) to resume, so keeping it in one
+ * place stops the two copies from disagreeing.
+ */
+export function sessionEventToSseFrame(event: EngineEvent): SseFrame {
+  const { seq, ...rest } = event as EngineEvent & { seq?: string };
+  const frame: SseFrame = { event: event.type, data: rest };
+  if (typeof seq === "string" && seq !== "") frame.id = seq;
+  return frame;
+}
+
+/** Convenience wrapper: the exact bytes written to the stream for one event. */
+export function formatSessionEventFrame(event: EngineEvent): string {
+  return formatSseFrame(sessionEventToSseFrame(event));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Handler helpers                                                             */
+/* -------------------------------------------------------------------------- */
+
+interface WorkspaceLike {
+  id?: string;
+  engineId?: string;
+}
+
+function requireParam(ctx: RequestContext, name: string): string {
+  const value = ctx.params[name]?.trim();
+  if (!value) {
+    throw new ApiError(400, "invalid_request", `Missing path parameter: ${name}`, { param: name });
+  }
+  return value;
+}
+
+/**
+ * Structural rather than `instanceof` check: the registry can be constructed in a
+ * different Bun module context than this file, which is the same hazard `isApiError`
+ * exists for in `../../../errors.ts`.
+ */
+function engineRegistry(context: ApiModuleContext): EngineAdapterRegistry {
+  const engines = context.services.engines as EngineAdapterRegistry | undefined;
+  if (!engines || typeof engines.get !== "function") {
+    throw new ApiError(
+      500,
+      "engine_registry_unavailable",
+      "Engine adapter registry is not configured for the sessions module",
+    );
+  }
+  return engines;
+}
+
+async function connectEngine(context: ApiModuleContext, ctx: RequestContext): Promise<EngineConnection> {
+  const workspaceId = requireParam(ctx, "workspaceId");
+  const workspace = (await context.resolveWorkspace(ctx.config, workspaceId)) as WorkspaceLike | undefined;
+  const adapter = engineRegistry(context).get(workspace?.engineId);
+  return adapter.connect(workspace);
+}
+
+/** Capability flags that are a plain yes/no, as opposed to the `promptOptions` group. */
+type BooleanCapability = {
+  [K in keyof EngineCapabilities]: EngineCapabilities[K] extends boolean ? K : never;
+}[keyof EngineCapabilities];
+
+function requireCapability(
+  connection: EngineConnection,
+  capability: BooleanCapability,
+  operationId: string,
+): void {
+  if (connection.capabilities[capability]) return;
+  throw new ApiError(
+    501,
+    "engine_capability_unsupported",
+    `Engine ${connection.engineId} does not support ${capability}`,
+    { engine: connection.engineId, capability, operationId },
+  );
+}
+
+/**
+ * Rejects prompt options the selected engine would not actually apply.
+ *
+ * The engines differ: OpenCode's v2 prompt endpoint has no field for `system` or
+ * `reasoningEffort`, while DeepSeek Harness applies both. Passing them through anyway
+ * would return a normal 202 while the option vanished inside the adapter, so the caller
+ * would have no way to tell a working system prompt from an ignored one. Failing here
+ * makes the difference visible at the moment it matters.
+ */
+function requireSupportedPromptOptions(
+  connection: EngineConnection,
+  body: { system?: string; reasoningEffort?: string; variant?: string },
+): void {
+  const unsupported = ENGINE_PROMPT_OPTIONS.filter(
+    (option) => body[option] !== undefined && !connection.capabilities.promptOptions[option],
+  );
+  if (unsupported.length === 0) return;
+  throw new ApiError(
+    501,
+    "engine_prompt_option_unsupported",
+    `Engine ${connection.engineId} does not apply: ${unsupported.join(", ")}`,
+    { engine: connection.engineId, unsupported, operationId: "promptSession" },
+  );
+}
+
+/** Turns a zod failure into the API's `400 invalid_payload`, keeping every issue. */
+export function parsePayload<T>(schema: z.ZodType<T>, value: unknown, what = "Request body"): T {
+  const result = schema.safeParse(value);
+  if (result.success) return result.data;
+  throw new ApiError(400, "invalid_payload", `${what} failed validation`, {
+    issues: result.error.issues.map((issue) => ({
+      path: issue.path.map((segment) => String(segment)).join("."),
+      code: issue.code,
+      message: issue.message,
+    })),
+  });
+}
+
+type PromptBody = z.infer<typeof promptSessionBodySchema>;
+
+/** `text` is sugar for a leading text part; both may be supplied together. */
+export function buildPromptParts(body: PromptBody): EnginePromptPart[] {
+  const parts: EnginePromptPart[] = [];
+  if (body.text !== undefined) parts.push({ type: "text", text: body.text });
+  for (const part of body.parts ?? []) parts.push(part);
+  return parts;
+}
+
+function describeEngine(connection: EngineConnection): { engine: string; capabilities: EngineCapabilities } {
+  return { engine: connection.engineId, capabilities: connection.capabilities };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Module                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const SESSIONS_OPERATION_IDS = [
+  "createSession",
+  "getSession",
+  "deleteSession",
+  "updateSession",
+  "promptSession",
+  "interruptSession",
+  "streamSessionEvents",
+  "listSessionPermissions",
+  "replySessionPermission",
+  "listSessionQuestions",
+  "replySessionQuestion",
+] as const;
+
+const BASE = "/api/v1/workspaces/:workspaceId/sessions";
+
+export const sessionsModule: ApiModule = {
+  id: "sessions",
+  title: "Sessions",
+  description:
+    "Engine-agnostic conversation sessions: create, inspect, prompt, interrupt, stream events, and answer permission and question requests.",
+  version: "1.0.0",
+  stability: "stable",
+
+  register(context: ApiModuleContext): ApiOperation[] {
+    const { jsonResponse, readJsonBody } = context;
+
+    return [
+      {
+        operationId: "createSession",
+        method: "POST",
+        path: BASE,
+        summary: "Create a session in a workspace",
+        description:
+          "Creates a session on the workspace's engine. `agent` and `model` are applied at creation when the engine supports them.",
+        effect: "write",
+        pathParams: workspacePathParams,
+        requestBody: {
+          type: "object",
+          properties: {
+            title: { type: "string", minLength: 1, maxLength: 500, description: "Initial session title." },
+            agent: { type: "string", minLength: 1, description: "Agent / preset id to start the session with." },
+            model: {
+              type: "object",
+              required: ["providerID", "modelID"],
+              properties: { providerID: { type: "string" }, modelID: { type: "string" } },
+            },
+          },
+          additionalProperties: false,
+        },
+        responses: {
+          201: { description: "The created session.", schema: sessionEnvelopeSchema },
+          400: badRequest,
+          404: notFound,
+          409: engineNotRegistered,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const body = parsePayload(createSessionBodySchema, await readJsonBody(ctx.request));
+          const session = await connection.createSession(body);
+          return jsonResponse({ session, ...describeEngine(connection) }, 201);
+        },
+      },
+
+      {
+        operationId: "getSession",
+        method: "GET",
+        path: `${BASE}/:sessionId`,
+        summary: "Get one session",
+        description: "Returns the session as the engine reports it, together with the engine's capabilities.",
+        effect: "read",
+        pathParams: sessionPathParams,
+        responses: {
+          200: { description: "The session.", schema: sessionEnvelopeSchema },
+          404: notFound,
+          409: engineNotRegistered,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const session = await connection.getSession(requireParam(ctx, "sessionId"));
+          return jsonResponse({ session, ...describeEngine(connection) });
+        },
+      },
+
+      {
+        operationId: "deleteSession",
+        method: "DELETE",
+        path: `${BASE}/:sessionId`,
+        summary: "Delete a session",
+        description: "Permanently removes the session from the engine. Not reversible.",
+        effect: "destructive",
+        pathParams: sessionPathParams,
+        responses: {
+          200: {
+            description: "The session was deleted.",
+            schema: {
+              type: "object",
+              required: ["deleted", "sessionId"],
+              properties: { deleted: { type: "boolean", enum: [true] }, sessionId: { type: "string" } },
+            },
+          },
+          404: notFound,
+          409: engineNotRegistered,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          await connection.deleteSession(sessionId);
+          return jsonResponse({ deleted: true, sessionId });
+        },
+      },
+
+      {
+        operationId: "updateSession",
+        method: "PATCH",
+        path: `${BASE}/:sessionId`,
+        summary: "Update a session title",
+        description: "Renames the session. The refreshed session is returned.",
+        effect: "write",
+        pathParams: sessionPathParams,
+        requestBody: {
+          type: "object",
+          required: ["title"],
+          properties: { title: { type: "string", minLength: 1, maxLength: 500 } },
+          additionalProperties: false,
+        },
+        responses: {
+          200: { description: "The updated session.", schema: sessionEnvelopeSchema },
+          400: badRequest,
+          404: notFound,
+          409: engineNotRegistered,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          const body = parsePayload(updateSessionBodySchema, await readJsonBody(ctx.request));
+          await connection.renameSession(sessionId, body.title);
+          const session = await connection.getSession(sessionId);
+          return jsonResponse({ session, ...describeEngine(connection) });
+        },
+      },
+
+      {
+        operationId: "promptSession",
+        method: "POST",
+        path: `${BASE}/:sessionId/prompt`,
+        summary: "Send a prompt to a session",
+        description:
+          "Queues a user turn. Returns as soon as the engine accepts it — follow `GET .../events` for the assistant response. Supply `text`, `parts`, or both; `parts` are appended after `text`.",
+        effect: "write",
+        pathParams: sessionPathParams,
+        requestBody: {
+          type: "object",
+          description: "At least one of `text` or a non-empty `parts` is required.",
+          properties: {
+            text: { type: "string", minLength: 1, description: "Shorthand for a single leading text part." },
+            parts: {
+              type: "array",
+              minItems: 1,
+              items: {
+                oneOf: [
+                  {
+                    type: "object",
+                    required: ["type", "text"],
+                    properties: { type: { const: "text" }, text: { type: "string", minLength: 1 } },
+                    additionalProperties: false,
+                  },
+                  {
+                    type: "object",
+                    required: ["type", "mime", "url"],
+                    properties: {
+                      type: { const: "file" },
+                      mime: { type: "string" },
+                      url: { type: "string", description: "Absolute URL or data: URI of the attachment." },
+                      filename: { type: "string" },
+                    },
+                    additionalProperties: false,
+                  },
+                  {
+                    type: "object",
+                    required: ["type", "name"],
+                    properties: { type: { const: "agent" }, name: { type: "string" } },
+                    additionalProperties: false,
+                  },
+                ],
+              },
+            },
+            model: {
+              type: "object",
+              required: ["providerID", "modelID"],
+              properties: { providerID: { type: "string" }, modelID: { type: "string" } },
+            },
+            agent: { type: "string", description: "Agent / mode to run this turn with." },
+            system: {
+              type: "string",
+              description:
+                "Per-turn system prompt override. Engine-dependent: rejected with 501 "
+                + "`engine_prompt_option_unsupported` by engines that cannot apply it, rather than "
+                + "being accepted and ignored.",
+            },
+            reasoningEffort: {
+              type: "string",
+              description:
+                "Reasoning-effort hint. Engine-dependent, same 501 contract as `system`.",
+            },
+            variant: { type: "string", description: "Model variant selector." },
+            delivery: {
+              type: "string",
+              enum: ["steer", "queue"],
+              description: "`steer` interrupts the in-flight turn; `queue` runs after it.",
+            },
+          },
+          additionalProperties: false,
+        },
+        responses: {
+          202: {
+            description: "The prompt was accepted.",
+            schema: {
+              type: "object",
+              required: ["accepted", "sessionId", "messageId"],
+              properties: {
+                accepted: { type: "boolean", enum: [true] },
+                sessionId: { type: "string" },
+                messageId: { type: ["string", "null"], description: "Engine message id, when the engine reports one." },
+              },
+            },
+          },
+          400: badRequest,
+          404: notFound,
+          409: engineNotRegistered,
+          501: {
+            description:
+              "The workspace engine cannot apply one of the supplied prompt options "
+              + "(`system`, `reasoningEffort`, `variant`). `details.unsupported` lists them.",
+            schema: errorSchema,
+          },
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          const body = parsePayload(promptSessionBodySchema, await readJsonBody(ctx.request));
+          requireSupportedPromptOptions(connection, body);
+          const result = await connection.prompt({
+            sessionId,
+            parts: buildPromptParts(body),
+            ...(body.model ? { model: body.model } : {}),
+            ...(body.agent ? { agent: body.agent } : {}),
+            ...(body.system ? { system: body.system } : {}),
+            ...(body.reasoningEffort ? { reasoningEffort: body.reasoningEffort } : {}),
+            ...(body.variant ? { variant: body.variant } : {}),
+            ...(body.delivery ? { delivery: body.delivery } : {}),
+          });
+          return jsonResponse({ accepted: true, sessionId, messageId: result?.messageId ?? null }, 202);
+        },
+      },
+
+      {
+        operationId: "interruptSession",
+        method: "POST",
+        path: `${BASE}/:sessionId/interrupt`,
+        summary: "Interrupt the running turn",
+        description: "Aborts whatever the session is currently doing. Requires the `interrupt` engine capability.",
+        effect: "write",
+        pathParams: sessionPathParams,
+        requestBody: { type: "object", properties: {}, additionalProperties: false, description: "No body." },
+        responses: {
+          200: {
+            description: "Interrupt result. `interrupted` is false when nothing was running.",
+            schema: {
+              type: "object",
+              required: ["interrupted", "sessionId"],
+              properties: { interrupted: { type: "boolean" }, sessionId: { type: "string" } },
+            },
+          },
+          404: notFound,
+          409: engineNotRegistered,
+          501: capabilityUnsupported,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          requireCapability(connection, "interrupt", "interruptSession");
+          const interrupted = await connection.interrupt(sessionId);
+          return jsonResponse({ interrupted, sessionId });
+        },
+      },
+
+      {
+        operationId: "streamSessionEvents",
+        method: "GET",
+        path: `${BASE}/:sessionId/events`,
+        summary: "Stream session events (SSE)",
+        description:
+          "Server-sent events for one session. Each frame carries the event type on the `event:` line and the normalized event as JSON on `data:`. Events with a durable cursor also carry an `id:` line; pass that value back as `?after=` to resume without gaps. Engines whose `resumableStreaming` capability is false reject `?after=` with 501. A `stream.open` frame is sent immediately and `: keepalive` comments keep intermediaries from timing the connection out.",
+        effect: "read",
+        streaming: "sse",
+        pathParams: sessionPathParams,
+        query: {
+          type: "object",
+          properties: {
+            after: {
+              type: "string",
+              minLength: 1,
+              description: "Durable cursor from a previous `id:` line. Requires `resumableStreaming`.",
+            },
+          },
+          additionalProperties: false,
+        },
+        responses: {
+          200: {
+            description: "An open event stream.",
+            contentType: "text/event-stream",
+            schema: engineEventSchema,
+          },
+          400: badRequest,
+          404: notFound,
+          409: engineNotRegistered,
+          501: capabilityUnsupported,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          requireCapability(connection, "streaming", "streamSessionEvents");
+
+          const raw = ctx.url.searchParams.get("after");
+          const query = parsePayload(
+            streamSessionEventsQuerySchema,
+            raw === null || raw.trim() === "" ? {} : { after: raw.trim() },
+            "Query string",
+          );
+          if (query.after !== undefined) {
+            requireCapability(connection, "resumableStreaming", "streamSessionEvents");
+          }
+
+          // Resolve the session before opening the stream so an unknown id is a plain
+          // 404 instead of a stream that opens and immediately errors.
+          await connection.getSession(sessionId);
+
+          return createSseResponse({
+            signal: ctx.request.signal,
+            hello: {
+              event: "stream.open",
+              data: {
+                sessionId,
+                engine: connection.engineId,
+                after: query.after ?? null,
+                resumable: connection.capabilities.resumableStreaming,
+              },
+            },
+            start: async (emit, signal) => {
+              await connection.subscribe({
+                sessionId,
+                ...(query.after !== undefined ? { after: query.after } : {}),
+                signal,
+                onEvent: (event) => emit(sessionEventToSseFrame(event)),
+              });
+            },
+          });
+        },
+      },
+
+      {
+        operationId: "listSessionPermissions",
+        method: "GET",
+        path: `${BASE}/:sessionId/permissions`,
+        summary: "List pending permission requests",
+        description: "Permission requests the session is currently blocked on. Requires the `permissions` capability.",
+        effect: "read",
+        pathParams: sessionPathParams,
+        responses: {
+          200: {
+            description: "Pending permission requests, oldest first.",
+            schema: {
+              type: "object",
+              required: ["permissions"],
+              properties: { permissions: { type: "array", items: permissionSchema } },
+            },
+          },
+          404: notFound,
+          409: engineNotRegistered,
+          501: capabilityUnsupported,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          requireCapability(connection, "permissions", "listSessionPermissions");
+          const permissions = await connection.listPermissions(sessionId);
+          return jsonResponse({ permissions });
+        },
+      },
+
+      {
+        operationId: "replySessionPermission",
+        method: "POST",
+        path: `${BASE}/:sessionId/permissions/:permissionId`,
+        summary: "Answer a permission request",
+        description:
+          "Answers one pending permission request. `once` allows this occurrence, `always` persists the allowance, `reject` denies it.",
+        effect: "write",
+        pathParams: pathParamsWith("permissionId", "Permission request id."),
+        requestBody: {
+          type: "object",
+          required: ["reply"],
+          properties: { reply: { type: "string", enum: ["once", "always", "reject"] } },
+          additionalProperties: false,
+        },
+        responses: {
+          200: {
+            description: "The reply was delivered.",
+            schema: {
+              type: "object",
+              required: ["ok", "permissionId", "reply"],
+              properties: {
+                ok: { type: "boolean", enum: [true] },
+                permissionId: { type: "string" },
+                reply: { type: "string", enum: ["once", "always", "reject"] },
+              },
+            },
+          },
+          400: badRequest,
+          404: notFound,
+          409: engineNotRegistered,
+          501: capabilityUnsupported,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          const permissionId = requireParam(ctx, "permissionId");
+          requireCapability(connection, "permissions", "replySessionPermission");
+          const body = parsePayload(replyPermissionBodySchema, await readJsonBody(ctx.request));
+          await connection.replyPermission({ sessionId, permissionId, reply: body.reply });
+          return jsonResponse({ ok: true, permissionId, reply: body.reply });
+        },
+      },
+
+      {
+        operationId: "listSessionQuestions",
+        method: "GET",
+        path: `${BASE}/:sessionId/questions`,
+        summary: "List pending questions",
+        description: "Questions the engine is waiting on an answer for. Requires the `questions` capability.",
+        effect: "read",
+        pathParams: sessionPathParams,
+        responses: {
+          200: {
+            description: "Pending questions, oldest first.",
+            schema: {
+              type: "object",
+              required: ["questions"],
+              properties: { questions: { type: "array", items: questionSchema } },
+            },
+          },
+          404: notFound,
+          409: engineNotRegistered,
+          501: capabilityUnsupported,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          requireCapability(connection, "questions", "listSessionQuestions");
+          const questions = await connection.listQuestions(sessionId);
+          return jsonResponse({ questions });
+        },
+      },
+
+      {
+        operationId: "replySessionQuestion",
+        method: "POST",
+        path: `${BASE}/:sessionId/questions/:questionId`,
+        summary: "Answer a pending question",
+        description:
+          "Answers one pending question request. `answers` holds one array of selected option labels per question in the request, in order.",
+        effect: "write",
+        pathParams: pathParamsWith("questionId", "Question request id."),
+        requestBody: {
+          type: "object",
+          required: ["answers"],
+          properties: {
+            answers: {
+              type: "array",
+              minItems: 1,
+              description: "One entry per question; each entry lists the chosen option labels.",
+              items: { type: "array", items: { type: "string" } },
+            },
+          },
+          additionalProperties: false,
+        },
+        responses: {
+          200: {
+            description: "The answer was delivered.",
+            schema: {
+              type: "object",
+              required: ["ok", "questionId"],
+              properties: { ok: { type: "boolean", enum: [true] }, questionId: { type: "string" } },
+            },
+          },
+          400: badRequest,
+          404: notFound,
+          409: engineNotRegistered,
+          501: capabilityUnsupported,
+          502: engineFailed,
+        },
+        handler: async (ctx) => {
+          const connection = await connectEngine(context, ctx);
+          const sessionId = requireParam(ctx, "sessionId");
+          const questionId = requireParam(ctx, "questionId");
+          requireCapability(connection, "questions", "replySessionQuestion");
+          const body = parsePayload(replyQuestionBodySchema, await readJsonBody(ctx.request));
+          await connection.replyQuestion({ sessionId, questionId, answers: body.answers });
+          return jsonResponse({ ok: true, questionId });
+        },
+      },
+    ];
+  },
+};

--- a/apps/server/src/api/modules/tasks/module.test.ts
+++ b/apps/server/src/api/modules/tasks/module.test.ts
@@ -1,0 +1,1024 @@
+import { describe, expect, test } from "bun:test";
+
+import { ApiError, isApiError } from "../../../errors.js";
+import type { RequestContext, Route } from "../../../routes/registry.js";
+import { matchRoute } from "../../../routes/registry.js";
+import type { ServerConfig } from "../../../types.js";
+import type {
+  EngineCapabilities,
+  EngineConnection,
+  EngineEvent,
+  EnginePromptInput,
+  EngineSession,
+} from "../../engine/types.js";
+import { registerApiModules, type ApiModule, type ApiModuleContext, type ApiOperation } from "../../module.js";
+import { createTaskRunner, createTaskTextAccumulator, extractTaskArtifact, taskTitle } from "./runner.js";
+import { createTaskStore, type TaskRecord, type TaskStore } from "./store.js";
+import {
+  parseAfterCursor,
+  parseCreateTaskBody,
+  parseTaskListQuery,
+  resolveTaskApprovalPolicy,
+  serializeTask,
+  tasksModule,
+  type TasksModuleServices,
+} from "./module.js";
+
+/* -------------------------------------------------------------------------- */
+/* Stubs                                                                       */
+/* -------------------------------------------------------------------------- */
+
+const config = { workspaces: [], readOnly: false } as unknown as ServerConfig;
+
+const STUB_CAPABILITIES: EngineCapabilities = {
+  streaming: true,
+  resumableStreaming: false,
+  permissions: true,
+  questions: false,
+  interrupt: true,
+  wait: false,
+  promptOptions: { system: true, reasoningEffort: true, variant: true },
+};
+
+interface StubConnection extends EngineConnection {
+  emit(event: EngineEvent): void;
+  /** Resolves once `subscribe` has attached. */
+  ready: Promise<void>;
+  prompts: EnginePromptInput[];
+  createdSessions: Array<{ title?: string; agent?: string }>;
+  permissionReplies: Array<{ permissionId: string; reply: string }>;
+  interrupts: string[];
+}
+
+function createStubConnection(overrides: {
+  capabilities?: Partial<EngineCapabilities>;
+  createSession?: () => Promise<EngineSession>;
+  prompt?: () => Promise<{ messageId?: string }>;
+  sessionId?: string;
+} = {}): StubConnection {
+  const sessionId = overrides.sessionId ?? "session-1";
+  const prompts: EnginePromptInput[] = [];
+  const createdSessions: Array<{ title?: string; agent?: string }> = [];
+  const permissionReplies: Array<{ permissionId: string; reply: string }> = [];
+  const interrupts: string[] = [];
+
+  let listener: ((event: EngineEvent) => void) | null = null;
+  let markReady: () => void = () => {};
+  const ready = new Promise<void>((resolve) => {
+    markReady = resolve;
+  });
+
+  const unsupported = async (): Promise<never> => {
+    throw new ApiError(501, "not_implemented", "not used by these tests");
+  };
+
+  const connection: StubConnection = {
+    engineId: "stub-engine",
+    capabilities: { ...STUB_CAPABILITIES, ...overrides.capabilities },
+
+    createSession: overrides.createSession
+      ?? (async (input) => {
+        createdSessions.push({ ...(input.title !== undefined ? { title: input.title } : {}), ...(input.agent !== undefined ? { agent: input.agent } : {}) });
+        return { id: sessionId, title: input.title ?? "stub" };
+      }),
+    getSession: async () => ({ id: sessionId, title: "stub" }),
+    deleteSession: unsupported,
+    renameSession: unsupported,
+
+    prompt: overrides.prompt
+      ?? (async (input) => {
+        prompts.push(input);
+        return {};
+      }),
+    interrupt: async (id) => {
+      interrupts.push(id);
+      return true;
+    },
+    wait: async () => {},
+
+    listPermissions: async () => [],
+    replyPermission: async ({ permissionId, reply }) => {
+      permissionReplies.push({ permissionId, reply });
+    },
+    listQuestions: async () => [],
+    replyQuestion: unsupported,
+
+    subscribe: async ({ onEvent, signal }) => {
+      listener = onEvent;
+      markReady();
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve();
+          return;
+        }
+        signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      listener = null;
+    },
+
+    emit(event) {
+      listener?.(event);
+    },
+    ready,
+    prompts,
+    createdSessions,
+    permissionReplies,
+    interrupts,
+  };
+
+  return connection;
+}
+
+/** Lets pending microtasks and a macrotask turn run. */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function textDelta(sessionId: string, delta: string): EngineEvent {
+  return { type: "message.delta", sessionId, messageId: "m1", partId: "p1", kind: "text", delta };
+}
+
+function idle(sessionId: string): EngineEvent {
+  return { type: "session.idle", sessionId };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Module context                                                              */
+/* -------------------------------------------------------------------------- */
+
+function createModuleContext(services: TasksModuleServices = {}): ApiModuleContext {
+  return {
+    config,
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+    readJsonBody: async (request) => {
+      try {
+        return (await request.json()) as Record<string, unknown>;
+      } catch {
+        throw new ApiError(400, "invalid_json", "Invalid JSON body");
+      }
+    },
+    resolveWorkspace: async (_config, id) => {
+      if (id !== "w1") throw new ApiError(404, "workspace_not_found", `Unknown workspace: ${id}`);
+      return { id, engineId: "stub-engine" };
+    },
+    services,
+  };
+}
+
+function requestContext(
+  request: Request,
+  params: Record<string, string> = {},
+): RequestContext {
+  return {
+    request,
+    url: new URL(request.url),
+    params,
+    config,
+    approvals: {} as never,
+    reloadEvents: {} as never,
+    tokens: {} as never,
+  };
+}
+
+function operationsOf(services: TasksModuleServices): Map<string, ApiOperation> {
+  const operations = tasksModule.register(createModuleContext(services));
+  return new Map(operations.map((operation) => [operation.operationId, operation]));
+}
+
+function stubRegistry(connection: EngineConnection) {
+  return {
+    get: () => ({ connect: () => connection }),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Declaration                                                                 */
+/* -------------------------------------------------------------------------- */
+
+describe("tasksModule declaration", () => {
+  test("identifies itself and depends on sessions", () => {
+    expect(tasksModule.id).toBe("tasks");
+    expect(tasksModule.version).toBe("1.0.0");
+    expect(tasksModule.stability).toBe("preview");
+    expect(tasksModule.dependsOn).toEqual(["sessions"]);
+  });
+
+  test("says out loud that tasks do not survive a restart", () => {
+    expect(tasksModule.description).toMatch(/LOST ON RESTART/);
+  });
+
+  test("declares exactly the five task operations", () => {
+    const operations = tasksModule.register(createModuleContext());
+    expect(operations.map((operation) => [operation.operationId, operation.method, operation.path, operation.effect]))
+      .toEqual([
+        ["createTask", "POST", "/api/v1/workspaces/:workspaceId/tasks", "write"],
+        ["listTasks", "GET", "/api/v1/workspaces/:workspaceId/tasks", "read"],
+        ["getTask", "GET", "/api/v1/workspaces/:workspaceId/tasks/:taskId", "read"],
+        ["cancelTask", "POST", "/api/v1/workspaces/:workspaceId/tasks/:taskId/cancel", "write"],
+        ["streamTaskEvents", "GET", "/api/v1/workspaces/:workspaceId/tasks/:taskId/events", "read"],
+      ]);
+  });
+
+  test("every operation documents a schema and its failure responses", () => {
+    for (const operation of tasksModule.register(createModuleContext())) {
+      expect(operation.summary.length).toBeGreaterThan(0);
+      expect(operation.pathParams).toBeDefined();
+      expect(Object.keys(operation.responses ?? {}).length).toBeGreaterThan(1);
+      const success = operation.responses?.[200] ?? operation.responses?.[202];
+      expect(success?.schema).toBeDefined();
+    }
+  });
+
+  test("only streamTaskEvents streams, and it streams SSE", () => {
+    const operations = tasksModule.register(createModuleContext());
+    for (const operation of operations) {
+      expect(operation.streaming).toBe(operation.operationId === "streamTaskEvents" ? "sse" : undefined);
+    }
+    const stream = operations.find((operation) => operation.operationId === "streamTaskEvents");
+    expect(stream?.responses?.[200]?.contentType).toBe("text/event-stream");
+  });
+
+  test("the createTask response schema repeats the durability caveat", () => {
+    const create = tasksModule.register(createModuleContext())
+      .find((operation) => operation.operationId === "createTask");
+    const schema = create?.responses?.[202]?.schema as { description?: string } | undefined;
+    expect(schema?.description).toMatch(/lost on restart/i);
+  });
+
+  test("registers onto the route table alongside a sessions module", () => {
+    const routes: Route[] = [];
+    const sessions: ApiModule = {
+      id: "sessions",
+      title: "Sessions",
+      description: "stub",
+      version: "1.0.0",
+      stability: "stable",
+      register: () => [],
+    };
+    const result = registerApiModules(routes, [sessions, tasksModule], createModuleContext());
+    expect(result.operations).toHaveLength(5);
+    expect(matchRoute(routes, "POST", "/api/v1/workspaces/w1/tasks")).not.toBeNull();
+    expect(matchRoute(routes, "GET", "/api/v1/workspaces/w1/tasks/t1/events")?.params)
+      .toEqual({ workspaceId: "w1", taskId: "t1" });
+  });
+
+  test("refuses to register without the sessions module", () => {
+    expect(() => registerApiModules([], [tasksModule], createModuleContext()))
+      .toThrow(/requires sessions/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Body and query validation                                                   */
+/* -------------------------------------------------------------------------- */
+
+describe("parseCreateTaskBody", () => {
+  test("accepts a minimal body and fills the documented defaults", () => {
+    expect(parseCreateTaskBody({ goal: "  do the thing  " })).toEqual({
+      goal: "do the thing",
+      agent: null,
+      model: null,
+      approvalPolicy: "auto",
+      timeoutMs: null,
+      metadata: {},
+    });
+  });
+
+  test("accepts a full body", () => {
+    expect(parseCreateTaskBody({
+      goal: "refactor",
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude" },
+      approvalPolicy: "manual",
+      timeoutMs: 5_000,
+      metadata: { ticket: "ABC-1" },
+    })).toEqual({
+      goal: "refactor",
+      agent: "build",
+      model: { providerID: "anthropic", modelID: "claude" },
+      approvalPolicy: "manual",
+      timeoutMs: 5_000,
+      metadata: { ticket: "ABC-1" },
+    });
+  });
+
+  const rejected: Array<[string, Record<string, unknown>, string]> = [
+    ["a missing goal", {}, "goal"],
+    ["a blank goal", { goal: "   " }, "goal"],
+    ["a non-string goal", { goal: 42 }, "goal"],
+    ["an over-long goal", { goal: "x".repeat(100_001) }, "goal"],
+    ["a blank agent", { goal: "g", agent: "  " }, "agent"],
+    ["a non-object model", { goal: "g", model: "claude" }, "model"],
+    ["a model without providerID", { goal: "g", model: { modelID: "m" } }, "model.providerID"],
+    ["a model without modelID", { goal: "g", model: { providerID: "p" } }, "model.modelID"],
+    ["an unknown approvalPolicy", { goal: "g", approvalPolicy: "sometimes" }, "approvalPolicy"],
+    ["a zero timeout", { goal: "g", timeoutMs: 0 }, "timeoutMs"],
+    ["a fractional timeout", { goal: "g", timeoutMs: 1.5 }, "timeoutMs"],
+    ["a timeout beyond the cap", { goal: "g", timeoutMs: 86_400_001 }, "timeoutMs"],
+    ["array metadata", { goal: "g", metadata: [1] }, "metadata"],
+  ];
+
+  for (const [label, body, field] of rejected) {
+    test(`rejects ${label}`, () => {
+      try {
+        parseCreateTaskBody(body);
+        throw new Error("expected a throw");
+      } catch (error) {
+        expect(isApiError(error)).toBe(true);
+        expect((error as { status: number }).status).toBe(400);
+        expect((error as { details: { field: string } }).details.field).toBe(field);
+      }
+    });
+  }
+
+  test("treats explicit nulls as absent", () => {
+    expect(parseCreateTaskBody({ goal: "g", agent: null, model: null, timeoutMs: null, metadata: null }))
+      .toMatchObject({ agent: null, model: null, timeoutMs: null, metadata: {} });
+  });
+});
+
+describe("parseTaskListQuery", () => {
+  test("parses repeated and comma-separated states", () => {
+    expect(parseTaskListQuery(new URLSearchParams("state=running&state=done,failed")))
+      .toEqual({ state: ["running", "done", "failed"] });
+  });
+
+  test("parses a limit and rejects a bad one", () => {
+    expect(parseTaskListQuery(new URLSearchParams("limit=10"))).toEqual({ limit: 10 });
+    expect(() => parseTaskListQuery(new URLSearchParams("limit=0"))).toThrow(/positive integer/);
+    expect(() => parseTaskListQuery(new URLSearchParams("limit=abc"))).toThrow(/positive integer/);
+  });
+
+  test("rejects an unknown state instead of ignoring it", () => {
+    expect(() => parseTaskListQuery(new URLSearchParams("state=pending"))).toThrow(/Unknown task state/);
+  });
+
+  test("an empty query filters nothing", () => {
+    expect(parseTaskListQuery(new URLSearchParams(""))).toEqual({});
+  });
+});
+
+describe("parseAfterCursor", () => {
+  test("accepts a non-negative integer and rejects anything else", () => {
+    expect(parseAfterCursor(null)).toBeUndefined();
+    expect(parseAfterCursor("")).toBeUndefined();
+    expect(parseAfterCursor("0")).toBe(0);
+    expect(parseAfterCursor("7")).toBe(7);
+    expect(() => parseAfterCursor("-1")).toThrow(/non-negative/);
+    expect(() => parseAfterCursor("x")).toThrow(/non-negative/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Handlers                                                                    */
+/* -------------------------------------------------------------------------- */
+
+function createHandlerHarness() {
+  const store = createTaskStore();
+  const started: Array<{ task: TaskRecord; connection: EngineConnection }> = [];
+  const cancelled: Array<{ taskId: string; reason?: string }> = [];
+  const runner = {
+    run: async ({ task }: { task: TaskRecord }) => task,
+    start: (input: { task: TaskRecord; connection: EngineConnection }) => {
+      started.push(input);
+    },
+    cancel: async (taskId: string, reason?: string) => {
+      cancelled.push({ taskId, ...(reason !== undefined ? { reason } : {}) });
+      return store.cancel(taskId, reason);
+    },
+    active: 0,
+    shutdown: () => {},
+  };
+  const connection = createStubConnection();
+  const operations = operationsOf({
+    engines: stubRegistry(connection),
+    taskStore: store,
+    taskRunner: runner,
+  });
+  return { store, started, cancelled, operations, connection };
+}
+
+describe("createTask handler", () => {
+  test("accepts the task with 202 and hands it to the runner", async () => {
+    const harness = createHandlerHarness();
+    const response = await harness.operations.get("createTask")!.handler(
+      requestContext(
+        new Request("http://localhost/api/v1/workspaces/w1/tasks", {
+          method: "POST",
+          body: JSON.stringify({ goal: "build it", metadata: { ticket: "A-1" } }),
+        }),
+        { workspaceId: "w1" },
+      ),
+    );
+
+    expect(response.status).toBe(202);
+    const body = await response.json() as Record<string, unknown>;
+    expect(body).toMatchObject({
+      workspaceId: "w1",
+      state: "queued",
+      goal: "build it",
+      approvalPolicy: "auto",
+      metadata: { ticket: "A-1" },
+      sessionId: null,
+    });
+    expect(harness.started).toHaveLength(1);
+    expect(harness.started[0]?.connection).toBe(harness.connection);
+    expect(harness.store.size).toBe(1);
+  });
+
+  test("rejects an invalid body without creating a task", async () => {
+    const harness = createHandlerHarness();
+    await expect(
+      harness.operations.get("createTask")!.handler(
+        requestContext(
+          new Request("http://localhost/api/v1/workspaces/w1/tasks", {
+            method: "POST",
+            body: JSON.stringify({ goal: "" }),
+          }),
+          { workspaceId: "w1" },
+        ),
+      ),
+    ).rejects.toThrow(/goal is required/);
+    expect(harness.store.size).toBe(0);
+    expect(harness.started).toHaveLength(0);
+  });
+
+  test("an unknown workspace fails before a task is recorded", async () => {
+    const harness = createHandlerHarness();
+    await expect(
+      harness.operations.get("createTask")!.handler(
+        requestContext(
+          new Request("http://localhost/api/v1/workspaces/nope/tasks", {
+            method: "POST",
+            body: JSON.stringify({ goal: "build it" }),
+          }),
+          { workspaceId: "nope" },
+        ),
+      ),
+    ).rejects.toThrow(/Unknown workspace/);
+    expect(harness.store.size).toBe(0);
+  });
+
+  test("reports a missing engine registry as a server-side wiring error", async () => {
+    const operations = operationsOf({ taskStore: createTaskStore() });
+    try {
+      await operations.get("createTask")!.handler(
+        requestContext(
+          new Request("http://localhost/api/v1/workspaces/w1/tasks", {
+            method: "POST",
+            body: JSON.stringify({ goal: "g" }),
+          }),
+          { workspaceId: "w1" },
+        ),
+      );
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { code: string; status: number }).code).toBe("api_service_missing");
+      expect((error as { status: number }).status).toBe(500);
+    }
+  });
+});
+
+describe("listTasks and getTask handlers", () => {
+  test("list is scoped to the workspace and reports durable: false", async () => {
+    const harness = createHandlerHarness();
+    harness.store.add({ workspaceId: "w1", goal: "a" });
+    harness.store.add({ workspaceId: "other", goal: "b" });
+
+    const response = await harness.operations.get("listTasks")!.handler(
+      requestContext(new Request("http://localhost/api/v1/workspaces/w1/tasks"), { workspaceId: "w1" }),
+    );
+    const body = await response.json() as { items: Array<{ goal: string }>; count: number; durable: boolean };
+    expect(body.count).toBe(1);
+    expect(body.items[0]?.goal).toBe("a");
+    expect(body.durable).toBe(false);
+  });
+
+  test("list honours the state filter", async () => {
+    const harness = createHandlerHarness();
+    const first = harness.store.add({ workspaceId: "w1", goal: "a" });
+    harness.store.add({ workspaceId: "w1", goal: "b" });
+    harness.store.update(first.id, { state: "running" });
+
+    const response = await harness.operations.get("listTasks")!.handler(
+      requestContext(new Request("http://localhost/api/v1/workspaces/w1/tasks?state=running"), { workspaceId: "w1" }),
+    );
+    const body = await response.json() as { count: number };
+    expect(body.count).toBe(1);
+  });
+
+  test("get returns the task and 404s across workspaces", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+
+    const response = await harness.operations.get("getTask")!.handler(
+      requestContext(new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}`), {
+        workspaceId: "w1",
+        taskId: task.id,
+      }),
+    );
+    expect((await response.json() as { id: string }).id).toBe(task.id);
+
+    await expect(
+      harness.operations.get("getTask")!.handler(
+        requestContext(new Request("http://localhost/api/v1/workspaces/w1/tasks/ghost"), {
+          workspaceId: "w1",
+          taskId: "ghost",
+        }),
+      ),
+    ).rejects.toThrow(/Task not found/);
+  });
+});
+
+describe("cancelTask handler", () => {
+  test("cancels with an optional reason and tolerates an empty body", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+
+    const response = await harness.operations.get("cancelTask")!.handler(
+      requestContext(
+        new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}/cancel`, { method: "POST" }),
+        { workspaceId: "w1", taskId: task.id },
+      ),
+    );
+    const body = await response.json() as { state: string; cancelReason: string };
+    expect(body.state).toBe("cancelled");
+    expect(body.cancelReason).toBe("Cancelled by request");
+    expect(harness.cancelled).toEqual([{ taskId: task.id }]);
+  });
+
+  test("passes a reason through", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+    const response = await harness.operations.get("cancelTask")!.handler(
+      requestContext(
+        new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}/cancel`, {
+          method: "POST",
+          body: JSON.stringify({ reason: "superseded" }),
+        }),
+        { workspaceId: "w1", taskId: task.id },
+      ),
+    );
+    expect((await response.json() as { cancelReason: string }).cancelReason).toBe("superseded");
+  });
+
+  test("409s on an already-finished task", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+    harness.store.update(task.id, { state: "running" });
+    harness.store.update(task.id, { state: "done" });
+
+    await expect(
+      harness.operations.get("cancelTask")!.handler(
+        requestContext(
+          new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}/cancel`, { method: "POST" }),
+          { workspaceId: "w1", taskId: task.id },
+        ),
+      ),
+    ).rejects.toThrow(/already finished/);
+  });
+});
+
+describe("streamTaskEvents handler", () => {
+  test("replays the log as SSE frames and closes on a terminal state", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+    harness.store.update(task.id, { state: "running" });
+    harness.store.update(task.id, { state: "done", summary: "all done" });
+
+    const response = await harness.operations.get("streamTaskEvents")!.handler(
+      requestContext(new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}/events`), {
+        workspaceId: "w1",
+        taskId: task.id,
+      }),
+    );
+    expect(response.headers.get("content-type")).toBe("text/event-stream");
+
+    const text = await response.text();
+    expect(text).toContain("event: stream.open");
+    expect(text).toContain("event: task.created");
+    expect(text).toContain("event: task.state");
+    expect(text).toContain("id: 3");
+    expect(text).toContain("all done");
+    // Each frame is one `data:` line of JSON.
+    const dataLines = text.split("\n").filter((line) => line.startsWith("data: "));
+    expect(dataLines).toHaveLength(4);
+    expect(JSON.parse(dataLines[3]!.slice(6))).toMatchObject({ seq: 3, type: "task.state", to: "done" });
+  });
+
+  test("after skips already-seen events", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+    harness.store.update(task.id, { state: "running" });
+    harness.store.update(task.id, { state: "failed", error: { code: "boom", message: "boom" } });
+
+    const response = await harness.operations.get("streamTaskEvents")!.handler(
+      requestContext(new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}/events?after=2`), {
+        workspaceId: "w1",
+        taskId: task.id,
+      }),
+    );
+    const text = await response.text();
+    expect(text).not.toContain("event: task.created");
+    expect(text).toContain("id: 3");
+  });
+
+  test("rejects a malformed cursor", async () => {
+    const harness = createHandlerHarness();
+    const task = harness.store.add({ workspaceId: "w1", goal: "a" });
+    await expect(
+      harness.operations.get("streamTaskEvents")!.handler(
+        requestContext(new Request(`http://localhost/api/v1/workspaces/w1/tasks/${task.id}/events?after=nope`), {
+          workspaceId: "w1",
+          taskId: task.id,
+        }),
+      ),
+    ).rejects.toThrow(/non-negative integer/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Runner                                                                      */
+/* -------------------------------------------------------------------------- */
+
+function runnerHarness(): { store: TaskStore; runner: ReturnType<typeof createTaskRunner> } {
+  const store = createTaskStore();
+  return { store, runner: createTaskRunner({ store }) };
+}
+
+describe("runner happy path", () => {
+  test("creates a session, prompts with the goal, and finishes on idle", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "Write the README\nand nothing else" });
+
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+
+    expect(store.require(task.id).state).toBe("running");
+    expect(store.require(task.id).sessionId).toBe("session-1");
+    expect(store.require(task.id).engineId).toBe("stub-engine");
+    expect(connection.prompts[0]?.parts).toEqual([{ type: "text", text: "Write the README\nand nothing else" }]);
+    // The session title is the first line, not the whole goal.
+    expect(connection.createdSessions[0]?.title).toBe("Write the README");
+
+    connection.emit(textDelta("session-1", "Wrote "));
+    connection.emit(textDelta("session-1", "README.md."));
+    connection.emit({
+      type: "tool.called",
+      sessionId: "session-1",
+      messageId: "m1",
+      callId: "c1",
+      tool: "write",
+      input: { filePath: "/repo/README.md" },
+    });
+    connection.emit({
+      type: "tool.completed",
+      sessionId: "session-1",
+      messageId: "m1",
+      callId: "c1",
+      tool: "write",
+      status: "success",
+    });
+    connection.emit(idle("session-1"));
+
+    const final = await running;
+    expect(final.state).toBe("done");
+    expect(final.summary).toBe("Wrote README.md.");
+    expect(final.artifacts).toEqual([
+      { id: "c1", kind: "file", tool: "write", path: "/repo/README.md", createdAt: expect.any(Number) },
+    ]);
+    expect(final.completedAt).toBeGreaterThan(0);
+    expect(runner.active).toBe(0);
+  });
+
+  test("auto-approves permissions and stays running", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "edit a file", approvalPolicy: "auto" });
+
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+
+    connection.emit({
+      type: "permission.asked",
+      permission: {
+        id: "perm-1",
+        sessionId: "session-1",
+        kind: "edit",
+        resources: ["/repo/a.ts"],
+        remember: [],
+        metadata: {},
+        receivedAt: 1,
+      },
+    });
+    await tick();
+
+    expect(connection.permissionReplies).toEqual([{ permissionId: "perm-1", reply: "once" }]);
+    expect(store.require(task.id).state).toBe("running");
+
+    connection.emit(idle("session-1"));
+    expect((await running).state).toBe("done");
+  });
+
+  test("manual policy parks on awaiting_approval and resumes when the permission is answered", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "edit a file", approvalPolicy: "manual" });
+
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+
+    connection.emit({
+      type: "permission.asked",
+      permission: {
+        id: "perm-1",
+        sessionId: "session-1",
+        kind: "edit",
+        resources: ["/repo/a.ts"],
+        remember: ["session"],
+        metadata: {},
+        receivedAt: 42,
+      },
+    });
+
+    const parked = store.require(task.id);
+    expect(parked.state).toBe("awaiting_approval");
+    expect(parked.pendingPermissions).toEqual([
+      { permissionId: "perm-1", sessionId: "session-1", kind: "edit", resources: ["/repo/a.ts"], askedAt: 42 },
+    ]);
+    // A manual permission is never auto-answered.
+    expect(connection.permissionReplies).toEqual([]);
+
+    // The engine idling while it waits is a pause, not a result.
+    connection.emit(idle("session-1"));
+    await tick();
+    expect(store.require(task.id).state).toBe("awaiting_approval");
+
+    connection.emit({ type: "permission.replied", sessionId: "session-1", requestId: "perm-1" });
+    expect(store.require(task.id).state).toBe("running");
+    expect(store.require(task.id).pendingPermissions).toEqual([]);
+
+    connection.emit(idle("session-1"));
+    const final = await running;
+    expect(final.state).toBe("done");
+  });
+
+  test("an engine error fails the task with the engine's code", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "break" });
+
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+    connection.emit({
+      type: "session.error",
+      sessionId: "session-1",
+      error: { code: "provider_error", message: "no credential" },
+    });
+
+    const final = await running;
+    expect(final.state).toBe("failed");
+    expect(final.error).toEqual({ code: "provider_error", message: "no credential" });
+  });
+
+  test("a failure to create the session fails the task instead of throwing", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection({
+      createSession: async () => {
+        throw new ApiError(502, "opencode_request_failed", "engine is down");
+      },
+    });
+    const task = store.add({ workspaceId: "w1", goal: "start" });
+
+    const final = await runner.run({ task, connection });
+    expect(final.state).toBe("failed");
+    expect(final.error).toEqual({ code: "opencode_request_failed", message: "engine is down" });
+    expect(final.sessionId).toBeNull();
+  });
+
+  test("a failing prompt fails the task", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection({
+      prompt: async () => {
+        throw new ApiError(502, "opencode_request_failed", "prompt rejected");
+      },
+    });
+    const task = store.add({ workspaceId: "w1", goal: "start" });
+
+    const final = await runner.run({ task, connection });
+    expect(final.state).toBe("failed");
+    expect(final.error?.code).toBe("opencode_request_failed");
+  });
+
+  test("times out, interrupts the session, and reports task_timeout", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "slow", timeoutMs: 5 });
+
+    const final = await runner.run({ task, connection });
+    expect(final.state).toBe("failed");
+    expect(final.error?.code).toBe("task_timeout");
+    expect(connection.interrupts).toEqual(["session-1"]);
+  });
+
+  test("refuses to run on an engine that can neither stream nor wait", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection({ capabilities: { streaming: false, wait: false } });
+    const task = store.add({ workspaceId: "w1", goal: "blind" });
+
+    const final = await runner.run({ task, connection });
+    expect(final.state).toBe("failed");
+    expect(final.error?.code).toBe("engine_capability_unsupported");
+  });
+
+  test("falls back to wait() when the engine cannot stream", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection({ capabilities: { streaming: false, wait: true } });
+    const task = store.add({ workspaceId: "w1", goal: "blocking" });
+
+    const final = await runner.run({ task, connection });
+    expect(final.state).toBe("done");
+  });
+});
+
+describe("runner cancellation", () => {
+  test("cancel stops the run, interrupts the session, and keeps partial output", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "long job" });
+
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+    connection.emit(textDelta("session-1", "partial work"));
+
+    const cancelled = await runner.cancel(task.id, "user changed their mind");
+    expect(cancelled.state).toBe("cancelled");
+    expect(cancelled.cancelReason).toBe("user changed their mind");
+
+    const final = await running;
+    expect(final.state).toBe("cancelled");
+    expect(final.summary).toBe("partial work");
+    expect(connection.interrupts).toEqual(["session-1"]);
+    expect(runner.active).toBe(0);
+  });
+
+  test("a late idle event cannot resurrect a cancelled task", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "long job" });
+
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+    await runner.cancel(task.id);
+    connection.emit(idle("session-1"));
+
+    expect((await running).state).toBe("cancelled");
+    expect(store.require(task.id).state).toBe("cancelled");
+  });
+
+  test("cancelling a queued task that was never started still works", async () => {
+    const { store, runner } = runnerHarness();
+    const task = store.add({ workspaceId: "w1", goal: "never ran" });
+    expect((await runner.cancel(task.id)).state).toBe("cancelled");
+  });
+
+  test("cancelling a finished task is a 409", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "quick" });
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+    connection.emit(idle("session-1"));
+    await running;
+
+    await expect(runner.cancel(task.id)).rejects.toThrow(/already finished/);
+  });
+
+  test("shutdown aborts every in-flight run", async () => {
+    const { store, runner } = runnerHarness();
+    const connection = createStubConnection();
+    const task = store.add({ workspaceId: "w1", goal: "long job" });
+    const running = runner.run({ task, connection });
+    await connection.ready;
+    await tick();
+
+    runner.shutdown();
+    const final = await running;
+    expect(final.state).toBe("cancelled");
+    expect(final.cancelReason).toBe("Run aborted");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Runner helpers                                                              */
+/* -------------------------------------------------------------------------- */
+
+describe("runner helpers", () => {
+  test("the text accumulator keeps the tail and marks truncation", () => {
+    const accumulator = createTaskTextAccumulator(10);
+    accumulator.append("0123456789");
+    expect(accumulator.value()).toBe("0123456789");
+    accumulator.append("abcde");
+    expect(accumulator.value()).toBe("[…truncated]\n56789abcde");
+  });
+
+  test("artifacts come only from successful file tools", () => {
+    const success = {
+      type: "tool.completed",
+      sessionId: "s",
+      messageId: "m",
+      callId: "c",
+      tool: "write",
+      status: "success",
+    } as const;
+    expect(extractTaskArtifact(success, 5, { filePath: "/a.ts" }))
+      .toEqual({ id: "c", kind: "file", tool: "write", path: "/a.ts", createdAt: 5 });
+    expect(extractTaskArtifact({ ...success, status: "failed", error: "no" }, 5, { filePath: "/a.ts" })).toBeNull();
+    expect(extractTaskArtifact({ ...success, tool: "bash" }, 5, { filePath: "/a.ts" })).toBeNull();
+    expect(extractTaskArtifact({ type: "session.idle", sessionId: "s" }, 5)).toBeNull();
+  });
+
+  test("artifact paths are read from either the input or the output", () => {
+    const event = {
+      type: "tool.completed",
+      sessionId: "s",
+      messageId: "m",
+      callId: "c",
+      tool: "edit",
+      status: "success",
+      output: { path: "/from-output.ts" },
+    } as const;
+    expect(extractTaskArtifact(event, 1)?.path).toBe("/from-output.ts");
+    expect(extractTaskArtifact({ ...event, output: {} }, 1)).toEqual({
+      id: "c",
+      kind: "output",
+      tool: "edit",
+      createdAt: 1,
+    });
+  });
+
+  test("taskTitle takes the first line and truncates", () => {
+    expect(taskTitle("Do the thing\nthen the other")).toBe("Do the thing");
+    expect(taskTitle("x".repeat(200)).length).toBe(80);
+  });
+});
+
+describe("serializeTask", () => {
+  test("publishes a fixed field set", () => {
+    const store = createTaskStore();
+    const task = store.add({ workspaceId: "w1", goal: "a" });
+    expect(Object.keys(serializeTask(task)).sort()).toEqual([
+      "agent",
+      "approvalPolicy",
+      "artifacts",
+      "cancelReason",
+      "completedAt",
+      "createdAt",
+      "engineId",
+      "error",
+      "goal",
+      "id",
+      "metadata",
+      "model",
+      "pendingPermissions",
+      "sessionId",
+      "startedAt",
+      "state",
+      "summary",
+      "timeoutMs",
+      "updatedAt",
+      "workspaceId",
+    ]);
+  });
+});
+
+describe("resolveTaskApprovalPolicy", () => {
+  test("a manual server overrides an auto request", () => {
+    // Otherwise one POST body silently opts the run out of the human-in-the-loop posture
+    // the operator configured, and every tool call is self-approved.
+    expect(resolveTaskApprovalPolicy("auto", "manual")).toBe("manual");
+  });
+
+  test("a manual server leaves an already-manual request alone", () => {
+    expect(resolveTaskApprovalPolicy("manual", "manual")).toBe("manual");
+  });
+
+  test("an auto server honours what the caller asked for", () => {
+    expect(resolveTaskApprovalPolicy("auto", "auto")).toBe("auto");
+    expect(resolveTaskApprovalPolicy("manual", "auto")).toBe("manual");
+  });
+
+  test("an unset server mode is not treated as manual", () => {
+    expect(resolveTaskApprovalPolicy("auto", undefined)).toBe("auto");
+  });
+});

--- a/apps/server/src/api/modules/tasks/module.ts
+++ b/apps/server/src/api/modules/tasks/module.ts
@@ -1,0 +1,776 @@
+/**
+ * `tasks` API module — the one-shot automation surface.
+ *
+ * The sessions module is the conversational surface: open a session, send turns, read
+ * the stream. A task is the other shape of the same engine: submit a goal, walk away,
+ * come back to a terminal state, a summary, and the files the run touched. Automation
+ * callers (CI, cron, a webhook consumer) want that shape, and building it out of the
+ * session primitives means every caller re-implements the same prompt / stream /
+ * approve / timeout loop.
+ *
+ * A task is therefore a thin, honest wrapper over exactly one session:
+ *
+ *   queued -> running -> (awaiting_approval <-> running) -> done | failed | cancelled
+ *
+ * The task never becomes a second permission system. Under `approvalPolicy: "manual"`
+ * it parks in `awaiting_approval` and publishes the `sessionId` + `permissionId`, and
+ * the caller answers through the sessions module's permission endpoint — one pending
+ * permission, one owner.
+ *
+ * ## Tasks are in-memory and are lost on restart
+ *
+ * This is the module's most important caveat, so it is stated in the module
+ * description, in the `createTask` summary, in the `createTask` response schema, and
+ * in `store.ts`. Records live in the server process: a restart, a crash, or a second
+ * server instance loses them, and `getTask` will answer `404` for an id that was
+ * valid a moment earlier. A caller that needs durability must record the returned
+ * `sessionId` — the session itself is engine-persisted — and reconcile from there.
+ */
+
+import { ApiError } from "../../../errors.js";
+import type { EngineConnection } from "../../engine/types.js";
+import type {
+  ApiModule,
+  ApiModuleContext,
+  ApiModuleServices,
+  ApiOperation,
+  JsonSchema,
+} from "../../module.js";
+import { createSseResponse } from "../../sse.js";
+import type { RequestContext } from "../../../routes/registry.js";
+import { createTaskRunner, type TaskRunner } from "./runner.js";
+import {
+  createTaskStore,
+  isTerminalTaskState,
+  TASK_STATES,
+  type TaskApprovalPolicy,
+  type TaskEvent,
+  type TaskModelRef,
+  type TaskRecord,
+  type TaskState,
+  type TaskStore,
+} from "./store.js";
+
+/* -------------------------------------------------------------------------- */
+/* Services                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Structural view of `EngineAdapterRegistry` (`../../engine/types.ts`).
+ *
+ * Declared structurally rather than imported as a class so a test can hand in a stub
+ * registry, and so the module depends on the lookup it uses rather than on the
+ * concrete registry implementation.
+ */
+export interface TasksEngineRegistryLike {
+  get(engineId?: string | null): { connect(workspace: unknown): EngineConnection };
+}
+
+/** What `tasks` reads out of `ApiModuleContext.services`. */
+export interface TasksModuleServices extends ApiModuleServices {
+  /** Required. The server injects its `EngineAdapterRegistry` here. */
+  engines?: TasksEngineRegistryLike;
+  /** Optional overrides, used by tests and by a future durable implementation. */
+  taskStore?: TaskStore;
+  taskRunner?: TaskRunner;
+}
+
+const MAX_GOAL_CHARS = 100_000;
+const MAX_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+/* -------------------------------------------------------------------------- */
+/* Request parsing                                                             */
+/* -------------------------------------------------------------------------- */
+
+export interface TaskCreateRequest {
+  goal: string;
+  agent: string | null;
+  model: TaskModelRef | null;
+  approvalPolicy: TaskApprovalPolicy;
+  timeoutMs: number | null;
+  metadata: Record<string, unknown>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function invalid(message: string, field: string): ApiError {
+  return new ApiError(400, "invalid_request", message, { field });
+}
+
+/**
+ * Validates a `createTask` body.
+ *
+ * Pure and exported so the contract can be tested without a request, and so the
+ * failure mode is a `400` with the offending field rather than a task that runs with
+ * a silently coerced goal.
+ */
+/**
+ * The strongest approval posture the caller may ask for.
+ *
+ * A server started with `IPOLLOWORK_APPROVAL_MODE=manual` is stating that a human sees
+ * every write. The task runner answers permission requests itself, so an unconstrained
+ * `approvalPolicy: "auto"` in the request body would quietly opt out of that — one POST
+ * and the operator's setting is gone. The server's mode is a floor, not a default.
+ */
+export function resolveTaskApprovalPolicy(
+  requested: TaskApprovalPolicy,
+  serverMode: string | undefined,
+): TaskApprovalPolicy {
+  return serverMode === "manual" ? "manual" : requested;
+}
+
+export function parseCreateTaskBody(body: Record<string, unknown>): TaskCreateRequest {
+  const rawGoal = body.goal;
+  if (typeof rawGoal !== "string" || !rawGoal.trim()) {
+    throw invalid("goal is required and must be a non-empty string", "goal");
+  }
+  if (rawGoal.length > MAX_GOAL_CHARS) {
+    throw invalid(`goal must be at most ${MAX_GOAL_CHARS} characters`, "goal");
+  }
+
+  let agent: string | null = null;
+  if (body.agent !== undefined && body.agent !== null) {
+    if (typeof body.agent !== "string" || !body.agent.trim()) {
+      throw invalid("agent must be a non-empty string", "agent");
+    }
+    agent = body.agent.trim();
+  }
+
+  let model: TaskModelRef | null = null;
+  if (body.model !== undefined && body.model !== null) {
+    if (!isRecord(body.model)) throw invalid("model must be an object", "model");
+    const providerID = body.model.providerID;
+    const modelID = body.model.modelID;
+    if (typeof providerID !== "string" || !providerID.trim()) {
+      throw invalid("model.providerID is required", "model.providerID");
+    }
+    if (typeof modelID !== "string" || !modelID.trim()) {
+      throw invalid("model.modelID is required", "model.modelID");
+    }
+    model = { providerID: providerID.trim(), modelID: modelID.trim() };
+  }
+
+  let approvalPolicy: TaskApprovalPolicy = "auto";
+  if (body.approvalPolicy !== undefined && body.approvalPolicy !== null) {
+    if (body.approvalPolicy !== "auto" && body.approvalPolicy !== "manual") {
+      throw invalid('approvalPolicy must be "auto" or "manual"', "approvalPolicy");
+    }
+    approvalPolicy = body.approvalPolicy;
+  }
+
+  let timeoutMs: number | null = null;
+  if (body.timeoutMs !== undefined && body.timeoutMs !== null) {
+    const value = body.timeoutMs;
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+      throw invalid("timeoutMs must be a positive integer", "timeoutMs");
+    }
+    if (value > MAX_TIMEOUT_MS) {
+      throw invalid(`timeoutMs must be at most ${MAX_TIMEOUT_MS}`, "timeoutMs");
+    }
+    timeoutMs = value;
+  }
+
+  let metadata: Record<string, unknown> = {};
+  if (body.metadata !== undefined && body.metadata !== null) {
+    if (!isRecord(body.metadata)) throw invalid("metadata must be an object", "metadata");
+    metadata = body.metadata;
+  }
+
+  return { goal: rawGoal.trim(), agent, model, approvalPolicy, timeoutMs, metadata };
+}
+
+/** Parses `?state=` / `?limit=`, rejecting an unknown state rather than ignoring it. */
+export function parseTaskListQuery(params: URLSearchParams): { state?: TaskState[]; limit?: number } {
+  const result: { state?: TaskState[]; limit?: number } = {};
+
+  const stateValues = params
+    .getAll("state")
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (stateValues.length > 0) {
+    for (const value of stateValues) {
+      if (!(TASK_STATES as readonly string[]).includes(value)) {
+        throw new ApiError(400, "invalid_request", `Unknown task state: ${value}`, {
+          field: "state",
+          allowed: TASK_STATES,
+        });
+      }
+    }
+    result.state = stateValues as TaskState[];
+  }
+
+  const limitValue = params.get("limit");
+  if (limitValue !== null && limitValue.trim() !== "") {
+    const limit = Number(limitValue);
+    if (!Number.isInteger(limit) || limit <= 0) {
+      throw new ApiError(400, "invalid_request", "limit must be a positive integer", { field: "limit" });
+    }
+    result.limit = limit;
+  }
+
+  return result;
+}
+
+export function parseAfterCursor(value: string | null): number | undefined {
+  if (value === null || value.trim() === "") return undefined;
+  const seq = Number(value);
+  if (!Number.isInteger(seq) || seq < 0) {
+    throw new ApiError(400, "invalid_request", "after must be a non-negative integer sequence", {
+      field: "after",
+    });
+  }
+  return seq;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Serialization                                                               */
+/* -------------------------------------------------------------------------- */
+
+/** Explicit wire shape, so an internal field added to `TaskRecord` cannot leak. */
+export function serializeTask(task: TaskRecord): Record<string, unknown> {
+  return {
+    id: task.id,
+    workspaceId: task.workspaceId,
+    state: task.state,
+    goal: task.goal,
+    agent: task.agent,
+    model: task.model,
+    approvalPolicy: task.approvalPolicy,
+    timeoutMs: task.timeoutMs,
+    metadata: task.metadata,
+    sessionId: task.sessionId,
+    engineId: task.engineId,
+    summary: task.summary,
+    artifacts: task.artifacts,
+    pendingPermissions: task.pendingPermissions,
+    error: task.error,
+    cancelReason: task.cancelReason,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    startedAt: task.startedAt,
+    completedAt: task.completedAt,
+  };
+}
+
+export function serializeTaskEvent(event: TaskEvent): Record<string, unknown> {
+  return {
+    seq: event.seq,
+    at: event.at,
+    taskId: event.taskId,
+    type: event.type,
+    ...(event.from !== undefined ? { from: event.from } : {}),
+    ...(event.to !== undefined ? { to: event.to } : {}),
+    task: serializeTask(event.task),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Schemas                                                                     */
+/* -------------------------------------------------------------------------- */
+
+const MODEL_SCHEMA: JsonSchema = {
+  type: "object",
+  description: "Engine model reference. Defaults to the workspace's configured model.",
+  properties: {
+    providerID: { type: "string", minLength: 1 },
+    modelID: { type: "string", minLength: 1 },
+  },
+  required: ["providerID", "modelID"],
+  additionalProperties: false,
+};
+
+const ARTIFACT_SCHEMA: JsonSchema = {
+  type: "object",
+  description: "Something the run produced, derived from a successful file-writing tool call.",
+  properties: {
+    id: { type: "string", description: "The engine tool call id." },
+    kind: { type: "string", enum: ["file", "output"] },
+    tool: { type: "string" },
+    path: { type: "string", description: "Absent when the tool call reported no path." },
+    createdAt: { type: "integer" },
+  },
+  required: ["id", "kind", "tool", "createdAt"],
+  additionalProperties: false,
+};
+
+const PENDING_PERMISSION_SCHEMA: JsonSchema = {
+  type: "object",
+  description:
+    "A permission the engine is waiting on. Answer it through the sessions module's "
+    + "permission endpoint using `sessionId` and `permissionId`; tasks deliberately do "
+    + "not expose a second way to reply to the same permission.",
+  properties: {
+    permissionId: { type: "string" },
+    sessionId: { type: "string" },
+    kind: { type: "string", description: "Engine-specific permission kind, normally the tool name." },
+    resources: { type: "array", items: { type: "string" } },
+    askedAt: { type: "integer" },
+  },
+  required: ["permissionId", "sessionId", "kind", "resources", "askedAt"],
+  additionalProperties: false,
+};
+
+const TASK_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    workspaceId: { type: "string" },
+    state: {
+      type: "string",
+      enum: [...TASK_STATES],
+      description:
+        "queued -> running -> (awaiting_approval <-> running) -> done | failed | cancelled. "
+        + "`done`, `failed` and `cancelled` are terminal.",
+    },
+    goal: { type: "string" },
+    agent: { type: ["string", "null"] },
+    model: { oneOf: [MODEL_SCHEMA, { type: "null" }] },
+    approvalPolicy: { type: "string", enum: ["auto", "manual"] },
+    timeoutMs: { type: ["integer", "null"] },
+    metadata: { type: "object", additionalProperties: true },
+    sessionId: {
+      type: ["string", "null"],
+      description:
+        "The session the task runs in. Null until the runner has created it. This is the "
+        + "only durable handle a task exposes — the session outlives the task record.",
+    },
+    engineId: { type: ["string", "null"] },
+    summary: {
+      type: "string",
+      description: "Assistant text collected from the run, truncated from the front when long.",
+    },
+    artifacts: { type: "array", items: ARTIFACT_SCHEMA },
+    pendingPermissions: { type: "array", items: PENDING_PERMISSION_SCHEMA },
+    error: {
+      oneOf: [
+        {
+          type: "object",
+          properties: { code: { type: "string" }, message: { type: "string" } },
+          required: ["code", "message"],
+          additionalProperties: false,
+        },
+        { type: "null" },
+      ],
+    },
+    cancelReason: { type: ["string", "null"] },
+    createdAt: { type: "integer" },
+    updatedAt: { type: "integer" },
+    startedAt: { type: ["integer", "null"] },
+    completedAt: { type: ["integer", "null"] },
+  },
+  required: [
+    "id",
+    "workspaceId",
+    "state",
+    "goal",
+    "approvalPolicy",
+    "metadata",
+    "summary",
+    "artifacts",
+    "pendingPermissions",
+    "createdAt",
+    "updatedAt",
+  ],
+  additionalProperties: false,
+};
+
+const CREATED_TASK_SCHEMA: JsonSchema = {
+  ...TASK_SCHEMA,
+  description:
+    "The accepted task, in state `queued` or `running`. **Tasks are held in server "
+    + "memory and are lost on restart**: this id is not durable, and `getTask` will "
+    + "answer 404 for it after the server restarts, crashes, or fails over to another "
+    + "instance. Record `sessionId` if you need a handle that survives — the underlying "
+    + "session is persisted by the engine.",
+};
+
+const WORKSPACE_PATH_PARAMS: JsonSchema = {
+  type: "object",
+  properties: { workspaceId: { type: "string" } },
+  required: ["workspaceId"],
+};
+
+const TASK_PATH_PARAMS: JsonSchema = {
+  type: "object",
+  properties: { workspaceId: { type: "string" }, taskId: { type: "string" } },
+  required: ["workspaceId", "taskId"],
+};
+
+const CREATE_TASK_BODY: JsonSchema = {
+  type: "object",
+  properties: {
+    goal: {
+      type: "string",
+      minLength: 1,
+      maxLength: MAX_GOAL_CHARS,
+      description: "What the agent should accomplish. Sent verbatim as the first prompt.",
+    },
+    agent: { type: "string", minLength: 1, description: "Agent / mode id understood by the engine." },
+    model: MODEL_SCHEMA,
+    approvalPolicy: {
+      type: "string",
+      enum: ["auto", "manual"],
+      default: "auto",
+      description:
+        "`auto` answers every permission request with `once` and keeps running. `manual` "
+        + "moves the task to `awaiting_approval` and publishes the pending permission, which "
+        + "the caller answers through the sessions module. A server running with "
+        + "`IPOLLOWORK_APPROVAL_MODE=manual` forces `manual` regardless of what is requested: "
+        + "the operator's posture is a floor, not a default. The task's effective policy is "
+        + "reported back on the created task.",
+    },
+    timeoutMs: {
+      type: "integer",
+      minimum: 1,
+      maximum: MAX_TIMEOUT_MS,
+      description: "Wall-clock budget. On expiry the session is interrupted and the task fails with `task_timeout`.",
+    },
+    metadata: { type: "object", additionalProperties: true, description: "Opaque caller data, echoed back." },
+  },
+  required: ["goal"],
+  additionalProperties: false,
+};
+
+const CANCEL_TASK_BODY: JsonSchema = {
+  type: "object",
+  properties: { reason: { type: "string", description: "Recorded on the task as `cancelReason`." } },
+  additionalProperties: false,
+};
+
+const TASK_EVENT_SCHEMA: JsonSchema = {
+  type: "object",
+  description: "One SSE frame payload. Every event carries the full task snapshot.",
+  properties: {
+    seq: { type: "integer", description: "Monotonic cursor. Pass the last one back as `?after=`." },
+    at: { type: "integer" },
+    taskId: { type: "string" },
+    type: { type: "string", enum: ["task.created", "task.state", "task.updated"] },
+    from: { type: "string", enum: [...TASK_STATES], description: "Present on `task.state`." },
+    to: { type: "string", enum: [...TASK_STATES], description: "Present on `task.state`." },
+    task: TASK_SCHEMA,
+  },
+  required: ["seq", "at", "taskId", "type", "task"],
+};
+
+const ERROR_SCHEMA: JsonSchema = {
+  type: "object",
+  properties: {
+    code: { type: "string" },
+    message: { type: "string" },
+    details: {},
+  },
+  required: ["code", "message"],
+};
+
+function errorResponse(description: string) {
+  return { description, schema: ERROR_SCHEMA };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Module                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Reads an optional JSON body.
+ *
+ * `cancelTask` takes no required input, and a `POST` with no body at all is the
+ * normal way to call it; `readJsonBody` rejects that as invalid JSON.
+ */
+async function readOptionalJsonBody(request: Request): Promise<Record<string, unknown>> {
+  const raw = await request.text();
+  if (!raw.trim()) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) throw new Error("not an object");
+    return parsed;
+  } catch {
+    throw new ApiError(400, "invalid_json", "Invalid JSON body");
+  }
+}
+
+export const tasksModule: ApiModule = {
+  id: "tasks",
+  title: "Tasks",
+  description:
+    "One-shot automation over a session: submit a goal, poll or stream until the task "
+    + "reaches done / failed / cancelled, then read its summary and artifacts. "
+    + "Tasks are held in server memory only and are LOST ON RESTART — the task id is not "
+    + "durable, while the `sessionId` a task reports is. Manual approvals are answered "
+    + "through the sessions module, not here.",
+  version: "1.0.0",
+  stability: "preview",
+  dependsOn: ["sessions"],
+
+  register(context: ApiModuleContext): ApiOperation[] {
+    const services = context.services as TasksModuleServices;
+    const store = services.taskStore ?? createTaskStore();
+    const runner = services.taskRunner ?? createTaskRunner({ store });
+
+    const engines = (): TasksEngineRegistryLike => {
+      if (!services.engines) {
+        throw new ApiError(
+          500,
+          "api_service_missing",
+          "The tasks module requires an engine registry in ApiModuleContext.services.engines",
+          { service: "engines" },
+        );
+      }
+      return services.engines;
+    };
+
+    const connect = async (ctx: RequestContext): Promise<EngineConnection> => {
+      const workspace = await context.resolveWorkspace(ctx.config, ctx.params.workspaceId ?? "");
+      const engineId = isRecord(workspace) && typeof workspace.engineId === "string"
+        ? workspace.engineId
+        : null;
+      return engines().get(engineId).connect(workspace);
+    };
+
+    return [
+      {
+        operationId: "createTask",
+        method: "POST",
+        path: "/api/v1/workspaces/:workspaceId/tasks",
+        summary: "Submit a goal as a background task (in-memory; lost on restart)",
+        description:
+          "Creates a session, sends `goal` as its first prompt, and drives it to a terminal "
+          + "state. Returns immediately with the queued task; follow it with `getTask` or "
+          + "`streamTaskEvents`. The task record lives in server memory and does not survive a "
+          + "restart — persist the returned `sessionId` if you need a durable handle.",
+        effect: "write",
+        pathParams: WORKSPACE_PATH_PARAMS,
+        requestBody: CREATE_TASK_BODY,
+        responses: {
+          202: { description: "Task accepted and queued.", schema: CREATED_TASK_SCHEMA },
+          400: errorResponse("The body failed validation."),
+          403: errorResponse("The server is read-only or the token scope is insufficient."),
+          404: errorResponse("Unknown workspace."),
+          409: errorResponse("The workspace's engine is not registered."),
+        },
+        handler: async (ctx) => {
+          const workspaceId = ctx.params.workspaceId ?? "";
+          const body = await context.readJsonBody(ctx.request);
+          const request = parseCreateTaskBody(body);
+          // Resolved before the task is recorded, so an unknown workspace or an
+          // unregistered engine is a 404/409 rather than a task that fails a beat later.
+          const connection = await connect(ctx);
+
+          const task = store.add({
+            workspaceId,
+            goal: request.goal,
+            agent: request.agent,
+            model: request.model,
+            approvalPolicy: resolveTaskApprovalPolicy(request.approvalPolicy, ctx.config.approval?.mode),
+            timeoutMs: request.timeoutMs,
+            metadata: request.metadata,
+          });
+          runner.start({ task, connection });
+          return context.jsonResponse(serializeTask(store.get(task.id) ?? task), 202);
+        },
+      },
+
+      {
+        operationId: "listTasks",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/tasks",
+        summary: "List the tasks this server instance is holding",
+        description:
+          "Newest first. Only tasks created since the current server process started are "
+          + "visible; there is no historical archive.",
+        effect: "read",
+        pathParams: WORKSPACE_PATH_PARAMS,
+        query: {
+          type: "object",
+          properties: {
+            state: {
+              type: "string",
+              description: "Repeatable, or comma-separated. Filters by task state.",
+              enum: [...TASK_STATES],
+            },
+            limit: { type: "integer", minimum: 1, maximum: 200, default: 50 },
+          },
+        },
+        responses: {
+          200: {
+            description: "The matching tasks.",
+            schema: {
+              type: "object",
+              properties: {
+                items: { type: "array", items: TASK_SCHEMA },
+                count: { type: "integer" },
+                durable: {
+                  type: "boolean",
+                  description: "Always false. Tasks are in-memory and are lost on restart.",
+                },
+              },
+              required: ["items", "count", "durable"],
+            },
+          },
+          400: errorResponse("An unknown state or a malformed limit."),
+          404: errorResponse("Unknown workspace."),
+        },
+        handler: async (ctx) => {
+          const workspaceId = ctx.params.workspaceId ?? "";
+          await context.resolveWorkspace(ctx.config, workspaceId);
+          const query = parseTaskListQuery(ctx.url.searchParams);
+          const items = store.list({ workspaceId, ...query });
+          return context.jsonResponse({
+            items: items.map(serializeTask),
+            count: items.length,
+            durable: false,
+          });
+        },
+      },
+
+      {
+        operationId: "getTask",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/tasks/:taskId",
+        summary: "Read one task",
+        description:
+          "Answers 404 for a task from another workspace, and for any task created before "
+          + "the current server process started.",
+        effect: "read",
+        pathParams: TASK_PATH_PARAMS,
+        responses: {
+          200: { description: "The task.", schema: TASK_SCHEMA },
+          404: errorResponse("Unknown workspace, or unknown task in that workspace."),
+        },
+        handler: async (ctx) => {
+          const workspaceId = ctx.params.workspaceId ?? "";
+          await context.resolveWorkspace(ctx.config, workspaceId);
+          const task = store.require(ctx.params.taskId ?? "", workspaceId);
+          return context.jsonResponse(serializeTask(task));
+        },
+      },
+
+      {
+        operationId: "cancelTask",
+        method: "POST",
+        path: "/api/v1/workspaces/:workspaceId/tasks/:taskId/cancel",
+        summary: "Cancel a running or queued task",
+        description:
+          "Moves the task to `cancelled`, aborts the run, and interrupts the underlying "
+          + "session when the engine supports interruption. Already-terminal tasks answer 409; "
+          + "cancellation is not idempotent on purpose, so a caller can tell whether it was the "
+          + "one that stopped the task.",
+        effect: "write",
+        pathParams: TASK_PATH_PARAMS,
+        requestBody: CANCEL_TASK_BODY,
+        responses: {
+          200: { description: "The cancelled task.", schema: TASK_SCHEMA },
+          404: errorResponse("Unknown workspace, or unknown task in that workspace."),
+          409: errorResponse("The task already reached a terminal state."),
+        },
+        handler: async (ctx) => {
+          const workspaceId = ctx.params.workspaceId ?? "";
+          await context.resolveWorkspace(ctx.config, workspaceId);
+          const taskId = ctx.params.taskId ?? "";
+          store.require(taskId, workspaceId);
+          const body = await readOptionalJsonBody(ctx.request);
+          const reason = typeof body.reason === "string" ? body.reason : undefined;
+          const task = await runner.cancel(taskId, reason);
+          return context.jsonResponse(serializeTask(task));
+        },
+      },
+
+      {
+        operationId: "streamTaskEvents",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/tasks/:taskId/events",
+        summary: "Stream a task's state changes as SSE",
+        description:
+          "Frames use the shared SSE format: `id:` is the event `seq`, `event:` is the event "
+          + "type, `data:` is a JSON `TaskEvent` carrying the full task snapshot. The buffered "
+          + "log is replayed first (pass `?after=<seq>` to resume from a cursor), and the stream "
+          + "closes on its own once the task reaches a terminal state. This is a coarse "
+          + "state-change stream — for token-level output subscribe to the task's `sessionId` "
+          + "through the sessions module.",
+        effect: "read",
+        streaming: "sse",
+        pathParams: TASK_PATH_PARAMS,
+        query: {
+          type: "object",
+          properties: {
+            after: {
+              type: "integer",
+              minimum: 0,
+              description: "Replay only events with a greater `seq`. Omit to replay the whole buffer.",
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "An event stream of `TaskEvent` frames.",
+            contentType: "text/event-stream",
+            schema: TASK_EVENT_SCHEMA,
+          },
+          400: errorResponse("A malformed `after` cursor."),
+          404: errorResponse("Unknown workspace, or unknown task in that workspace."),
+        },
+        handler: async (ctx) => {
+          const workspaceId = ctx.params.workspaceId ?? "";
+          await context.resolveWorkspace(ctx.config, workspaceId);
+          const taskId = ctx.params.taskId ?? "";
+          const task = store.require(taskId, workspaceId);
+          const after = parseAfterCursor(ctx.url.searchParams.get("after"));
+
+          return createSseResponse({
+            signal: ctx.request.signal,
+            hello: {
+              event: "stream.open",
+              data: { taskId, state: task.state, after: after ?? null },
+            },
+            start: (emit, signal) =>
+              new Promise<void>((resolve) => {
+                let done = false;
+                let unsubscribe: (() => void) | null = null;
+                const finish = (): void => {
+                  if (done) return;
+                  done = true;
+                  unsubscribe?.();
+                  signal.removeEventListener("abort", finish);
+                  resolve();
+                };
+
+                if (signal.aborted) {
+                  finish();
+                  return;
+                }
+                signal.addEventListener("abort", finish, { once: true });
+
+                // `after ?? 0` replays the whole retained log for a fresh subscriber,
+                // which is also what closes the stream immediately for a task that
+                // already finished before anyone attached.
+                const off = store.subscribe({
+                  taskId,
+                  after: after ?? 0,
+                  onEvent: (event) => {
+                    if (done) return;
+                    emit({
+                      id: String(event.seq),
+                      event: event.type,
+                      data: serializeTaskEvent(event),
+                    });
+                    if (isTerminalTaskState(event.task.state)) finish();
+                  },
+                });
+                if (done) off();
+                else unsubscribe = off;
+
+                // Safety net for a task that reached its terminal state with an empty
+                // retained log (evicted, or resumed past the final seq).
+                const current = store.get(taskId);
+                if (current && isTerminalTaskState(current.state)) finish();
+              }),
+          });
+        },
+      },
+    ];
+  },
+};
+
+export default tasksModule;

--- a/apps/server/src/api/modules/tasks/runner.ts
+++ b/apps/server/src/api/modules/tasks/runner.ts
@@ -1,0 +1,497 @@
+/**
+ * Task runner.
+ *
+ * Drives one task to a terminal state over an `EngineConnection`: create a session,
+ * send the goal as a prompt, follow the event stream, and translate what happens
+ * there into task state. Everything engine-specific already lives behind
+ * `EngineConnection`, so this file is engine-agnostic and a stub connection is enough
+ * to test it.
+ *
+ * Three things decide the shape of it:
+ *
+ * - **Approvals.** An agent that stops to ask for permission is the normal case, not
+ *   an error. Under `approvalPolicy: "auto"` the runner answers `once` and the task
+ *   stays `running`; under `"manual"` it parks the task in `awaiting_approval` and
+ *   records the session id and permission id, because replying is the sessions
+ *   module's job and duplicating a permission-reply endpoint here would give the same
+ *   pending permission two owners.
+ * - **Finishing.** `session.idle` is the completion signal, but only when no manual
+ *   approval is outstanding — the engine also goes idle while it waits for an answer,
+ *   and treating that as success would report a half-done task as `done`.
+ * - **Stopping.** Timeout, client cancellation, and engine error all converge on one
+ *   `AbortController`, so there is a single teardown path that ends the subscription
+ *   and interrupts the session rather than three that can each leak it.
+ */
+
+import type {
+  EngineConnection,
+  EngineEvent,
+  EnginePermission,
+} from "../../engine/types.js";
+import { ApiError } from "../../../errors.js";
+import type {
+  TaskArtifact,
+  TaskError,
+  TaskPendingPermission,
+  TaskRecord,
+  TaskStore,
+} from "./store.js";
+
+/** Bound on the retained assistant text. The tail is kept: it holds the conclusion. */
+export const MAX_TASK_SUMMARY_CHARS = 16_000;
+
+const TRUNCATION_MARKER = "[…truncated]\n";
+
+/** Tools whose successful completion is recorded as a file artifact. */
+const FILE_TOOLS = new Set(["write", "edit", "multiedit", "patch", "apply_patch", "apply-patch"]);
+
+const FILE_INPUT_KEYS = ["filePath", "file_path", "path", "filename"] as const;
+
+export interface TaskTextAccumulator {
+  append(chunk: string): void;
+  value(): string;
+}
+
+/**
+ * Bounded text buffer.
+ *
+ * A long-running task can stream megabytes of assistant text; keeping all of it in a
+ * process-resident record is how an in-memory store turns into a leak. Trimming from
+ * the front preserves the end of the run, which is where the answer is.
+ */
+export function createTaskTextAccumulator(limit = MAX_TASK_SUMMARY_CHARS): TaskTextAccumulator {
+  const max = Math.max(1, limit);
+  let buffer = "";
+  let truncated = false;
+  return {
+    append(chunk) {
+      if (!chunk) return;
+      buffer += chunk;
+      if (buffer.length > max) {
+        buffer = buffer.slice(buffer.length - max);
+        truncated = true;
+      }
+    },
+    value() {
+      return truncated ? `${TRUNCATION_MARKER}${buffer}` : buffer;
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Recognises an artifact in a completed tool call.
+ *
+ * `tool.completed` carries no input, so the path comes from the matching
+ * `tool.called` the runner remembered — the same pairing the Harness adapter keeps
+ * for exactly this reason. Pure and exported so the tool-name and input-shape
+ * heuristics can be tested directly; a failed tool call produces nothing, since a
+ * task's artifacts are what it actually produced.
+ */
+export function extractTaskArtifact(
+  event: EngineEvent,
+  at: number,
+  input?: unknown,
+): TaskArtifact | null {
+  if (event.type !== "tool.completed" || event.status !== "success") return null;
+  const tool = event.tool.toLowerCase();
+  if (!FILE_TOOLS.has(tool)) return null;
+  const sources = [input, event.output].filter(isRecord);
+  let path: string | undefined;
+  outer: for (const source of sources) {
+    for (const key of FILE_INPUT_KEYS) {
+      const value = source[key];
+      if (typeof value === "string" && value.trim()) {
+        path = value.trim();
+        break outer;
+      }
+    }
+  }
+  return {
+    id: event.callId,
+    kind: path ? "file" : "output",
+    tool: event.tool,
+    ...(path ? { path } : {}),
+    createdAt: at,
+  };
+}
+
+function toPendingPermission(permission: EnginePermission): TaskPendingPermission {
+  return {
+    permissionId: permission.id,
+    sessionId: permission.sessionId,
+    kind: permission.kind,
+    resources: [...permission.resources],
+    askedAt: permission.receivedAt,
+  };
+}
+
+function toTaskError(error: unknown, fallbackCode: string): TaskError {
+  if (error instanceof ApiError) return { code: error.code, message: error.message };
+  if (error instanceof Error) return { code: fallbackCode, message: error.message };
+  return { code: fallbackCode, message: String(error ?? "Task failed") };
+}
+
+/** How a run stopped, before it is written back to the store. */
+type RunOutcome =
+  | { kind: "done" }
+  | { kind: "failed"; error: TaskError }
+  | { kind: "aborted" };
+
+interface ActiveRun {
+  controller: AbortController;
+  connection: EngineConnection;
+  sessionId: string | null;
+}
+
+export interface TaskRunnerOptions {
+  store: TaskStore;
+  now?: () => number;
+  summaryLimit?: number;
+}
+
+export interface TaskRunInput {
+  task: TaskRecord;
+  connection: EngineConnection;
+}
+
+export interface TaskRunner {
+  /** Runs to completion. Never rejects: a failure is recorded on the task instead. */
+  run(input: TaskRunInput): Promise<TaskRecord>;
+  /** Starts a run in the background and returns immediately. */
+  start(input: TaskRunInput): void;
+  /**
+   * Cancels a task. Marks it `cancelled` first (throwing `409` when it already
+   * finished), then aborts the run and interrupts the session best-effort.
+   */
+  cancel(taskId: string, reason?: string): Promise<TaskRecord>;
+  /** Number of runs currently in flight. */
+  readonly active: number;
+  /** Aborts every in-flight run, for shutdown. */
+  shutdown(): void;
+}
+
+export function createTaskRunner(options: TaskRunnerOptions): TaskRunner {
+  const { store } = options;
+  const now = options.now ?? (() => Date.now());
+  const runs = new Map<string, ActiveRun>();
+
+  const runner: TaskRunner = {
+    async run({ task, connection }) {
+      const taskId = task.id;
+      const controller = new AbortController();
+      const active: ActiveRun = { controller, connection, sessionId: null };
+      runs.set(taskId, active);
+
+      const text = createTaskTextAccumulator(options.summaryLimit);
+      const artifacts = new Map<string, TaskArtifact>();
+      const pending = new Map<string, TaskPendingPermission>();
+      const toolInputs = new Map<string, unknown>();
+
+      let settled = false;
+      let settle: (outcome: RunOutcome) => void = () => {};
+      const finished = new Promise<RunOutcome>((resolve) => {
+        settle = (outcome) => {
+          if (settled) return;
+          settled = true;
+          resolve(outcome);
+        };
+      });
+
+      let timedOut = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const onAbort = () => settle({ kind: "aborted" });
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+
+      /** Writes the terminal state, unless something already finished the task. */
+      const finalize = async (): Promise<TaskRecord> => {
+        controller.signal.removeEventListener("abort", onAbort);
+        if (timer !== undefined) clearTimeout(timer);
+        if (!controller.signal.aborted) controller.abort();
+        runs.delete(taskId);
+        return store.get(taskId) ?? task;
+      };
+
+      const failNow = async (error: unknown, code: string): Promise<TaskRecord> => {
+        const current = store.get(taskId);
+        if (current && !isFinished(current)) {
+          store.update(taskId, {
+            state: "failed",
+            error: toTaskError(error, code),
+            summary: text.value(),
+            artifacts: [...artifacts.values()],
+            pendingPermissions: [],
+          });
+        }
+        return finalize();
+      };
+
+      // ---- start ------------------------------------------------------------
+      try {
+        store.update(taskId, { state: "running", startedAt: now() });
+      } catch {
+        // The task was cancelled between `add` and `run`, so `queued -> running` is no
+        // longer legal. The terminal state already recorded is the right answer.
+        return finalize();
+      }
+
+      let sessionId: string;
+      try {
+        const session = await connection.createSession({
+          title: taskTitle(task.goal),
+          ...(task.agent ? { agent: task.agent } : {}),
+          ...(task.model ? { model: task.model } : {}),
+        });
+        sessionId = session.id;
+      } catch (error) {
+        return failNow(error, "task_session_failed");
+      }
+      active.sessionId = sessionId;
+      store.update(taskId, { sessionId, engineId: connection.engineId });
+
+      // ---- events -----------------------------------------------------------
+      const syncPermissions = (): void => {
+        const list = [...pending.values()];
+        const current = store.get(taskId);
+        if (!current || isFinished(current)) return;
+        if (list.length > 0 && current.state === "running") {
+          store.update(taskId, { state: "awaiting_approval", pendingPermissions: list });
+          return;
+        }
+        if (list.length === 0 && current.state === "awaiting_approval") {
+          store.update(taskId, { state: "running", pendingPermissions: [] });
+          return;
+        }
+        store.update(taskId, { pendingPermissions: list });
+      };
+
+      const onEvent = (event: EngineEvent): void => {
+        if (settled) return;
+        if (event.type === "message.delta" && event.kind === "text") {
+          text.append(event.delta);
+          return;
+        }
+        if (event.type === "tool.called") {
+          toolInputs.set(event.callId, event.input);
+          return;
+        }
+        if (event.type === "tool.completed") {
+          const artifact = extractTaskArtifact(event, now(), toolInputs.get(event.callId));
+          toolInputs.delete(event.callId);
+          if (artifact) artifacts.set(artifact.id, artifact);
+          return;
+        }
+        if (event.type === "permission.asked") {
+          if (task.approvalPolicy === "auto") {
+            void connection
+              .replyPermission({
+                sessionId: event.permission.sessionId,
+                permissionId: event.permission.id,
+                reply: "once",
+              })
+              .catch((error: unknown) => {
+                settle({ kind: "failed", error: toTaskError(error, "task_permission_failed") });
+              });
+            return;
+          }
+          pending.set(event.permission.id, toPendingPermission(event.permission));
+          syncPermissions();
+          return;
+        }
+        if (event.type === "permission.replied") {
+          if (pending.delete(event.requestId)) syncPermissions();
+          return;
+        }
+        if (event.type === "session.error") {
+          settle({
+            kind: "failed",
+            error: {
+              code: event.error.code ?? "task_engine_error",
+              message: event.error.message,
+            },
+          });
+          return;
+        }
+        if (event.type === "session.idle") {
+          // The engine also idles while a manual approval is outstanding; that is a
+          // pause, not a result.
+          if (pending.size === 0) settle({ kind: "done" });
+          return;
+        }
+      };
+
+      let subscription: Promise<void> = Promise.resolve();
+      if (connection.capabilities.streaming) {
+        subscription = connection
+          .subscribe({ sessionId, signal: controller.signal, onEvent })
+          .catch((error: unknown) => {
+            if (controller.signal.aborted || settled) return;
+            settle({ kind: "failed", error: toTaskError(error, "task_stream_failed") });
+          });
+      }
+
+      // ---- prompt -----------------------------------------------------------
+      try {
+        await connection.prompt({
+          sessionId,
+          parts: [{ type: "text", text: task.goal }],
+          ...(task.agent ? { agent: task.agent } : {}),
+          ...(task.model ? { model: task.model } : {}),
+        });
+      } catch (error) {
+        controller.abort();
+        await subscription;
+        return failNow(error, "task_prompt_failed");
+      }
+
+      if (task.timeoutMs !== null && task.timeoutMs > 0) {
+        timer = setTimeout(() => {
+          timedOut = true;
+          controller.abort();
+        }, task.timeoutMs);
+        (timer as unknown as { unref?: () => void }).unref?.();
+      }
+
+      // An engine with no stream cannot report idleness through `onEvent`; fall back
+      // to the blocking primitive when it has one, and say so plainly when it does not.
+      if (!connection.capabilities.streaming) {
+        if (!connection.capabilities.wait) {
+          return failNow(
+            new ApiError(
+              501,
+              "engine_capability_unsupported",
+              `Engine ${connection.engineId} supports neither event streaming nor wait(), so a task cannot be observed to completion`,
+              { engineId: connection.engineId },
+            ),
+            "engine_capability_unsupported",
+          );
+        }
+        void connection
+          .wait(sessionId, controller.signal)
+          .then(() => settle({ kind: "done" }))
+          .catch((error: unknown) => {
+            if (controller.signal.aborted || settled) return;
+            settle({ kind: "failed", error: toTaskError(error, "task_wait_failed") });
+          });
+      }
+
+      const outcome = await finished;
+      controller.abort();
+      await subscription;
+
+      const current = store.get(taskId);
+      if (!current || isFinished(current)) {
+        // Something outside the run already wrote the terminal state — `cancel()` is
+        // the only such path, and it has already interrupted the session. The partial
+        // summary and artifacts are still worth keeping.
+        if (current) {
+          store.update(taskId, { summary: text.value(), artifacts: [...artifacts.values()] });
+        }
+        return finalize();
+      }
+
+      if (timedOut) {
+        if (connection.capabilities.interrupt) await interruptQuietly(connection, sessionId);
+        store.update(taskId, {
+          state: "failed",
+          error: {
+            code: "task_timeout",
+            message: `Task exceeded its ${task.timeoutMs}ms timeout`,
+          },
+          summary: text.value(),
+          artifacts: [...artifacts.values()],
+          pendingPermissions: [],
+        });
+        return finalize();
+      }
+
+      if (outcome.kind === "failed") {
+        store.update(taskId, {
+          state: "failed",
+          error: outcome.error,
+          summary: text.value(),
+          artifacts: [...artifacts.values()],
+          pendingPermissions: [],
+        });
+        return finalize();
+      }
+
+      if (outcome.kind === "aborted") {
+        if (connection.capabilities.interrupt) await interruptQuietly(connection, sessionId);
+        store.update(taskId, {
+          state: "cancelled",
+          cancelReason: "Run aborted",
+          summary: text.value(),
+          artifacts: [...artifacts.values()],
+          pendingPermissions: [],
+        });
+        return finalize();
+      }
+
+      // `done` is only reachable from `running`; a task parked on an approval is
+      // moved back before the idle event is accepted.
+      if (store.get(taskId)?.state === "awaiting_approval") {
+        store.update(taskId, { state: "running", pendingPermissions: [] });
+      }
+      store.update(taskId, {
+        state: "done",
+        summary: text.value(),
+        artifacts: [...artifacts.values()],
+        pendingPermissions: [],
+      });
+      return finalize();
+    },
+
+    start(input) {
+      void runner.run(input);
+    },
+
+    async cancel(taskId, reason) {
+      // Marking first makes the store the single arbiter: `cancel` throws 409 for an
+      // already-finished task, and the run's own finalizer then sees a terminal state
+      // and does not try to transition again.
+      const record = store.cancel(taskId, reason);
+      const active = runs.get(taskId);
+      if (active) {
+        active.controller.abort();
+        if (active.sessionId && active.connection.capabilities.interrupt) {
+          await interruptQuietly(active.connection, active.sessionId);
+        }
+      }
+      return record;
+    },
+
+    get active() {
+      return runs.size;
+    },
+
+    shutdown() {
+      for (const run of runs.values()) run.controller.abort();
+      runs.clear();
+    },
+  };
+
+  return runner;
+}
+
+function isFinished(task: TaskRecord): boolean {
+  return task.state === "done" || task.state === "failed" || task.state === "cancelled";
+}
+
+async function interruptQuietly(connection: EngineConnection, sessionId: string): Promise<void> {
+  try {
+    await connection.interrupt(sessionId);
+  } catch {
+    // The session may already be gone; the task's state is what matters here.
+  }
+}
+
+/** Session titles are a one-line handle, not the whole goal. */
+export function taskTitle(goal: string, limit = 80): string {
+  const line = goal.trim().split("\n")[0]?.trim() ?? "";
+  const title = line || goal.trim();
+  return title.length > limit ? `${title.slice(0, limit - 1)}…` : title;
+}

--- a/apps/server/src/api/modules/tasks/store.test.ts
+++ b/apps/server/src/api/modules/tasks/store.test.ts
@@ -1,0 +1,419 @@
+import { describe, expect, test } from "bun:test";
+
+import { isApiError } from "../../../errors.js";
+import {
+  canTransitionTask,
+  createTaskStore,
+  isTerminalTaskState,
+  TASK_STATES,
+  TASK_TRANSITIONS,
+  TERMINAL_TASK_STATES,
+  type TaskEvent,
+  type TaskState,
+  type TaskStore,
+} from "./store.js";
+
+function createHarness() {
+  let clock = 1_000;
+  let counter = 0;
+  const store = createTaskStore({
+    now: () => clock,
+    newId: () => `task_${++counter}`,
+  });
+  return {
+    store,
+    tick(by = 1): number {
+      clock += by;
+      return clock;
+    },
+    get clock() {
+      return clock;
+    },
+  };
+}
+
+function addTask(store: TaskStore, overrides: { workspaceId?: string; goal?: string } = {}) {
+  return store.add({
+    workspaceId: overrides.workspaceId ?? "w1",
+    goal: overrides.goal ?? "Ship the thing",
+  });
+}
+
+/** Walks a fresh task to `state` using only legal transitions. */
+function taskInState(store: TaskStore, state: TaskState, workspaceId = "w1") {
+  const task = store.add({ workspaceId, goal: `reach ${state}` });
+  const path: Record<TaskState, TaskState[]> = {
+    queued: [],
+    running: ["running"],
+    awaiting_approval: ["running", "awaiting_approval"],
+    done: ["running", "done"],
+    failed: ["failed"],
+    cancelled: ["cancelled"],
+  };
+  let current = task;
+  for (const next of path[state]) current = store.update(task.id, { state: next });
+  expect(current.state).toBe(state);
+  return current;
+}
+
+describe("task state machine constants", () => {
+  test("declares a transition list for every state", () => {
+    for (const state of TASK_STATES) {
+      expect(Array.isArray(TASK_TRANSITIONS[state])).toBe(true);
+    }
+  });
+
+  test("terminal states accept no transition", () => {
+    for (const state of TERMINAL_TASK_STATES) {
+      expect(TASK_TRANSITIONS[state]).toEqual([]);
+      expect(isTerminalTaskState(state)).toBe(true);
+    }
+  });
+
+  test("the happy path and both approval directions are legal", () => {
+    expect(canTransitionTask("queued", "running")).toBe(true);
+    expect(canTransitionTask("running", "awaiting_approval")).toBe(true);
+    expect(canTransitionTask("awaiting_approval", "running")).toBe(true);
+    expect(canTransitionTask("running", "done")).toBe(true);
+  });
+
+  test("done is only reachable from running", () => {
+    for (const state of TASK_STATES) {
+      expect(canTransitionTask(state, "done")).toBe(state === "running");
+    }
+  });
+
+  test("failed and cancelled are reachable from every live state", () => {
+    for (const state of ["queued", "running", "awaiting_approval"] as const) {
+      expect(canTransitionTask(state, "failed")).toBe(true);
+      expect(canTransitionTask(state, "cancelled")).toBe(true);
+    }
+  });
+});
+
+describe("add", () => {
+  test("creates a queued task with documented defaults", () => {
+    const { store } = createHarness();
+    const task = addTask(store);
+
+    expect(task).toMatchObject({
+      id: "task_1",
+      workspaceId: "w1",
+      state: "queued",
+      goal: "Ship the thing",
+      agent: null,
+      model: null,
+      approvalPolicy: "auto",
+      timeoutMs: null,
+      sessionId: null,
+      engineId: null,
+      summary: "",
+      artifacts: [],
+      pendingPermissions: [],
+      error: null,
+      cancelReason: null,
+      startedAt: null,
+      completedAt: null,
+    });
+    expect(store.size).toBe(1);
+  });
+
+  test("trims the goal and rejects an empty one", () => {
+    const { store } = createHarness();
+    expect(store.add({ workspaceId: "w1", goal: "  hello  " }).goal).toBe("hello");
+    expect(() => store.add({ workspaceId: "w1", goal: "   " })).toThrow(/must not be empty/);
+  });
+
+  test("rejects a duplicate id", () => {
+    const { store } = createHarness();
+    store.add({ workspaceId: "w1", goal: "a", id: "fixed" });
+    try {
+      store.add({ workspaceId: "w1", goal: "b", id: "fixed" });
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { code: string }).code).toBe("task_duplicate");
+    }
+  });
+
+  test("copies metadata rather than aliasing the caller's object", () => {
+    const { store } = createHarness();
+    const metadata = { run: 1 };
+    const task = store.add({ workspaceId: "w1", goal: "a", metadata });
+    metadata.run = 2;
+    expect(task.metadata).toEqual({ run: 1 });
+  });
+});
+
+describe("update transitions", () => {
+  test("accepts every legal transition", () => {
+    for (const from of TASK_STATES) {
+      for (const to of TASK_TRANSITIONS[from]) {
+        const { store } = createHarness();
+        const task = taskInState(store, from);
+        expect(store.update(task.id, { state: to }).state).toBe(to);
+      }
+    }
+  });
+
+  test("rejects every illegal transition", () => {
+    for (const from of TASK_STATES) {
+      for (const to of TASK_STATES) {
+        if (from === to || TASK_TRANSITIONS[from].includes(to)) continue;
+        const { store } = createHarness();
+        const task = taskInState(store, from);
+        try {
+          store.update(task.id, { state: to });
+          throw new Error(`expected ${from} -> ${to} to be rejected`);
+        } catch (error) {
+          expect(isApiError(error)).toBe(true);
+          expect((error as { code: string; status: number }).code).toBe("task_invalid_transition");
+          expect((error as { status: number }).status).toBe(409);
+        }
+        // The rejected transition must not have been partially applied.
+        expect(store.require(task.id).state).toBe(from);
+      }
+    }
+  });
+
+  test("a same-state write is not a transition", () => {
+    const { store } = createHarness();
+    const task = taskInState(store, "done");
+    expect(store.update(task.id, { state: "done", summary: "final" }).summary).toBe("final");
+  });
+
+  test("stamps completedAt when a task becomes terminal", () => {
+    const harness = createHarness();
+    const task = taskInState(harness.store, "running");
+    expect(task.completedAt).toBeNull();
+    harness.tick(50);
+    const done = harness.store.update(task.id, { state: "done" });
+    expect(done.completedAt).toBe(harness.clock);
+  });
+
+  test("non-state fields stay writable after a task finished", () => {
+    const { store } = createHarness();
+    const task = taskInState(store, "cancelled");
+    const updated = store.update(task.id, { summary: "partial output", sessionId: "s1" });
+    expect(updated.state).toBe("cancelled");
+    expect(updated.summary).toBe("partial output");
+    expect(updated.sessionId).toBe("s1");
+  });
+
+  test("update returns a new record rather than mutating the old one", () => {
+    const { store } = createHarness();
+    const task = addTask(store);
+    const running = store.update(task.id, { state: "running" });
+    expect(task.state).toBe("queued");
+    expect(running).not.toBe(task);
+  });
+
+  test("throws 404 for an unknown task", () => {
+    const { store } = createHarness();
+    try {
+      store.update("nope", { state: "running" });
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { status: number; code: string }).status).toBe(404);
+      expect((error as { code: string }).code).toBe("task_not_found");
+    }
+  });
+});
+
+describe("cancel", () => {
+  test("cancels from every live state and records a reason", () => {
+    for (const state of ["queued", "running", "awaiting_approval"] as const) {
+      const { store } = createHarness();
+      const task = taskInState(store, state);
+      const cancelled = store.cancel(task.id, " user asked ");
+      expect(cancelled.state).toBe("cancelled");
+      expect(cancelled.cancelReason).toBe("user asked");
+      expect(cancelled.pendingPermissions).toEqual([]);
+    }
+  });
+
+  test("defaults the reason", () => {
+    const { store } = createHarness();
+    expect(store.cancel(addTask(store).id).cancelReason).toBe("Cancelled by request");
+  });
+
+  test("refuses an already-terminal task with 409", () => {
+    for (const state of TERMINAL_TASK_STATES) {
+      const { store } = createHarness();
+      const task = taskInState(store, state);
+      try {
+        store.cancel(task.id);
+        throw new Error(`expected cancel of ${state} to be rejected`);
+      } catch (error) {
+        expect((error as { code: string }).code).toBe("task_not_cancellable");
+        expect((error as { status: number }).status).toBe(409);
+      }
+    }
+  });
+});
+
+describe("require", () => {
+  test("scopes by workspace so ids from another workspace read as missing", () => {
+    const { store } = createHarness();
+    const task = addTask(store, { workspaceId: "w1" });
+    expect(store.require(task.id, "w1").id).toBe(task.id);
+    try {
+      store.require(task.id, "w2");
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect((error as { status: number; code: string }).status).toBe(404);
+      expect((error as { code: string }).code).toBe("task_not_found");
+    }
+  });
+});
+
+describe("list", () => {
+  test("filters by workspace and returns newest first", () => {
+    const harness = createHarness();
+    const a = addTask(harness.store, { workspaceId: "w1", goal: "a" });
+    harness.tick(10);
+    const b = addTask(harness.store, { workspaceId: "w1", goal: "b" });
+    harness.tick(10);
+    const other = addTask(harness.store, { workspaceId: "w2", goal: "c" });
+
+    expect(harness.store.list({ workspaceId: "w1" }).map((task) => task.id)).toEqual([b.id, a.id]);
+    expect(harness.store.list({ workspaceId: "w2" }).map((task) => task.id)).toEqual([other.id]);
+    expect(harness.store.list().length).toBe(3);
+  });
+
+  test("filters by a single state and by a list of states", () => {
+    const { store } = createHarness();
+    const queued = taskInState(store, "queued");
+    const running = taskInState(store, "running");
+    const done = taskInState(store, "done");
+
+    expect(store.list({ state: "running" }).map((task) => task.id)).toEqual([running.id]);
+    expect(new Set(store.list({ state: ["queued", "done"] }).map((task) => task.id)))
+      .toEqual(new Set([queued.id, done.id]));
+    expect(store.list({ state: "failed" })).toEqual([]);
+  });
+
+  test("applies and clamps the limit", () => {
+    const harness = createHarness();
+    for (let index = 0; index < 5; index += 1) {
+      addTask(harness.store, { goal: `goal ${index}` });
+      harness.tick();
+    }
+    expect(harness.store.list({ limit: 2 })).toHaveLength(2);
+    expect(harness.store.list({ limit: 10_000 })).toHaveLength(5);
+  });
+});
+
+describe("subscribe", () => {
+  test("delivers created, state and updated events", () => {
+    const { store } = createHarness();
+    const seen: TaskEvent[] = [];
+    store.subscribe({ onEvent: (event) => seen.push(event) });
+
+    const task = addTask(store);
+    store.update(task.id, { state: "running" });
+    store.update(task.id, { summary: "half" });
+
+    expect(seen.map((event) => event.type)).toEqual(["task.created", "task.state", "task.updated"]);
+    expect(seen[1]).toMatchObject({ from: "queued", to: "running" });
+    expect(seen[2]?.task.summary).toBe("half");
+    expect(seen.map((event) => event.seq)).toEqual([1, 2, 3]);
+  });
+
+  test("unsubscribing stops delivery", () => {
+    const { store } = createHarness();
+    const seen: TaskEvent[] = [];
+    const unsubscribe = store.subscribe({ onEvent: (event) => seen.push(event) });
+    const task = addTask(store);
+    unsubscribe();
+    store.update(task.id, { state: "running" });
+    expect(seen).toHaveLength(1);
+  });
+
+  test("a taskId filter only sees that task", () => {
+    const { store } = createHarness();
+    const first = addTask(store, { goal: "first" });
+    const second = addTask(store, { goal: "second" });
+    const seen: TaskEvent[] = [];
+    store.subscribe({ taskId: second.id, onEvent: (event) => seen.push(event) });
+
+    store.update(first.id, { state: "running" });
+    store.update(second.id, { state: "running" });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.taskId).toBe(second.id);
+  });
+
+  test("after replays the buffered log before attaching", () => {
+    const { store } = createHarness();
+    const task = addTask(store);
+    store.update(task.id, { state: "running" });
+
+    const seen: TaskEvent[] = [];
+    const unsubscribe = store.subscribe({ taskId: task.id, after: 1, onEvent: (event) => seen.push(event) });
+    expect(seen.map((event) => event.seq)).toEqual([2]);
+
+    store.update(task.id, { state: "done" });
+    expect(seen.map((event) => event.seq)).toEqual([2, 3]);
+    unsubscribe();
+  });
+
+  test("a throwing subscriber does not break the store or other subscribers", () => {
+    const { store } = createHarness();
+    const seen: TaskEvent[] = [];
+    store.subscribe({
+      onEvent: () => {
+        throw new Error("subscriber exploded");
+      },
+    });
+    store.subscribe({ onEvent: (event) => seen.push(event) });
+
+    const task = addTask(store);
+    expect(() => store.update(task.id, { state: "running" })).not.toThrow();
+    expect(seen).toHaveLength(2);
+    expect(store.require(task.id).state).toBe("running");
+  });
+});
+
+describe("events", () => {
+  test("returns the whole log, or only what follows a cursor", () => {
+    const { store } = createHarness();
+    const task = addTask(store);
+    store.update(task.id, { state: "running" });
+    store.update(task.id, { state: "done" });
+
+    expect(store.events(task.id).map((event) => event.seq)).toEqual([1, 2, 3]);
+    expect(store.events(task.id, 2).map((event) => event.seq)).toEqual([3]);
+    expect(store.events(task.id, 99)).toEqual([]);
+    expect(store.events("unknown")).toEqual([]);
+  });
+
+  test("bounds the retained log per task", () => {
+    const store = createTaskStore({ maxEventsPerTask: 3 });
+    const task = store.add({ workspaceId: "w1", goal: "noisy" });
+    for (let index = 0; index < 10; index += 1) store.update(task.id, { summary: `n${index}` });
+    expect(store.events(task.id)).toHaveLength(3);
+  });
+});
+
+describe("retention", () => {
+  test("evicts the oldest terminal tasks but never a live one", () => {
+    const harness = createHarness();
+    const store = createTaskStore({ now: () => harness.clock, maxTasks: 2 });
+
+    const oldDone = store.add({ workspaceId: "w1", goal: "old" });
+    store.update(oldDone.id, { state: "running" });
+    store.update(oldDone.id, { state: "done" });
+    harness.tick(10);
+    const live = store.add({ workspaceId: "w1", goal: "live" });
+    store.update(live.id, { state: "running" });
+    harness.tick(10);
+    const newDone = store.add({ workspaceId: "w1", goal: "new" });
+    store.update(newDone.id, { state: "failed" });
+
+    expect(store.size).toBe(2);
+    expect(store.get(oldDone.id)).toBeUndefined();
+    expect(store.get(live.id)?.state).toBe("running");
+    expect(store.get(newDone.id)?.state).toBe("failed");
+  });
+});

--- a/apps/server/src/api/modules/tasks/store.ts
+++ b/apps/server/src/api/modules/tasks/store.ts
@@ -1,0 +1,455 @@
+/**
+ * In-memory task store.
+ *
+ * A task is the one-shot automation wrapper over a session: submit a goal, get a
+ * terminal state plus whatever artifacts the run produced. This file owns the task
+ * *state* only — it never talks HTTP and never touches an engine, so the whole state
+ * machine is unit-testable without a server or a live agent.
+ *
+ * ## Durability
+ *
+ * There is none. Records live in a `Map` inside the server process and are gone on
+ * restart, on crash, and on a second server instance. That is deliberate for the
+ * preview stability of the `tasks` module, but it is not hidden: `createTaskStore`
+ * has no persistence hook to forget to wire up, the module description says so, and
+ * the `createTask` response schema says so. A caller that needs a task to survive a
+ * restart must poll and re-submit, or use the session APIs directly.
+ *
+ * ## State machine
+ *
+ *   queued -> running -> (awaiting_approval <-> running) -> done | failed | cancelled
+ *
+ * `failed` and `cancelled` are also reachable from `queued` and `awaiting_approval`,
+ * because a task can die before it ever starts (engine unreachable) or while it is
+ * parked on a manual approval. `done` is only reachable from `running`: a task that
+ * finished must have been running when it finished. The three terminal states accept
+ * no further transition, and an illegal one throws rather than being coerced — a
+ * silent coercion here would make the reported state a lie.
+ */
+
+import { ApiError } from "../../../errors.js";
+
+export const TASK_STATES = [
+  "queued",
+  "running",
+  "awaiting_approval",
+  "done",
+  "failed",
+  "cancelled",
+] as const;
+
+export type TaskState = (typeof TASK_STATES)[number];
+
+export const TERMINAL_TASK_STATES: readonly TaskState[] = ["done", "failed", "cancelled"];
+
+/** The single source of truth for the state machine. */
+export const TASK_TRANSITIONS: Readonly<Record<TaskState, readonly TaskState[]>> = {
+  queued: ["running", "failed", "cancelled"],
+  running: ["awaiting_approval", "done", "failed", "cancelled"],
+  awaiting_approval: ["running", "failed", "cancelled"],
+  done: [],
+  failed: [],
+  cancelled: [],
+};
+
+export function isTerminalTaskState(state: TaskState): boolean {
+  return TERMINAL_TASK_STATES.includes(state);
+}
+
+export function canTransitionTask(from: TaskState, to: TaskState): boolean {
+  return TASK_TRANSITIONS[from].includes(to);
+}
+
+export type TaskApprovalPolicy = "auto" | "manual";
+
+export interface TaskModelRef {
+  providerID: string;
+  modelID: string;
+}
+
+export interface TaskError {
+  code: string;
+  message: string;
+}
+
+/**
+ * A permission the engine asked for that nobody has answered yet.
+ *
+ * Only populated under `approvalPolicy: "manual"`. The task deliberately does not
+ * expose its own approve endpoint: the permission is a *session* permission, and the
+ * sessions module already owns replying to one. This record carries the session id
+ * and permission id a caller needs to answer it there.
+ */
+export interface TaskPendingPermission {
+  permissionId: string;
+  sessionId: string;
+  /** Engine-specific permission kind, normally the tool name. */
+  kind: string;
+  resources: string[];
+  askedAt: number;
+}
+
+export interface TaskArtifact {
+  id: string;
+  /** `file` when the run wrote a path; `output` for any other recorded tool result. */
+  kind: "file" | "output";
+  tool: string;
+  path?: string;
+  createdAt: number;
+}
+
+export interface TaskRecord {
+  id: string;
+  workspaceId: string;
+  state: TaskState;
+  goal: string;
+  agent: string | null;
+  model: TaskModelRef | null;
+  approvalPolicy: TaskApprovalPolicy;
+  timeoutMs: number | null;
+  metadata: Record<string, unknown>;
+  /** The session the runner created for this task, once it exists. */
+  sessionId: string | null;
+  engineId: string | null;
+  /** Assistant text collected from the run, truncated to a bounded length. */
+  summary: string;
+  artifacts: TaskArtifact[];
+  pendingPermissions: TaskPendingPermission[];
+  error: TaskError | null;
+  cancelReason: string | null;
+  createdAt: number;
+  updatedAt: number;
+  startedAt: number | null;
+  completedAt: number | null;
+}
+
+export interface TaskCreateInput {
+  workspaceId: string;
+  goal: string;
+  agent?: string | null;
+  model?: TaskModelRef | null;
+  approvalPolicy?: TaskApprovalPolicy;
+  timeoutMs?: number | null;
+  metadata?: Record<string, unknown>;
+  /** Explicit id, mostly for deterministic tests. */
+  id?: string;
+}
+
+/**
+ * A partial write. Only `state` is validated against the state machine; every other
+ * field is a plain overwrite, so a finished run can still record the summary and
+ * artifacts it produced before it was cancelled.
+ */
+export interface TaskUpdate {
+  state?: TaskState;
+  sessionId?: string | null;
+  engineId?: string | null;
+  summary?: string;
+  artifacts?: TaskArtifact[];
+  pendingPermissions?: TaskPendingPermission[];
+  error?: TaskError | null;
+  cancelReason?: string | null;
+  metadata?: Record<string, unknown>;
+  startedAt?: number | null;
+  completedAt?: number | null;
+}
+
+export type TaskEventType = "task.created" | "task.state" | "task.updated";
+
+/**
+ * One entry on a task's event log.
+ *
+ * Every event carries the full task snapshot rather than a delta: a client that
+ * reconnects mid-run gets the current truth from the next frame without a second
+ * round trip, and a dropped frame cannot leave the client's copy skewed. `seq` is
+ * store-global and monotonic, and is what `?after=` resumes from.
+ */
+export interface TaskEvent {
+  seq: number;
+  at: number;
+  taskId: string;
+  type: TaskEventType;
+  task: TaskRecord;
+  /** Present on `task.state`. */
+  from?: TaskState;
+  /** Present on `task.state`. */
+  to?: TaskState;
+}
+
+export interface TaskListFilter {
+  workspaceId?: string;
+  state?: TaskState | readonly TaskState[];
+  /** Defaults to 50, clamped to `maxListLimit` (200). */
+  limit?: number;
+}
+
+export interface TaskSubscribeInput {
+  /** Restricts the subscription to one task. Omit to receive every task's events. */
+  taskId?: string;
+  /** Replays buffered events with `seq > after` before attaching the listener. */
+  after?: number;
+  onEvent: (event: TaskEvent) => void;
+}
+
+export interface TaskStoreOptions {
+  now?: () => number;
+  newId?: () => string;
+  /**
+   * Upper bound on retained tasks. Once exceeded, the oldest *terminal* tasks are
+   * dropped; a live task is never evicted. Defaults to 500.
+   */
+  maxTasks?: number;
+  /** Retained events per task, oldest dropped first. Defaults to 500. */
+  maxEventsPerTask?: number;
+}
+
+export interface TaskStore {
+  add(input: TaskCreateInput): TaskRecord;
+  get(taskId: string): TaskRecord | undefined;
+  /** Like `get`, but throws `404 task_not_found`. */
+  require(taskId: string, workspaceId?: string): TaskRecord;
+  list(filter?: TaskListFilter): TaskRecord[];
+  update(taskId: string, patch: TaskUpdate): TaskRecord;
+  /** Terminal shortcut for `update({state: "cancelled"})`, with a friendlier error. */
+  cancel(taskId: string, reason?: string): TaskRecord;
+  /** Buffered events with `seq > after`, oldest first. */
+  events(taskId: string, after?: number): TaskEvent[];
+  subscribe(input: TaskSubscribeInput): () => void;
+  /** Number of retained tasks. */
+  readonly size: number;
+  clear(): void;
+}
+
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 200;
+
+export function createTaskStore(options: TaskStoreOptions = {}): TaskStore {
+  const now = options.now ?? (() => Date.now());
+  const newId = options.newId ?? defaultTaskId;
+  const maxTasks = Math.max(1, options.maxTasks ?? 500);
+  const maxEventsPerTask = Math.max(1, options.maxEventsPerTask ?? 500);
+
+  const tasks = new Map<string, TaskRecord>();
+  const log = new Map<string, TaskEvent[]>();
+  const listeners = new Set<TaskSubscribeInput>();
+  let seq = 0;
+
+  const publish = (
+    task: TaskRecord,
+    type: TaskEventType,
+    transition?: { from: TaskState; to: TaskState },
+  ): TaskEvent => {
+    seq += 1;
+    const event: TaskEvent = {
+      seq,
+      at: task.updatedAt,
+      taskId: task.id,
+      type,
+      task,
+      ...(transition ?? {}),
+    };
+    const buffer = log.get(task.id);
+    if (buffer) {
+      buffer.push(event);
+      if (buffer.length > maxEventsPerTask) buffer.splice(0, buffer.length - maxEventsPerTask);
+    }
+    for (const listener of [...listeners]) {
+      if (listener.taskId && listener.taskId !== task.id) continue;
+      // One misbehaving subscriber must not abort the state change for everyone
+      // else, and must not leave the store half-updated.
+      try {
+        listener.onEvent(event);
+      } catch {
+        // Ignored on purpose.
+      }
+    }
+    return event;
+  };
+
+  /** Drops the oldest terminal tasks once the retention bound is exceeded. */
+  const evict = (): void => {
+    if (tasks.size <= maxTasks) return;
+    const evictable = [...tasks.values()]
+      .filter((task) => isTerminalTaskState(task.state))
+      .sort((left, right) => left.updatedAt - right.updatedAt);
+    let overflow = tasks.size - maxTasks;
+    for (const task of evictable) {
+      if (overflow <= 0) break;
+      tasks.delete(task.id);
+      log.delete(task.id);
+      overflow -= 1;
+    }
+  };
+
+  return {
+    add(input) {
+      const goal = input.goal.trim();
+      if (!goal) {
+        throw new ApiError(400, "task_goal_required", "Task goal must not be empty");
+      }
+      const id = input.id?.trim() || newId();
+      if (tasks.has(id)) {
+        throw new ApiError(409, "task_duplicate", `Task already exists: ${id}`, { taskId: id });
+      }
+      const at = now();
+      const task: TaskRecord = Object.freeze({
+        id,
+        workspaceId: input.workspaceId,
+        state: "queued",
+        goal,
+        agent: input.agent?.trim() || null,
+        model: input.model ?? null,
+        approvalPolicy: input.approvalPolicy ?? "auto",
+        timeoutMs: input.timeoutMs ?? null,
+        metadata: { ...(input.metadata ?? {}) },
+        sessionId: null,
+        engineId: null,
+        summary: "",
+        artifacts: [],
+        pendingPermissions: [],
+        error: null,
+        cancelReason: null,
+        createdAt: at,
+        updatedAt: at,
+        startedAt: null,
+        completedAt: null,
+      });
+      tasks.set(id, task);
+      log.set(id, []);
+      evict();
+      publish(task, "task.created");
+      return task;
+    },
+
+    get(taskId) {
+      return tasks.get(taskId);
+    },
+
+    require(taskId, workspaceId) {
+      const task = tasks.get(taskId);
+      // A task from another workspace is reported as missing rather than as
+      // forbidden, so the endpoint cannot be used to probe for task ids.
+      if (!task || (workspaceId !== undefined && task.workspaceId !== workspaceId)) {
+        throw new ApiError(404, "task_not_found", `Task not found: ${taskId}`, { taskId });
+      }
+      return task;
+    },
+
+    list(filter = {}) {
+      const states = filter.state === undefined
+        ? null
+        : new Set(Array.isArray(filter.state) ? filter.state : [filter.state as TaskState]);
+      const limit = Math.min(Math.max(1, filter.limit ?? DEFAULT_LIST_LIMIT), MAX_LIST_LIMIT);
+      return [...tasks.values()]
+        .filter((task) => filter.workspaceId === undefined || task.workspaceId === filter.workspaceId)
+        .filter((task) => states === null || states.has(task.state))
+        .sort((left, right) => right.createdAt - left.createdAt || right.updatedAt - left.updatedAt)
+        .slice(0, limit);
+    },
+
+    update(taskId, patch) {
+      const current = this.require(taskId);
+      const at = now();
+      const nextState = patch.state ?? current.state;
+
+      if (patch.state !== undefined && patch.state !== current.state) {
+        if (!canTransitionTask(current.state, patch.state)) {
+          throw new ApiError(
+            409,
+            "task_invalid_transition",
+            `Task ${taskId} cannot move from ${current.state} to ${patch.state}`,
+            {
+              taskId,
+              from: current.state,
+              to: patch.state,
+              allowed: TASK_TRANSITIONS[current.state],
+            },
+          );
+        }
+      }
+
+      const becameTerminal = nextState !== current.state && isTerminalTaskState(nextState);
+      const next: TaskRecord = Object.freeze({
+        ...current,
+        ...(patch.state !== undefined ? { state: patch.state } : {}),
+        ...(patch.sessionId !== undefined ? { sessionId: patch.sessionId } : {}),
+        ...(patch.engineId !== undefined ? { engineId: patch.engineId } : {}),
+        ...(patch.summary !== undefined ? { summary: patch.summary } : {}),
+        ...(patch.artifacts !== undefined ? { artifacts: [...patch.artifacts] } : {}),
+        ...(patch.pendingPermissions !== undefined
+          ? { pendingPermissions: [...patch.pendingPermissions] }
+          : {}),
+        ...(patch.error !== undefined ? { error: patch.error } : {}),
+        ...(patch.cancelReason !== undefined ? { cancelReason: patch.cancelReason } : {}),
+        ...(patch.metadata !== undefined ? { metadata: { ...patch.metadata } } : {}),
+        ...(patch.startedAt !== undefined ? { startedAt: patch.startedAt } : {}),
+        completedAt: patch.completedAt !== undefined
+          ? patch.completedAt
+          : becameTerminal
+            ? at
+            : current.completedAt,
+        updatedAt: at,
+      });
+
+      tasks.set(taskId, next);
+      publish(
+        next,
+        patch.state !== undefined && patch.state !== current.state ? "task.state" : "task.updated",
+        patch.state !== undefined && patch.state !== current.state
+          ? { from: current.state, to: patch.state }
+          : undefined,
+      );
+      if (becameTerminal) evict();
+      return next;
+    },
+
+    cancel(taskId, reason) {
+      const current = this.require(taskId);
+      if (isTerminalTaskState(current.state)) {
+        throw new ApiError(
+          409,
+          "task_not_cancellable",
+          `Task ${taskId} already finished in state ${current.state}`,
+          { taskId, state: current.state },
+        );
+      }
+      return this.update(taskId, {
+        state: "cancelled",
+        cancelReason: reason?.trim() || "Cancelled by request",
+        pendingPermissions: [],
+      });
+    },
+
+    events(taskId, after) {
+      const buffer = log.get(taskId) ?? [];
+      if (after === undefined) return [...buffer];
+      return buffer.filter((event) => event.seq > after);
+    },
+
+    subscribe(input) {
+      if (input.after !== undefined) {
+        const replay = input.taskId
+          ? this.events(input.taskId, input.after)
+          : [...log.values()].flat().filter((event) => event.seq > (input.after ?? 0)).sort((a, b) => a.seq - b.seq);
+        for (const event of replay) input.onEvent(event);
+      }
+      listeners.add(input);
+      return () => {
+        listeners.delete(input);
+      };
+    },
+
+    get size() {
+      return tasks.size;
+    },
+
+    clear() {
+      tasks.clear();
+      log.clear();
+    },
+  };
+}
+
+function defaultTaskId(): string {
+  return `task_${crypto.randomUUID().replace(/-/g, "")}`;
+}

--- a/apps/server/src/api/modules/webhooks/delivery.test.ts
+++ b/apps/server/src/api/modules/webhooks/delivery.test.ts
@@ -1,0 +1,693 @@
+import { createHmac } from "node:crypto";
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildDeliveryHeaders,
+  buildWebhookEnvelope,
+  deliverWebhook,
+  formatSignatureHeader,
+  isPrivateAddress,
+  isRetryableStatus,
+  nextRetryDelay,
+  parseHostAddress,
+  parseIPv4Loose,
+  parseIPv6,
+  parseSignatureHeader,
+  retryBaseDelay,
+  retryDelayBounds,
+  signWebhookPayload,
+  validateWebhookUrl,
+  verifyWebhookSignature,
+  webhookPrivateNetworkAllowed,
+  WEBHOOK_DELIVERY_HEADER,
+  WEBHOOK_EVENT_HEADER,
+  WEBHOOK_MAX_ATTEMPTS,
+  WEBHOOK_SIGNATURE_HEADER,
+  WEBHOOK_TIMESTAMP_HEADER,
+  WEBHOOK_URL_MAX_LENGTH,
+} from "./delivery.js";
+
+/* -------------------------------------------------------------------------- */
+/* Signing                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const SECRET = "whsec_test_secret";
+const BODY = JSON.stringify({ id: "evt_1", type: "task.created" });
+
+describe("signWebhookPayload", () => {
+  test("matches known vectors", () => {
+    expect(signWebhookPayload(SECRET, BODY, 1700000000))
+      .toBe("9c2f3b2f113eb39ef7e2df861efff0663645d7334d81d8997777b6645360c976");
+    expect(signWebhookPayload(SECRET, "", 0))
+      .toBe("e359a4b07054a77815d22548b11f4936e8b16e4160347fcbc7fbeac890d07c42");
+    expect(signWebhookPayload(SECRET, "{}", 1735689600))
+      .toBe("5e4324d9a545f78e160b07f1c6d30e488e7c0e72b215d0bebccd42ef80422b09");
+  });
+
+  test("signs exactly `${timestamp}.${body}`", () => {
+    // Spelled out literally, independent of the implementation's template literal, so a
+    // change to the signed material (separator, order, encoding) fails here.
+    const expected = createHmac("sha256", SECRET)
+      .update('1700000000.{"id":"evt_1","type":"task.created"}', "utf8")
+      .digest("hex");
+    expect(signWebhookPayload(SECRET, BODY, 1700000000)).toBe(expected);
+  });
+
+  test("a one second timestamp change produces a different signature", () => {
+    expect(signWebhookPayload(SECRET, BODY, 1700000001))
+      .toBe("f55885b5fdb22257ebc7c34ac5ef802210dfa9691dbd48032ab1a6aac1c47d2e");
+    expect(signWebhookPayload(SECRET, BODY, 1700000001)).not.toBe(signWebhookPayload(SECRET, BODY, 1700000000));
+  });
+
+  test("a different secret produces a different signature", () => {
+    expect(signWebhookPayload("another_secret", BODY, 1700000000))
+      .toBe("f21043bee06c3d8dba925b9b065310187e5b3a66ebec96303a4000f519b278ec");
+  });
+
+  test("a numeric and string timestamp are the same input", () => {
+    expect(signWebhookPayload(SECRET, BODY, "1700000000")).toBe(signWebhookPayload(SECRET, BODY, 1700000000));
+  });
+
+  test("output is 64 hex characters", () => {
+    expect(signWebhookPayload(SECRET, BODY, 1700000000)).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("signature header", () => {
+  test("formats as t=<ts>,v1=<hex>", () => {
+    expect(formatSignatureHeader(1700000000, "abc")).toBe("t=1700000000,v1=abc");
+  });
+
+  test("round-trips through the parser", () => {
+    const header = formatSignatureHeader(1700000000, signWebhookPayload(SECRET, BODY, 1700000000));
+    expect(parseSignatureHeader(header)).toEqual({
+      timestamp: "1700000000",
+      signatures: ["9c2f3b2f113eb39ef7e2df861efff0663645d7334d81d8997777b6645360c976"],
+    });
+  });
+
+  test("accepts multiple v1 values and tolerates whitespace", () => {
+    expect(parseSignatureHeader("t=1, v1=aa, v1=bb")).toEqual({ timestamp: "1", signatures: ["aa", "bb"] });
+  });
+
+  test("rejects a header with no timestamp or no signature", () => {
+    expect(parseSignatureHeader("v1=aa")).toBeNull();
+    expect(parseSignatureHeader("t=1")).toBeNull();
+    expect(parseSignatureHeader("")).toBeNull();
+  });
+});
+
+describe("verifyWebhookSignature", () => {
+  const now = () => 1700000000_000;
+  const header = formatSignatureHeader(1700000000, signWebhookPayload(SECRET, BODY, 1700000000));
+
+  test("accepts a genuine signature", () => {
+    expect(verifyWebhookSignature(SECRET, BODY, header, { now })).toBe(true);
+  });
+
+  test("rejects a tampered body", () => {
+    expect(verifyWebhookSignature(SECRET, `${BODY} `, header, { now })).toBe(false);
+  });
+
+  test("rejects the wrong secret", () => {
+    expect(verifyWebhookSignature("nope_nope_nope_16", BODY, header, { now })).toBe(false);
+  });
+
+  test("rejects a replay outside the tolerance window", () => {
+    const late = () => 1700000000_000 + 3600_000;
+    expect(verifyWebhookSignature(SECRET, BODY, header, { now: late })).toBe(false);
+    expect(verifyWebhookSignature(SECRET, BODY, header, { now: late, toleranceSeconds: 7200 })).toBe(true);
+  });
+
+  test("rejects a signature moved to a different timestamp", () => {
+    const forged = formatSignatureHeader(
+      1700000001,
+      signWebhookPayload(SECRET, BODY, 1700000000),
+    );
+    expect(verifyWebhookSignature(SECRET, BODY, forged, { now })).toBe(false);
+  });
+
+  test("a truncated signature does not throw on the constant-time compare", () => {
+    expect(verifyWebhookSignature(SECRET, BODY, "t=1700000000,v1=9c2f", { now })).toBe(false);
+  });
+});
+
+describe("buildDeliveryHeaders", () => {
+  const headers = buildDeliveryHeaders({
+    event: "task.created",
+    deliveryId: "d-1",
+    body: BODY,
+    secret: SECRET,
+    timestampSeconds: 1700000000,
+  });
+
+  test("carries event, delivery id and timestamp", () => {
+    expect(headers[WEBHOOK_EVENT_HEADER]).toBe("task.created");
+    expect(headers[WEBHOOK_DELIVERY_HEADER]).toBe("d-1");
+    expect(headers[WEBHOOK_TIMESTAMP_HEADER]).toBe("1700000000");
+    expect(headers["content-type"]).toBe("application/json");
+  });
+
+  test("carries a verifiable signature", () => {
+    expect(headers[WEBHOOK_SIGNATURE_HEADER])
+      .toBe("t=1700000000,v1=9c2f3b2f113eb39ef7e2df861efff0663645d7334d81d8997777b6645360c976");
+    expect(verifyWebhookSignature(SECRET, BODY, headers[WEBHOOK_SIGNATURE_HEADER] ?? "", {
+      now: () => 1700000000_000,
+    })).toBe(true);
+  });
+
+  test("omits the signature when there is no secret", () => {
+    const unsigned = buildDeliveryHeaders({
+      event: "task.created",
+      deliveryId: "d-1",
+      body: BODY,
+      timestampSeconds: 1700000000,
+    });
+    expect(unsigned[WEBHOOK_SIGNATURE_HEADER]).toBeUndefined();
+  });
+});
+
+describe("buildWebhookEnvelope", () => {
+  test("carries the delivery id, type and data", () => {
+    expect(buildWebhookEnvelope({
+      deliveryId: "d-1",
+      event: "task.created",
+      data: { taskId: "t1" },
+      workspaceId: "w1",
+      webhookId: "h1",
+      timestamp: 1700000000_000,
+    })).toEqual({
+      id: "d-1",
+      type: "task.created",
+      createdAt: 1700000000_000,
+      workspaceId: "w1",
+      webhookId: "h1",
+      data: { taskId: "t1" },
+    });
+  });
+
+  test("omits optional ids and normalizes missing data to null", () => {
+    expect(buildWebhookEnvelope({ deliveryId: "d", event: "e", data: undefined, timestamp: 1 }))
+      .toEqual({ id: "d", type: "e", createdAt: 1, data: null });
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* SSRF                                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("validateWebhookUrl", () => {
+  const blocked: Array<[string, string]> = [
+    // Scheme
+    ["file:///etc/passwd", "unsupported_scheme"],
+    ["javascript:alert(1)", "unsupported_scheme"],
+    ["ftp://example.com/hook", "unsupported_scheme"],
+    ["gopher://example.com:70/_", "unsupported_scheme"],
+    // Malformed
+    ["", "missing_url"],
+    ["   ", "missing_url"],
+    ["not a url", "invalid_url"],
+    ["https://", "invalid_url"],
+    // Userinfo smuggling: the host a human reads is not the host we would connect to.
+    ["http://evil@127.0.0.1/hook", "userinfo_not_allowed"],
+    ["https://hooks.example.com@127.0.0.1/hook", "userinfo_not_allowed"],
+    ["http://user:pass@example.com/hook", "userinfo_not_allowed"],
+    // Loopback, in every encoding a resolver accepts.
+    ["http://127.0.0.1/hook", "private_address"],
+    ["http://127.0.0.1:9999/hook", "private_address"],
+    ["http://127.1/hook", "private_address"],
+    ["http://0x7f.1/hook", "private_address"],
+    ["http://0x7f000001/hook", "private_address"],
+    ["http://2130706433/hook", "private_address"],
+    ["http://0177.0.0.1/hook", "private_address"],
+    ["http://127.0.0.254/hook", "private_address"],
+    // Named loopback.
+    ["http://localhost/hook", "blocked_hostname"],
+    ["http://localhost:4096/hook", "blocked_hostname"],
+    ["http://LOCALHOST./hook", "blocked_hostname"],
+    ["http://api.localhost/hook", "blocked_hostname"],
+    ["http://printer.local/hook", "blocked_hostname"],
+    ["http://svc.internal/hook", "blocked_hostname"],
+    // IPv6 loopback and its equivalents.
+    ["http://[::1]/hook", "private_address"],
+    ["http://[0:0:0:0:0:0:0:1]/hook", "private_address"],
+    ["http://[::ffff:127.0.0.1]/hook", "private_address"],
+    ["http://[::ffff:7f00:1]/hook", "private_address"],
+    ["http://[::]/hook", "private_address"],
+    ["http://[2002:7f00:1::]/hook", "private_address"],
+    ["http://[64:ff9b::7f00:1]/hook", "private_address"],
+    // IPv6 private / link-local / multicast.
+    ["http://[fd00::1]/hook", "private_address"],
+    ["http://[fc00::1]/hook", "private_address"],
+    ["http://[fe80::1]/hook", "private_address"],
+    ["http://[ff02::1]/hook", "private_address"],
+    // RFC1918 and friends.
+    ["http://10.0.0.1/hook", "private_address"],
+    ["http://10.255.255.255/hook", "private_address"],
+    ["http://172.16.0.1/hook", "private_address"],
+    ["http://172.31.255.255/hook", "private_address"],
+    ["http://192.168.1.1/hook", "private_address"],
+    ["http://100.64.0.1/hook", "private_address"],
+    // Cloud metadata — the single highest-value SSRF target.
+    ["http://169.254.169.254/latest/meta-data/iam/security-credentials/", "private_address"],
+    ["http://169.254.170.2/v2/credentials", "private_address"],
+    // 0.0.0.0 is a loopback alias on Linux.
+    ["http://0.0.0.0/hook", "private_address"],
+    ["http://0/hook", "private_address"],
+    // Multicast / reserved / broadcast.
+    ["http://224.0.0.1/hook", "private_address"],
+    ["http://255.255.255.255/hook", "private_address"],
+  ];
+
+  for (const [url, reason] of blocked) {
+    test(`rejects ${JSON.stringify(url)} (${reason})`, () => {
+      expect(validateWebhookUrl(url)).toEqual({ ok: false, reason });
+    });
+  }
+
+  const allowed = [
+    "https://hooks.example.com/ingest",
+    "http://hooks.example.com:8080/ingest",
+    "https://example.com./ingest",
+    "https://8.8.8.8/ingest",
+    "https://11.0.0.1/ingest",
+    // Boundaries either side of 172.16.0.0/12.
+    "https://172.15.255.255/ingest",
+    "https://172.32.0.1/ingest",
+    // Boundaries either side of 100.64.0.0/10.
+    "https://100.63.255.255/ingest",
+    "https://100.128.0.1/ingest",
+    "https://[2606:4700:4700::1111]/ingest",
+    "https://xn--r8jz45g.jp/ingest",
+    "https://例え.jp/ingest",
+    "https://hooks.example.com/ingest?token=abc#frag",
+  ];
+
+  for (const url of allowed) {
+    test(`allows ${JSON.stringify(url)}`, () => {
+      expect(validateWebhookUrl(url)).toEqual({ ok: true });
+    });
+  }
+
+  test("rejects a url past the length cap before parsing", () => {
+    const url = `https://example.com/${"a".repeat(WEBHOOK_URL_MAX_LENGTH)}`;
+    expect(validateWebhookUrl(url)).toEqual({ ok: false, reason: "url_too_long" });
+  });
+
+  test("allowPrivate opens loopback for local development", () => {
+    expect(validateWebhookUrl("http://127.0.0.1:3000/hook", { allowPrivate: true })).toEqual({ ok: true });
+    expect(validateWebhookUrl("http://localhost:3000/hook", { allowPrivate: true })).toEqual({ ok: true });
+    expect(validateWebhookUrl("http://[::1]:3000/hook", { allowPrivate: true })).toEqual({ ok: true });
+  });
+
+  test("allowPrivate does not open non-http schemes or userinfo", () => {
+    expect(validateWebhookUrl("file:///etc/passwd", { allowPrivate: true }))
+      .toEqual({ ok: false, reason: "unsupported_scheme" });
+    expect(validateWebhookUrl("http://evil@127.0.0.1/", { allowPrivate: true }))
+      .toEqual({ ok: false, reason: "userinfo_not_allowed" });
+  });
+
+  test("a public hostname passes even though it could still rebind to a private address", () => {
+    // Documents the known gap: this check is on the URL, not on the resolved address.
+    expect(validateWebhookUrl("https://rebind.example.com/hook")).toEqual({ ok: true });
+  });
+});
+
+describe("webhookPrivateNetworkAllowed", () => {
+  test("is opt-in and exact", () => {
+    expect(webhookPrivateNetworkAllowed({})).toBe(false);
+    expect(webhookPrivateNetworkAllowed({ IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE: "0" })).toBe(false);
+    expect(webhookPrivateNetworkAllowed({ IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE: "true" })).toBe(false);
+    expect(webhookPrivateNetworkAllowed({ IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE: "1" })).toBe(true);
+    expect(webhookPrivateNetworkAllowed({ IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE: " 1 " })).toBe(true);
+  });
+});
+
+describe("parseIPv4Loose", () => {
+  test("accepts every inet_aton form of 127.0.0.1", () => {
+    for (const form of ["127.0.0.1", "127.1", "0x7f.1", "0x7f000001", "2130706433", "0177.0.0.1"]) {
+      expect(parseIPv4Loose(form)).toEqual([127, 0, 0, 1]);
+    }
+  });
+
+  test("rejects out-of-range and over-long forms", () => {
+    expect(parseIPv4Loose("256.1.1.1")).toBeNull();
+    expect(parseIPv4Loose("1.2.3.256")).toBeNull();
+    expect(parseIPv4Loose("1.2.3.4.5")).toBeNull();
+    expect(parseIPv4Loose("0900.1.1.1")).toBeNull();
+    expect(parseIPv4Loose("")).toBeNull();
+  });
+
+  test("rejects hostnames", () => {
+    expect(parseIPv4Loose("example.com")).toBeNull();
+    expect(parseIPv4Loose("beef.cafe")).toBeNull();
+    expect(parseIPv4Loose("0xdead.0xbeef")).toBeNull();
+  });
+});
+
+describe("parseIPv6", () => {
+  test("expands compressed forms", () => {
+    expect(parseIPv6("::1")).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
+    expect(parseIPv6("::")).toEqual(new Array<number>(16).fill(0));
+    expect(parseIPv6("0:0:0:0:0:0:0:1")).toEqual(parseIPv6("::1"));
+  });
+
+  test("expands an embedded IPv4 tail", () => {
+    expect(parseIPv6("::ffff:127.0.0.1")?.slice(10)).toEqual([0xff, 0xff, 127, 0, 0, 1]);
+  });
+
+  test("drops a zone id and rejects garbage", () => {
+    expect(parseIPv6("fe80::1%eth0")?.slice(0, 2)).toEqual([0xfe, 0x80]);
+    expect(parseIPv6("::1::2")).toBeNull();
+    expect(parseIPv6("gg::1")).toBeNull();
+    expect(parseIPv6("1:2:3:4:5:6:7")).toBeNull();
+  });
+});
+
+describe("parseHostAddress / isPrivateAddress", () => {
+  test("a dns name is not an address", () => {
+    expect(parseHostAddress("hooks.example.com")).toBeNull();
+  });
+
+  test("classifies the boundaries of each blocked v4 range", () => {
+    const isPrivate = (host: string) => {
+      const address = parseHostAddress(host);
+      return address ? isPrivateAddress(address) : null;
+    };
+    expect(isPrivate("9.255.255.255")).toBe(false);
+    expect(isPrivate("10.0.0.0")).toBe(true);
+    expect(isPrivate("11.0.0.0")).toBe(false);
+    expect(isPrivate("172.15.255.255")).toBe(false);
+    expect(isPrivate("172.16.0.0")).toBe(true);
+    expect(isPrivate("172.31.255.255")).toBe(true);
+    expect(isPrivate("172.32.0.0")).toBe(false);
+    expect(isPrivate("192.167.255.255")).toBe(false);
+    expect(isPrivate("192.168.0.0")).toBe(true);
+    expect(isPrivate("169.253.255.255")).toBe(false);
+    expect(isPrivate("169.254.0.0")).toBe(true);
+    expect(isPrivate("126.255.255.255")).toBe(false);
+    expect(isPrivate("127.0.0.0")).toBe(true);
+    expect(isPrivate("128.0.0.0")).toBe(false);
+  });
+
+  test("classifies bracketed v6 literals", () => {
+    expect(isPrivateAddress(parseHostAddress("[::1]")!)).toBe(true);
+    expect(isPrivateAddress(parseHostAddress("[2606:4700::1111]")!)).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Retry policy                                                               */
+/* -------------------------------------------------------------------------- */
+
+describe("nextRetryDelay", () => {
+  test("doubles the base delay per attempt", () => {
+    expect([1, 2, 3, 4].map((attempt) => retryBaseDelay(attempt))).toEqual([1000, 2000, 4000, 8000]);
+  });
+
+  test("stops after the attempt cap", () => {
+    expect(nextRetryDelay(WEBHOOK_MAX_ATTEMPTS - 1)).not.toBeNull();
+    expect(nextRetryDelay(WEBHOOK_MAX_ATTEMPTS)).toBeNull();
+    expect(nextRetryDelay(WEBHOOK_MAX_ATTEMPTS + 5)).toBeNull();
+    expect(nextRetryDelay(1, { maxAttempts: 1 })).toBeNull();
+  });
+
+  test("rejects a nonsensical attempt number", () => {
+    expect(nextRetryDelay(0)).toBeNull();
+    expect(nextRetryDelay(Number.NaN)).toBeNull();
+  });
+
+  test("every sample lands inside the declared bounds", () => {
+    for (let attempt = 1; attempt < WEBHOOK_MAX_ATTEMPTS; attempt += 1) {
+      const { min, max } = retryDelayBounds(attempt);
+      for (let i = 0; i < 200; i += 1) {
+        const delay = nextRetryDelay(attempt);
+        expect(delay).not.toBeNull();
+        expect(delay!).toBeGreaterThanOrEqual(min);
+        expect(delay!).toBeLessThanOrEqual(max);
+      }
+    }
+  });
+
+  test("the jitter windows never overlap, so the schedule is strictly increasing", () => {
+    for (let attempt = 1; attempt < WEBHOOK_MAX_ATTEMPTS - 1; attempt += 1) {
+      expect(retryDelayBounds(attempt).max).toBeLessThan(retryDelayBounds(attempt + 1).min);
+    }
+    // Which means any two consecutive samples are ordered, whatever the randomness does.
+    for (let attempt = 1; attempt < WEBHOOK_MAX_ATTEMPTS - 1; attempt += 1) {
+      for (let i = 0; i < 50; i += 1) {
+        expect(nextRetryDelay(attempt)!).toBeLessThan(nextRetryDelay(attempt + 1)!);
+      }
+    }
+  });
+
+  test("jitter actually spreads the delay", () => {
+    expect(nextRetryDelay(1, { random: () => 0 })).toBe(800);
+    expect(nextRetryDelay(1, { random: () => 0.5 })).toBe(1000);
+    expect(nextRetryDelay(1, { random: () => 1 })).toBe(1200);
+    // An out-of-contract random source is clamped rather than producing a wild delay.
+    expect(nextRetryDelay(1, { random: () => -5 })).toBe(800);
+    expect(nextRetryDelay(1, { random: () => 5 })).toBe(1200);
+  });
+
+  test("the total retry window is bounded", () => {
+    let total = 0;
+    for (let attempt = 1; attempt < WEBHOOK_MAX_ATTEMPTS; attempt += 1) {
+      total += retryDelayBounds(attempt).max;
+    }
+    expect(total).toBeLessThanOrEqual(20_000);
+  });
+});
+
+describe("isRetryableStatus", () => {
+  test("retries 5xx and transport failures", () => {
+    for (const status of [0, 500, 502, 503, 504]) expect(isRetryableStatus(status)).toBe(true);
+  });
+
+  test("retries only 408 and 429 out of the 4xx family", () => {
+    expect(isRetryableStatus(408)).toBe(true);
+    expect(isRetryableStatus(429)).toBe(true);
+    for (const status of [400, 401, 403, 404, 405, 409, 410, 418, 422, 451]) {
+      expect(isRetryableStatus(status)).toBe(false);
+    }
+  });
+
+  test("does not retry a 2xx or 3xx", () => {
+    for (const status of [200, 204, 301, 302, 307]) expect(isRetryableStatus(status)).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Delivery                                                                   */
+/* -------------------------------------------------------------------------- */
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function recordingFetch(responses: Array<number | Error>) {
+  const calls: FetchCall[] = [];
+  let index = 0;
+  const impl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    const next = responses[Math.min(index, responses.length - 1)];
+    index += 1;
+    if (next instanceof Error) throw next;
+    return new Response(null, { status: next ?? 200 });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+const noSleep = async () => {};
+const fixedNow = () => 1700000000_000;
+
+describe("deliverWebhook", () => {
+  test("posts a signed body and reports success on the first attempt", async () => {
+    const { impl, calls } = recordingFetch([200]);
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x", secret: SECRET, id: "h1" },
+      { type: "task.created", data: { taskId: "t1" }, workspaceId: "w1" },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow, deliveryId: "d-1" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.deliveryId).toBe("d-1");
+    expect(result.attempts).toEqual([{ attempt: 1, status: 200 }]);
+    expect(calls).toHaveLength(1);
+
+    const call = calls[0]!;
+    expect(call.url).toBe("https://hooks.example.com/x");
+    expect(call.init.method).toBe("POST");
+    // A subscriber must not be able to bounce us to an internal address.
+    expect(call.init.redirect).toBe("manual");
+
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers[WEBHOOK_EVENT_HEADER]).toBe("task.created");
+    expect(headers[WEBHOOK_DELIVERY_HEADER]).toBe("d-1");
+
+    const body = String(call.init.body);
+    expect(JSON.parse(body)).toEqual({
+      id: "d-1",
+      type: "task.created",
+      createdAt: 1700000000_000,
+      workspaceId: "w1",
+      webhookId: "h1",
+      data: { taskId: "t1" },
+    });
+    expect(verifyWebhookSignature(SECRET, body, headers[WEBHOOK_SIGNATURE_HEADER] ?? "", { now: fixedNow }))
+      .toBe(true);
+  });
+
+  test("omits the signature header when the subscription has no secret", async () => {
+    const { impl, calls } = recordingFetch([200]);
+    await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "session.idle", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow },
+    );
+    expect((calls[0]!.init.headers as Record<string, string>)[WEBHOOK_SIGNATURE_HEADER]).toBeUndefined();
+  });
+
+  test("retries a 500 and succeeds", async () => {
+    const { impl, calls } = recordingFetch([500, 503, 200]);
+    const slept: number[] = [];
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x", secret: SECRET },
+      { type: "task.failed", data: {} },
+      {
+        fetchImpl: impl,
+        now: fixedNow,
+        sleep: async (ms) => {
+          slept.push(ms);
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(3);
+    expect(result.attempts.map((attempt) => attempt.status)).toEqual([500, 503, 200]);
+    expect(slept).toHaveLength(2);
+    expect(slept[0]!).toBeLessThan(slept[1]!);
+  });
+
+  test("retries a transport failure", async () => {
+    const { impl, calls } = recordingFetch([new Error("ECONNREFUSED"), 200]);
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "task.created", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow },
+    );
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(result.attempts[0]!.error).toBe("ECONNREFUSED");
+  });
+
+  test("gives up immediately on a 404 rather than hammering a dead endpoint", async () => {
+    const { impl, calls } = recordingFetch([404]);
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/gone" },
+      { type: "task.created", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("does not follow a redirect", async () => {
+    const { impl, calls } = recordingFetch([302]);
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "task.created", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(302);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("retries a 429 and a 408", async () => {
+    for (const status of [429, 408]) {
+      const { impl, calls } = recordingFetch([status, 200]);
+      const result = await deliverWebhook(
+        { url: "https://hooks.example.com/x" },
+        { type: "task.created", data: {} },
+        { fetchImpl: impl, sleep: noSleep, now: fixedNow },
+      );
+      expect(result.ok).toBe(true);
+      expect(calls).toHaveLength(2);
+    }
+  });
+
+  test("stops at the attempt cap", async () => {
+    const { impl, calls } = recordingFetch([500]);
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "task.created", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+    expect(calls).toHaveLength(WEBHOOK_MAX_ATTEMPTS);
+    expect(result.attempts).toHaveLength(WEBHOOK_MAX_ATTEMPTS);
+    // The last attempt has nothing scheduled after it.
+    expect(result.attempts[WEBHOOK_MAX_ATTEMPTS - 1]!.retryDelayMs).toBeUndefined();
+  });
+
+  test("maxAttempts of 1 is a single shot, as the test endpoint uses", async () => {
+    const { impl, calls } = recordingFetch([500]);
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "webhook.test", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow, maxAttempts: 1 },
+    );
+    expect(result.ok).toBe(false);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("aborts an attempt that exceeds the per-delivery timeout", async () => {
+    const hanging = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("timed out")), { once: true });
+      })) as unknown as typeof fetch;
+
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/slow" },
+      { type: "task.created", data: {} },
+      { fetchImpl: hanging, sleep: noSleep, now: fixedNow, timeoutMs: 5, maxAttempts: 2 },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("timed out");
+    expect(result.attempts).toHaveLength(2);
+  });
+
+  test("an already-aborted caller signal stops before any request", async () => {
+    const { impl, calls } = recordingFetch([200]);
+    const controller = new AbortController();
+    controller.abort();
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "task.created", data: {} },
+      { fetchImpl: impl, sleep: noSleep, now: fixedNow, signal: controller.signal },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("aborted");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("never throws, whatever the transport does", async () => {
+    const exploding = (() => {
+      throw new Error("synchronous boom");
+    }) as unknown as typeof fetch;
+    const result = await deliverWebhook(
+      { url: "https://hooks.example.com/x" },
+      { type: "task.created", data: {} },
+      { fetchImpl: exploding, sleep: noSleep, now: fixedNow, maxAttempts: 2 },
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("synchronous boom");
+  });
+});

--- a/apps/server/src/api/modules/webhooks/delivery.ts
+++ b/apps/server/src/api/modules/webhooks/delivery.ts
@@ -1,0 +1,660 @@
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto";
+
+/**
+ * Webhook delivery: URL admission control, payload signing, and the retry schedule.
+ *
+ * Everything here is a pure function or takes its side effects by injection
+ * (`fetchImpl`, `sleep`, `random`, `now`), because the three things that decide whether
+ * this feature is safe — which URLs we agree to fetch, what we sign, and how hard we
+ * retry — must be testable without a network, a clock, or a live subscriber.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* SSRF defence                                                               */
+/* -------------------------------------------------------------------------- */
+
+export interface WebhookUrlOptions {
+  /**
+   * Permits loopback / private / link-local destinations.
+   *
+   * Local development points webhooks at `http://127.0.0.1:xxxx`, so the escape hatch
+   * has to exist; it is opt-in per deployment (`IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE=1`)
+   * rather than per request, so a caller cannot ask for it through the API.
+   */
+  allowPrivate?: boolean;
+}
+
+export type WebhookUrlVerdict = { ok: true } | { ok: false; reason: string };
+
+/** Anything longer is rejected before parsing, so a pathological URL cannot be stored. */
+export const WEBHOOK_URL_MAX_LENGTH = 2048;
+
+export function webhookPrivateNetworkAllowed(env: Record<string, string | undefined> = process.env): boolean {
+  return (env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE ?? "").trim() === "1";
+}
+
+/**
+ * Decides whether the server is willing to send a request to `url`.
+ *
+ * A webhook URL is attacker-controlled input for a request the server makes from inside
+ * the trust boundary, which is the textbook SSRF shape: `http://169.254.169.254/` reads
+ * cloud instance credentials, `http://127.0.0.1:4096/` reaches the local engine's own
+ * admin surface. So the rule is deny-by-default on address ranges rather than a blocklist
+ * of known-bad hostnames.
+ *
+ * The literal forms an attacker reaches for — `http://0x7f.1`, `http://2130706433`,
+ * `http://[::ffff:127.0.0.1]`, `http://127.1` — all normalize to the same address, so the
+ * check runs on the parsed host and additionally re-parses it with inet_aton semantics
+ * instead of pattern-matching the raw string.
+ *
+ * IMPORTANT — this does not close DNS rebinding. `evil.example` can pass this check and
+ * then resolve to 127.0.0.1 at connect time, or resolve twice with different answers
+ * (TOCTOU). Fully closing that needs resolution-time enforcement: resolve the hostname
+ * ourselves, validate every returned address, and pin the connection to a validated IP
+ * (or run deliveries through an egress proxy that enforces the same table). URL
+ * inspection is the first gate, not the whole defence.
+ */
+export function validateWebhookUrl(url: string, opts: WebhookUrlOptions = {}): WebhookUrlVerdict {
+  const raw = typeof url === "string" ? url.trim() : "";
+  if (!raw) return { ok: false, reason: "missing_url" };
+  if (raw.length > WEBHOOK_URL_MAX_LENGTH) return { ok: false, reason: "url_too_long" };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return { ok: false, reason: "invalid_url" };
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, reason: "unsupported_scheme" };
+  }
+
+  // `http://trusted.example@127.0.0.1/` reads as a trusted host to a human and to any
+  // naive prefix check, but connects to the loopback. Credentials in a webhook URL have
+  // no legitimate use here anyway, so reject them outright rather than parse around them.
+  if (parsed.username !== "" || parsed.password !== "") {
+    return { ok: false, reason: "userinfo_not_allowed" };
+  }
+
+  const hostname = normalizeHostname(parsed.hostname);
+  if (!hostname) return { ok: false, reason: "missing_host" };
+
+  if (opts.allowPrivate === true) return { ok: true };
+
+  if (isBlockedHostname(hostname)) return { ok: false, reason: "blocked_hostname" };
+
+  const address = parseHostAddress(hostname);
+  if (address && isPrivateAddress(address)) {
+    return { ok: false, reason: "private_address" };
+  }
+
+  return { ok: true };
+}
+
+/** Lower-cases and drops the FQDN root dot so `LOCALHOST.` cannot slip past a name check. */
+function normalizeHostname(hostname: string): string {
+  let value = hostname.trim().toLowerCase();
+  if (value.startsWith("[") && value.endsWith("]")) return value;
+  while (value.endsWith(".")) value = value.slice(0, -1);
+  return value;
+}
+
+const BLOCKED_HOSTNAME_SUFFIXES = [".localhost", ".local", ".internal", ".home.arpa"];
+
+function isBlockedHostname(hostname: string): boolean {
+  if (hostname === "localhost") return true;
+  return BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
+
+export interface HostAddress {
+  family: 4 | 6;
+  /** 4 bytes for IPv4, 16 bytes for IPv6. */
+  bytes: number[];
+}
+
+/** Parses a host as an IP literal. Returns `null` for a genuine DNS name. */
+export function parseHostAddress(hostname: string): HostAddress | null {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    const bytes = parseIPv6(hostname.slice(1, -1));
+    return bytes ? { family: 6, bytes } : null;
+  }
+  const v4 = parseIPv4Loose(hostname);
+  if (v4) return { family: 4, bytes: v4 };
+  // A bare IPv6 literal without brackets is not valid in a URL, but the parser is cheap
+  // and this keeps the function usable on hosts that did not come through `new URL`.
+  if (hostname.includes(":")) {
+    const bytes = parseIPv6(hostname);
+    if (bytes) return { family: 6, bytes };
+  }
+  return null;
+}
+
+/**
+ * IPv4 parsing with inet_aton semantics: 1–4 dot-separated parts, each decimal, octal
+ * (leading `0`) or hex (leading `0x`), with the final part absorbing the remaining bytes.
+ *
+ * `0x7f.1`, `2130706433` and `0177.0.0.1` are all 127.0.0.1 to a resolver, so they must
+ * all be 127.0.0.1 to the check as well.
+ */
+export function parseIPv4Loose(host: string): number[] | null {
+  if (!host || /[^0-9a-fx.]/i.test(host)) return null;
+  const parts = host.split(".");
+  if (parts.length < 1 || parts.length > 4) return null;
+
+  const values: number[] = [];
+  for (const part of parts) {
+    const value = parseIPv4Part(part);
+    if (value === null) return null;
+    values.push(value);
+  }
+
+  const last = values[values.length - 1];
+  if (last === undefined) return null;
+  // Each leading part is one byte; the trailing part fills whatever is left.
+  const leading = values.slice(0, -1);
+  if (leading.some((value) => value > 0xff)) return null;
+  const remainingBytes = 4 - leading.length;
+  const maxLast = remainingBytes >= 4 ? 0xffffffff : Math.pow(256, remainingBytes) - 1;
+  if (last > maxLast) return null;
+
+  const bytes: number[] = [...leading];
+  for (let index = remainingBytes - 1; index >= 0; index -= 1) {
+    bytes.push(Math.floor(last / Math.pow(256, index)) % 256);
+  }
+  return bytes.length === 4 ? bytes : null;
+}
+
+function parseIPv4Part(part: string): number | null {
+  if (part === "") return null;
+  const lower = part.toLowerCase();
+  let value: number;
+  if (lower.startsWith("0x")) {
+    const digits = lower.slice(2);
+    if (!digits || /[^0-9a-f]/.test(digits)) return null;
+    value = Number.parseInt(digits, 16);
+  } else if (lower.length > 1 && lower.startsWith("0")) {
+    const digits = lower.slice(1);
+    if (/[^0-7]/.test(digits)) return null;
+    value = Number.parseInt(digits, 8);
+  } else {
+    if (/[^0-9]/.test(lower)) return null;
+    value = Number.parseInt(lower, 10);
+  }
+  if (!Number.isFinite(value) || value < 0 || value > 0xffffffff) return null;
+  return value;
+}
+
+/** Expands an IPv6 literal (including the `::ffff:127.0.0.1` embedded-IPv4 form) to 16 bytes. */
+export function parseIPv6(host: string): number[] | null {
+  const value = host.trim().toLowerCase().split("%")[0] ?? "";
+  if (!value || /[^0-9a-f:.]/.test(value)) return null;
+
+  const halves = value.split("::");
+  if (halves.length > 2) return null;
+
+  const expand = (segment: string): number[] | null => {
+    if (segment === "") return [];
+    const groups = segment.split(":");
+    const bytes: number[] = [];
+    for (let index = 0; index < groups.length; index += 1) {
+      const group = groups[index] ?? "";
+      if (group.includes(".")) {
+        // Only legal as the final group.
+        if (index !== groups.length - 1) return null;
+        const v4 = parseIPv4Loose(group);
+        if (!v4) return null;
+        bytes.push(...v4);
+        continue;
+      }
+      if (!group || group.length > 4 || /[^0-9a-f]/.test(group)) return null;
+      const parsedGroup = Number.parseInt(group, 16);
+      bytes.push((parsedGroup >> 8) & 0xff, parsedGroup & 0xff);
+    }
+    return bytes;
+  };
+
+  const head = expand(halves[0] ?? "");
+  if (!head) return null;
+  if (halves.length === 1) return head.length === 16 ? head : null;
+
+  const tail = expand(halves[1] ?? "");
+  if (!tail) return null;
+  const fill = 16 - head.length - tail.length;
+  if (fill < 0) return null;
+  return [...head, ...new Array<number>(fill).fill(0), ...tail];
+}
+
+interface CidrRule {
+  bytes: number[];
+  prefix: number;
+  label: string;
+}
+
+/** Address ranges the server refuses to fetch unless the private opt-in is set. */
+export const BLOCKED_IPV4_RANGES: readonly CidrRule[] = [
+  { bytes: [0, 0, 0, 0], prefix: 8, label: "this-network" },
+  { bytes: [10, 0, 0, 0], prefix: 8, label: "private" },
+  { bytes: [100, 64, 0, 0], prefix: 10, label: "cgnat" },
+  { bytes: [127, 0, 0, 0], prefix: 8, label: "loopback" },
+  { bytes: [169, 254, 0, 0], prefix: 16, label: "link-local" },
+  { bytes: [172, 16, 0, 0], prefix: 12, label: "private" },
+  { bytes: [192, 0, 0, 0], prefix: 24, label: "ietf-protocol" },
+  { bytes: [192, 168, 0, 0], prefix: 16, label: "private" },
+  { bytes: [198, 18, 0, 0], prefix: 15, label: "benchmark" },
+  { bytes: [224, 0, 0, 0], prefix: 4, label: "multicast" },
+  { bytes: [240, 0, 0, 0], prefix: 4, label: "reserved" },
+];
+
+const IPV6_LOOPBACK = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
+const IPV6_UNSPECIFIED = new Array<number>(16).fill(0);
+const IPV4_MAPPED_PREFIX = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff];
+const NAT64_PREFIX = [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0];
+
+export function isPrivateAddress(address: HostAddress): boolean {
+  if (address.family === 4) {
+    return BLOCKED_IPV4_RANGES.some((range) => matchesCidr(address.bytes, range.bytes, range.prefix));
+  }
+
+  const bytes = address.bytes;
+  if (bytes.length !== 16) return true;
+  if (sameBytes(bytes, IPV6_LOOPBACK) || sameBytes(bytes, IPV6_UNSPECIFIED)) return true;
+  // fc00::/7 unique-local, fe80::/10 link-local, ff00::/8 multicast.
+  const first = bytes[0] ?? 0;
+  const second = bytes[1] ?? 0;
+  if ((first & 0xfe) === 0xfc) return true;
+  if (first === 0xfe && (second & 0xc0) === 0x80) return true;
+  if (first === 0xff) return true;
+
+  // Addresses that carry an IPv4 address inside them must be judged as that IPv4
+  // address, or `::ffff:127.0.0.1` and `2002:7f00:1::` become loopback bypasses.
+  const mapped = embeddedIPv4(bytes);
+  if (mapped) return isPrivateAddress({ family: 4, bytes: mapped });
+
+  return false;
+}
+
+function embeddedIPv4(bytes: number[]): number[] | null {
+  if (startsWith(bytes, IPV4_MAPPED_PREFIX)) return bytes.slice(12, 16);
+  if (startsWith(bytes, NAT64_PREFIX)) return bytes.slice(12, 16);
+  // 2002::/16 (6to4) carries the IPv4 address in bytes 2..5.
+  if (bytes[0] === 0x20 && bytes[1] === 0x02) return bytes.slice(2, 6);
+  return null;
+}
+
+function startsWith(bytes: number[], prefix: number[]): boolean {
+  return prefix.every((value, index) => bytes[index] === value);
+}
+
+function sameBytes(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((value, index) => b[index] === value);
+}
+
+function matchesCidr(bytes: number[], network: number[], prefix: number): boolean {
+  let remaining = prefix;
+  for (let index = 0; index < network.length; index += 1) {
+    if (remaining <= 0) return true;
+    const take = Math.min(8, remaining);
+    const mask = take === 8 ? 0xff : (0xff << (8 - take)) & 0xff;
+    if (((bytes[index] ?? 0) & mask) !== ((network[index] ?? 0) & mask)) return false;
+    remaining -= take;
+  }
+  return true;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Signing                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const WEBHOOK_SIGNATURE_HEADER = "X-iPolloWork-Signature";
+export const WEBHOOK_EVENT_HEADER = "X-iPolloWork-Event";
+export const WEBHOOK_DELIVERY_HEADER = "X-iPolloWork-Delivery";
+export const WEBHOOK_TIMESTAMP_HEADER = "X-iPolloWork-Timestamp";
+
+/**
+ * HMAC-SHA256 over `${timestamp}.${body}`, hex encoded.
+ *
+ * The timestamp is inside the signed material rather than merely alongside it, so a
+ * captured delivery cannot be replayed later with a fresh timestamp: changing the
+ * timestamp invalidates the signature. Receivers should reject a delivery whose `t` is
+ * outside their tolerance window in addition to checking `v1`.
+ */
+export function signWebhookPayload(secret: string, body: string, timestamp: number | string): string {
+  return createHmac("sha256", secret).update(`${timestamp}.${body}`, "utf8").digest("hex");
+}
+
+/** Renders the `X-iPolloWork-Signature` value: `t=<unix-seconds>,v1=<hex>`. */
+export function formatSignatureHeader(timestamp: number | string, signature: string): string {
+  return `t=${timestamp},v1=${signature}`;
+}
+
+export function parseSignatureHeader(header: string): { timestamp: string; signatures: string[] } | null {
+  if (typeof header !== "string" || !header.trim()) return null;
+  let timestamp = "";
+  const signatures: string[] = [];
+  for (const segment of header.split(",")) {
+    const index = segment.indexOf("=");
+    if (index === -1) continue;
+    const key = segment.slice(0, index).trim();
+    const value = segment.slice(index + 1).trim();
+    if (key === "t") timestamp = value;
+    else if (key === "v1" && value) signatures.push(value);
+  }
+  if (!timestamp || signatures.length === 0) return null;
+  return { timestamp, signatures };
+}
+
+/**
+ * Receiver-side verification, exported so the SDKs and our own tests check the same way.
+ * Comparison is constant time; a length mismatch short-circuits before `timingSafeEqual`,
+ * which throws on unequal buffers.
+ */
+export function verifyWebhookSignature(
+  secret: string,
+  body: string,
+  header: string,
+  opts: { toleranceSeconds?: number; now?: () => number } = {},
+): boolean {
+  const parsed = parseSignatureHeader(header);
+  if (!parsed) return false;
+
+  const tolerance = opts.toleranceSeconds ?? 300;
+  const timestamp = Number(parsed.timestamp);
+  if (!Number.isFinite(timestamp)) return false;
+  if (tolerance > 0) {
+    const nowSeconds = Math.floor((opts.now?.() ?? Date.now()) / 1000);
+    if (Math.abs(nowSeconds - timestamp) > tolerance) return false;
+  }
+
+  const expected = Buffer.from(signWebhookPayload(secret, body, parsed.timestamp), "utf8");
+  return parsed.signatures.some((candidate) => {
+    const actual = Buffer.from(candidate, "utf8");
+    if (actual.length !== expected.length) return false;
+    return timingSafeEqual(actual, expected);
+  });
+}
+
+export interface WebhookEnvelope {
+  id: string;
+  type: string;
+  createdAt: number;
+  workspaceId?: string;
+  webhookId?: string;
+  data: unknown;
+}
+
+export function buildWebhookEnvelope(input: {
+  deliveryId: string;
+  event: string;
+  data: unknown;
+  workspaceId?: string;
+  webhookId?: string;
+  timestamp?: number;
+}): WebhookEnvelope {
+  return {
+    id: input.deliveryId,
+    type: input.event,
+    createdAt: input.timestamp ?? Date.now(),
+    ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+    ...(input.webhookId ? { webhookId: input.webhookId } : {}),
+    data: input.data ?? null,
+  };
+}
+
+export function buildDeliveryHeaders(input: {
+  event: string;
+  deliveryId: string;
+  body: string;
+  secret?: string;
+  timestampSeconds: number;
+}): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "user-agent": "iPolloWork-Webhooks/1.0",
+    [WEBHOOK_EVENT_HEADER]: input.event,
+    [WEBHOOK_DELIVERY_HEADER]: input.deliveryId,
+    [WEBHOOK_TIMESTAMP_HEADER]: String(input.timestampSeconds),
+  };
+  if (input.secret) {
+    headers[WEBHOOK_SIGNATURE_HEADER] = formatSignatureHeader(
+      input.timestampSeconds,
+      signWebhookPayload(input.secret, input.body, input.timestampSeconds),
+    );
+  }
+  return headers;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Retry policy                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Attempt cap, counting the first try. 5 attempts with the schedule below means a
+ * subscriber that is down stops being contacted after roughly 15 seconds of wall clock,
+ * so one dead endpoint cannot accumulate an unbounded backlog of in-flight retries.
+ */
+export const WEBHOOK_MAX_ATTEMPTS = 5;
+export const WEBHOOK_RETRY_BASE_MS = 1_000;
+export const WEBHOOK_RETRY_FACTOR = 2;
+/** Ceiling on a single backoff. Unreachable at 5 attempts; it bounds future cap changes. */
+export const WEBHOOK_RETRY_MAX_DELAY_MS = 30_000;
+/** Jitter is +/-20% of the base delay. */
+export const WEBHOOK_RETRY_JITTER = 0.2;
+export const WEBHOOK_DELIVERY_TIMEOUT_MS = 10_000;
+
+/** Un-jittered backoff for `attempt` (1-based), before the jitter window is applied. */
+export function retryBaseDelay(attempt: number): number {
+  const exponent = Math.max(0, Math.floor(attempt) - 1);
+  return Math.min(WEBHOOK_RETRY_MAX_DELAY_MS, WEBHOOK_RETRY_BASE_MS * Math.pow(WEBHOOK_RETRY_FACTOR, exponent));
+}
+
+/** Inclusive `[min, max]` window a `nextRetryDelay(attempt)` result must fall inside. */
+export function retryDelayBounds(attempt: number): { min: number; max: number } {
+  const base = retryBaseDelay(attempt);
+  return {
+    min: Math.round(base * (1 - WEBHOOK_RETRY_JITTER)),
+    max: Math.round(base * (1 + WEBHOOK_RETRY_JITTER)),
+  };
+}
+
+/**
+ * Delay in milliseconds before the attempt after `attempt`, or `null` once the cap is hit.
+ *
+ * Exponential with bounded jitter rather than full jitter: the +/-20% window is wide
+ * enough to break up a thundering herd of subscribers retrying in lockstep, and narrow
+ * enough that consecutive windows never overlap (1.2x of one attempt is below 0.8x of the
+ * next), which keeps the schedule strictly increasing and therefore assertable in a test.
+ */
+export function nextRetryDelay(
+  attempt: number,
+  opts: { random?: () => number; maxAttempts?: number } = {},
+): number | null {
+  const maxAttempts = opts.maxAttempts ?? WEBHOOK_MAX_ATTEMPTS;
+  if (!Number.isFinite(attempt) || attempt < 1) return null;
+  if (attempt >= maxAttempts) return null;
+
+  const random = opts.random ?? Math.random;
+  const base = retryBaseDelay(attempt);
+  const sample = Math.min(1, Math.max(0, random()));
+  const factor = 1 - WEBHOOK_RETRY_JITTER + sample * (2 * WEBHOOK_RETRY_JITTER);
+  return Math.round(base * factor);
+}
+
+/**
+ * Retry only what can plausibly succeed later.
+ *
+ * A 4xx means the subscriber understood the request and rejected it — retrying a 404 or a
+ * 401 just hammers an endpoint that will never accept the delivery. The two exceptions are
+ * 408 (request timeout) and 429 (rate limited), which explicitly invite a later attempt.
+ */
+export function isRetryableStatus(status: number): boolean {
+  if (status === 408 || status === 429) return true;
+  if (status >= 400 && status < 500) return false;
+  return status >= 500 || status === 0;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Delivery                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export interface WebhookDeliveryTarget {
+  url: string;
+  secret?: string;
+  id?: string;
+}
+
+export interface WebhookDeliveryAttempt {
+  attempt: number;
+  status?: number;
+  error?: string;
+  retryDelayMs?: number;
+}
+
+export interface WebhookDeliveryResult {
+  deliveryId: string;
+  event: string;
+  ok: boolean;
+  status?: number;
+  error?: string;
+  attempts: WebhookDeliveryAttempt[];
+}
+
+export interface WebhookDeliveryOptions {
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+  timeoutMs?: number;
+  maxAttempts?: number;
+  deliveryId?: string;
+  /** Aborts the whole delivery, retries included. */
+  signal?: AbortSignal;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    (timer as unknown as { unref?: () => void }).unref?.();
+  });
+
+/**
+ * Sends one event to one subscriber, retrying per the policy above.
+ *
+ * Never throws: a delivery failure is a reportable outcome, not an exception, because the
+ * dispatcher fans out to many subscribers and one unreachable endpoint must not abort the
+ * rest. Each attempt carries its own timeout so a subscriber that accepts the connection
+ * and then stalls cannot pin a delivery open indefinitely.
+ */
+export async function deliverWebhook(
+  target: WebhookDeliveryTarget,
+  event: { type: string; data: unknown; workspaceId?: string },
+  opts: WebhookDeliveryOptions = {},
+): Promise<WebhookDeliveryResult> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? defaultSleep;
+  const timeoutMs = opts.timeoutMs ?? WEBHOOK_DELIVERY_TIMEOUT_MS;
+  const maxAttempts = opts.maxAttempts ?? WEBHOOK_MAX_ATTEMPTS;
+  const deliveryId = opts.deliveryId ?? randomUUID();
+
+  const envelope = buildWebhookEnvelope({
+    deliveryId,
+    event: event.type,
+    data: event.data,
+    timestamp: now(),
+    ...(event.workspaceId ? { workspaceId: event.workspaceId } : {}),
+    ...(target.id ? { webhookId: target.id } : {}),
+  });
+  const body = JSON.stringify(envelope);
+
+  const attempts: WebhookDeliveryAttempt[] = [];
+  let lastStatus: number | undefined;
+  let lastError: string | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if (opts.signal?.aborted) {
+      attempts.push({ attempt, error: "aborted" });
+      return { deliveryId, event: event.type, ok: false, error: "aborted", attempts };
+    }
+
+    // The signature timestamp is refreshed per attempt so a retry arriving minutes later
+    // is still inside a receiver's replay window.
+    const timestampSeconds = Math.floor(now() / 1000);
+    const headers = buildDeliveryHeaders({
+      event: event.type,
+      deliveryId,
+      body,
+      timestampSeconds,
+      ...(target.secret ? { secret: target.secret } : {}),
+    });
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    (timer as unknown as { unref?: () => void }).unref?.();
+    const onAbort = () => controller.abort();
+    opts.signal?.addEventListener("abort", onAbort, { once: true });
+
+    let status: number | undefined;
+    let error: string | undefined;
+    try {
+      const response = await fetchImpl(target.url, {
+        method: "POST",
+        headers,
+        body,
+        signal: controller.signal,
+        redirect: "manual",
+      });
+      status = response.status;
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : String(cause);
+    } finally {
+      clearTimeout(timer);
+      opts.signal?.removeEventListener("abort", onAbort);
+    }
+
+    lastStatus = status;
+    lastError = error;
+
+    if (status !== undefined && status >= 200 && status < 300) {
+      attempts.push({ attempt, status });
+      return { deliveryId, event: event.type, ok: true, status, attempts };
+    }
+
+    // A 3xx is not followed: `redirect: "manual"` is what keeps a subscriber from
+    // bouncing us to an internal address that the URL check never saw.
+    const retryable = status === undefined ? true : isRetryableStatus(status);
+    if (!retryable) {
+      attempts.push({ attempt, ...(status !== undefined ? { status } : {}), ...(error ? { error } : {}) });
+      return {
+        deliveryId,
+        event: event.type,
+        ok: false,
+        ...(status !== undefined ? { status } : {}),
+        ...(error ? { error } : {}),
+        attempts,
+      };
+    }
+
+    const delay = nextRetryDelay(attempt, {
+      maxAttempts,
+      ...(opts.random ? { random: opts.random } : {}),
+    });
+    attempts.push({
+      attempt,
+      ...(status !== undefined ? { status } : {}),
+      ...(error ? { error } : {}),
+      ...(delay !== null ? { retryDelayMs: delay } : {}),
+    });
+    if (delay === null) break;
+    await sleep(delay);
+  }
+
+  return {
+    deliveryId,
+    event: event.type,
+    ok: false,
+    ...(lastStatus !== undefined ? { status: lastStatus } : {}),
+    ...(lastError ? { error: lastError } : {}),
+    attempts,
+  };
+}

--- a/apps/server/src/api/modules/webhooks/module.test.ts
+++ b/apps/server/src/api/modules/webhooks/module.test.ts
@@ -1,0 +1,680 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { isApiError } from "../../../errors.js";
+import type { RequestContext, Route } from "../../../routes/registry.js";
+import { matchRoute } from "../../../routes/registry.js";
+import type { ServerConfig } from "../../../types.js";
+import { describeModules, registerApiModules, type ApiModuleContext } from "../../module.js";
+import { verifyWebhookSignature, WEBHOOK_EVENT_HEADER, WEBHOOK_SIGNATURE_HEADER } from "./delivery.js";
+import {
+  dispatchWebhookEvent,
+  parseCreateWebhookInput,
+  webhooksModule,
+  WEBHOOK_SECRET_MIN_LENGTH,
+} from "./module.js";
+import {
+  isKnownWebhookEvent,
+  matchesWebhookEvent,
+  MemoryWebhookStore,
+  resolveWebhookStorePath,
+  toPublicWebhook,
+  WebhookStore,
+  WEBHOOK_EVENT_TYPES,
+  WEBHOOK_MAX_PER_WORKSPACE,
+  WEBHOOK_TEST_EVENT,
+  WEBHOOK_UNBRIDGED_EVENT_TYPES,
+} from "./store.js";
+
+const config = { workspaces: [], readOnly: false } as unknown as ServerConfig;
+
+const PUBLIC_URL = "https://hooks.example.com/ingest";
+const SUPPLIED_SECRET = "supplied_secret_value_0123456789";
+
+/* -------------------------------------------------------------------------- */
+/* Harness                                                                    */
+/* -------------------------------------------------------------------------- */
+
+interface Harness {
+  routes: Route[];
+  store: MemoryWebhookStore;
+  calls: Array<{ url: string; init: RequestInit }>;
+  call: (
+    method: string,
+    path: string,
+    body?: unknown,
+  ) => Promise<{ status: number; body: Record<string, unknown>; raw: string }>;
+}
+
+function createHarness(options: { fetchStatus?: number } = {}): Harness {
+  const store = new MemoryWebhookStore();
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const webhookFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), init: init ?? {} });
+    return new Response(null, { status: options.fetchStatus ?? 200 });
+  }) as unknown as typeof fetch;
+
+  const context: ApiModuleContext = {
+    config,
+    ensureWritable: () => {},
+    requireClientScope: () => {},
+    jsonResponse: (data, status = 200) => new Response(JSON.stringify(data), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+    readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+    resolveWorkspace: async (_config, id) => ({ id }),
+    services: { webhookStore: store, webhookFetch },
+  };
+
+  const routes: Route[] = [];
+  registerApiModules(routes, [webhooksModule], context);
+
+  const call: Harness["call"] = async (method, path, body) => {
+    const matched = matchRoute(routes, method, path);
+    if (!matched) throw new Error(`No route for ${method} ${path}`);
+    const request = new Request(`http://localhost${path}`, {
+      method,
+      ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { "content-type": "application/json" } }),
+    });
+    const ctx: RequestContext = {
+      request,
+      url: new URL(request.url),
+      params: matched.params,
+      config,
+      approvals: {} as never,
+      reloadEvents: {} as never,
+      tokens: {} as never,
+    };
+    const response = await matched.handler(ctx);
+    const raw = await response.text();
+    return { status: response.status, body: raw ? (JSON.parse(raw) as Record<string, unknown>) : {}, raw };
+  };
+
+  return { routes, store, calls, call };
+}
+
+const webhooksPath = (workspaceId = "w1") => `/api/v1/workspaces/${workspaceId}/webhooks`;
+
+async function createWebhook(harness: Harness, body: Record<string, unknown> = {}) {
+  return harness.call("POST", webhooksPath(), { url: PUBLIC_URL, events: ["task.created"], ...body });
+}
+
+const savedEnv = process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE;
+const savedStoreEnv = process.env.IPOLLOWORK_WEBHOOK_STORE;
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE;
+  else process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE = savedEnv;
+  if (savedStoreEnv === undefined) delete process.env.IPOLLOWORK_WEBHOOK_STORE;
+  else process.env.IPOLLOWORK_WEBHOOK_STORE = savedStoreEnv;
+});
+
+/* -------------------------------------------------------------------------- */
+/* Registration                                                               */
+/* -------------------------------------------------------------------------- */
+
+describe("webhooks module registration", () => {
+  test("declares the expected identity", () => {
+    expect(webhooksModule.id).toBe("webhooks");
+    expect(webhooksModule.version).toBe("1.0.0");
+    expect(webhooksModule.stability).toBe("preview");
+  });
+
+  test("registers five routes with the right effects and scopes", () => {
+    const routes: Route[] = [];
+    const result = registerApiModules(routes, [webhooksModule], {
+      config,
+      ensureWritable: () => {},
+      requireClientScope: () => {},
+      jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+      readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+      resolveWorkspace: async () => ({ id: "w1" }),
+      services: { webhookStore: new MemoryWebhookStore() },
+    });
+
+    expect(routes).toHaveLength(5);
+    const [described] = describeModules(result);
+    expect(described?.operations).toEqual([
+      {
+        operationId: "createWebhook",
+        method: "POST",
+        path: "/api/v1/workspaces/:workspaceId/webhooks",
+        effect: "write",
+        scope: "collaborator",
+        summary: "Create a webhook subscription",
+        streaming: null,
+        deprecated: false,
+      },
+      {
+        operationId: "listWebhooks",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/webhooks",
+        effect: "read",
+        scope: "viewer",
+        summary: "List webhook subscriptions",
+        streaming: null,
+        deprecated: false,
+      },
+      {
+        operationId: "getWebhook",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/webhooks/:webhookId",
+        effect: "read",
+        scope: "viewer",
+        summary: "Get a webhook subscription",
+        streaming: null,
+        deprecated: false,
+      },
+      {
+        operationId: "deleteWebhook",
+        method: "DELETE",
+        path: "/api/v1/workspaces/:workspaceId/webhooks/:webhookId",
+        effect: "destructive",
+        scope: "collaborator",
+        summary: "Delete a webhook subscription",
+        streaming: null,
+        deprecated: false,
+      },
+      {
+        operationId: "testWebhook",
+        method: "POST",
+        path: "/api/v1/workspaces/:workspaceId/webhooks/:webhookId/test",
+        effect: "write",
+        scope: "collaborator",
+        summary: "Send a test delivery to a webhook",
+        streaming: null,
+        deprecated: false,
+      },
+    ]);
+  });
+
+  test("write operations go through the module gates", async () => {
+    const gates: string[] = [];
+    const routes: Route[] = [];
+    registerApiModules(routes, [webhooksModule], {
+      config,
+      ensureWritable: () => gates.push("ensureWritable"),
+      requireClientScope: (_ctx, required) => gates.push(`scope:${required}`),
+      jsonResponse: (data, status = 200) => Response.json(data as never, { status }),
+      readJsonBody: async (request) => (await request.json()) as Record<string, unknown>,
+      resolveWorkspace: async () => ({ id: "w1" }),
+      services: { webhookStore: new MemoryWebhookStore() },
+    });
+
+    const matched = matchRoute(routes, "GET", webhooksPath())!;
+    await matched.handler({
+      request: new Request(`http://localhost${webhooksPath()}`),
+      url: new URL(`http://localhost${webhooksPath()}`),
+      params: matched.params,
+      config,
+      approvals: {} as never,
+      reloadEvents: {} as never,
+      tokens: {} as never,
+    });
+    // A read must not trip the write gate; that gating lives in the registry, not here.
+    expect(gates).toEqual(["scope:viewer"]);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Validation                                                                 */
+/* -------------------------------------------------------------------------- */
+
+describe("parseCreateWebhookInput", () => {
+  const expectApiError = (fn: () => unknown, code: string) => {
+    try {
+      fn();
+      throw new Error("expected a throw");
+    } catch (error) {
+      expect(isApiError(error)).toBe(true);
+      expect((error as { code: string }).code).toBe(code);
+      expect((error as { status: number }).status).toBe(400);
+    }
+  };
+
+  test("accepts a public url with known events", () => {
+    const parsed = parseCreateWebhookInput({ url: PUBLIC_URL, events: ["task.created", "task.failed"] });
+    expect(parsed.url).toBe(PUBLIC_URL);
+    expect(parsed.events).toEqual(["task.created", "task.failed"]);
+    expect(parsed.active).toBe(true);
+  });
+
+  test("rejects an engine event that nothing would ever deliver", () => {
+    // Accepting `session.idle` would create a subscription that can never fire, and the
+    // caller could not tell that from a quiet workspace.
+    expectApiError(
+      () => parseCreateWebhookInput({ url: PUBLIC_URL, events: ["session.idle"] }),
+      "webhook_events_invalid",
+    );
+  });
+
+  test("generates a secret when none is supplied", () => {
+    const parsed = parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"] });
+    expect(parsed.generatedSecret).toBe(true);
+    expect(parsed.secret).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("keeps a supplied secret and does not mark it generated", () => {
+    const parsed = parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"], secret: SUPPLIED_SECRET });
+    expect(parsed.generatedSecret).toBe(false);
+    expect(parsed.secret).toBe(SUPPLIED_SECRET);
+  });
+
+  test("trims and de-duplicates events", () => {
+    expect(parseCreateWebhookInput({ url: PUBLIC_URL, events: [" task.created ", "task.created"] }).events)
+      .toEqual(["task.created"]);
+  });
+
+  test("rejects a missing or malformed url", () => {
+    expectApiError(() => parseCreateWebhookInput({ events: ["*"] }), "webhook_url_invalid");
+    expectApiError(() => parseCreateWebhookInput({ url: 42, events: ["*"] }), "webhook_url_invalid");
+    expectApiError(() => parseCreateWebhookInput({ url: "not a url", events: ["*"] }), "webhook_url_invalid");
+  });
+
+  test("rejects a private url and points at the escape hatch", () => {
+    try {
+      parseCreateWebhookInput({ url: "http://169.254.169.254/latest", events: ["*"] });
+      throw new Error("expected a throw");
+    } catch (error) {
+      const details = (error as { details: { reason: string; hint?: string } }).details;
+      expect(details.reason).toBe("private_address");
+      expect(details.hint).toContain("IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE");
+    }
+  });
+
+  test("accepts a private url when the deployment opted in", () => {
+    expect(parseCreateWebhookInput({ url: "http://127.0.0.1:3000/hook", events: ["*"] }, { allowPrivate: true }).url)
+      .toBe("http://127.0.0.1:3000/hook");
+  });
+
+  test("rejects empty, non-string and unknown events", () => {
+    expectApiError(() => parseCreateWebhookInput({ url: PUBLIC_URL, events: [] }), "webhook_events_invalid");
+    expectApiError(() => parseCreateWebhookInput({ url: PUBLIC_URL, events: "task.created" }), "webhook_events_invalid");
+    expectApiError(() => parseCreateWebhookInput({ url: PUBLIC_URL, events: [1] }), "webhook_events_invalid");
+    expectApiError(
+      () => parseCreateWebhookInput({ url: PUBLIC_URL, events: ["task.exploded"] }),
+      "webhook_events_invalid",
+    );
+    // The test ping is not a subscribable product event.
+    expectApiError(
+      () => parseCreateWebhookInput({ url: PUBLIC_URL, events: [WEBHOOK_TEST_EVENT] }),
+      "webhook_events_invalid",
+    );
+  });
+
+  test("rejects a weak or non-string secret", () => {
+    expectApiError(
+      () => parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"], secret: "short" }),
+      "webhook_secret_invalid",
+    );
+    expectApiError(
+      () => parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"], secret: 12345678901234567890 }),
+      "webhook_secret_invalid",
+    );
+    expect(
+      parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"], secret: "x".repeat(WEBHOOK_SECRET_MIN_LENGTH) }).secret,
+    ).toHaveLength(WEBHOOK_SECRET_MIN_LENGTH);
+  });
+
+  test("rejects a non-boolean active flag", () => {
+    expectApiError(
+      () => parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"], active: "yes" }),
+      "webhook_active_invalid",
+    );
+    expect(parseCreateWebhookInput({ url: PUBLIC_URL, events: ["*"], active: false }).active).toBe(false);
+  });
+});
+
+describe("event catalogue", () => {
+  test("covers exactly the events that are actually delivered", () => {
+    expect(isKnownWebhookEvent("*")).toBe(true);
+    expect(isKnownWebhookEvent("task.awaiting_approval")).toBe(true);
+    expect(isKnownWebhookEvent("task.made_up")).toBe(false);
+    expect(WEBHOOK_EVENT_TYPES).toContain("task.failed");
+  });
+
+  test("engine events are not subscribable until something bridges them", () => {
+    // `bridgeTaskEventsToWebhooks` is the only producer, so these would be accepted and
+    // never fire. They are listed separately rather than silently offered.
+    for (const event of ["session.idle", "message.delta", "permission.asked"]) {
+      expect(isKnownWebhookEvent(event)).toBe(false);
+      expect(WEBHOOK_UNBRIDGED_EVENT_TYPES).toContain(event);
+    }
+  });
+
+  test("matching honours the wildcard", () => {
+    expect(matchesWebhookEvent(["*"], "anything.at.all")).toBe(true);
+    expect(matchesWebhookEvent(["task.created"], "task.created")).toBe(true);
+    expect(matchesWebhookEvent(["task.created"], "task.failed")).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Endpoints                                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("createWebhook", () => {
+  test("returns 201 with the public view and the generated secret once", async () => {
+    const harness = createHarness();
+    const created = await createWebhook(harness);
+
+    expect(created.status).toBe(201);
+    const webhook = created.body.webhook as Record<string, unknown>;
+    expect(webhook.url).toBe(PUBLIC_URL);
+    expect(webhook.events).toEqual(["task.created"]);
+    expect(webhook.active).toBe(true);
+    expect(webhook.hasSecret).toBe(true);
+    expect(webhook).not.toHaveProperty("secret");
+    // Generated secrets are shown exactly once, at the top level, never inside the record.
+    expect(typeof created.body.secret).toBe("string");
+  });
+
+  test("does not echo a caller-supplied secret", async () => {
+    const harness = createHarness();
+    const created = await createWebhook(harness, { secret: SUPPLIED_SECRET });
+    expect(created.body).not.toHaveProperty("secret");
+    expect(created.raw).not.toContain(SUPPLIED_SECRET);
+    expect((created.body.webhook as Record<string, unknown>).hasSecret).toBe(true);
+  });
+
+  test("rejects a private destination unless the server opted in", async () => {
+    delete process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE;
+    const harness = createHarness();
+    await expect(createWebhook(harness, { url: "http://127.0.0.1:8080/hook" }))
+      .rejects.toMatchObject({ code: "webhook_url_invalid", status: 400 });
+
+    process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE = "1";
+    const allowed = await createWebhook(harness, { url: "http://127.0.0.1:8080/hook" });
+    expect(allowed.status).toBe(201);
+  });
+
+  test("enforces the per-workspace limit", async () => {
+    const harness = createHarness();
+    for (let index = 0; index < WEBHOOK_MAX_PER_WORKSPACE; index += 1) {
+      await createWebhook(harness, { url: `${PUBLIC_URL}/${index}` });
+    }
+    await expect(createWebhook(harness)).rejects.toMatchObject({ code: "webhook_limit_reached", status: 409 });
+  });
+
+  test("scopes subscriptions to their workspace", async () => {
+    const harness = createHarness();
+    await createWebhook(harness);
+    await harness.call("POST", webhooksPath("w2"), { url: PUBLIC_URL, events: ["*"] });
+
+    const first = await harness.call("GET", webhooksPath("w1"));
+    const second = await harness.call("GET", webhooksPath("w2"));
+    expect((first.body.webhooks as unknown[])).toHaveLength(1);
+    expect((second.body.webhooks as unknown[])).toHaveLength(1);
+    expect((first.body.webhooks as Array<{ workspaceId: string }>)[0]?.workspaceId).toBe("w1");
+  });
+});
+
+describe("read endpoints never expose a secret", () => {
+  test("list and get return hasSecret instead of the secret", async () => {
+    const harness = createHarness();
+    const created = await createWebhook(harness, { secret: SUPPLIED_SECRET });
+    const id = (created.body.webhook as { id: string }).id;
+
+    const listed = await harness.call("GET", webhooksPath());
+    expect(listed.raw).not.toContain(SUPPLIED_SECRET);
+    expect(listed.raw).not.toContain("\"secret\"");
+    expect((listed.body.webhooks as Array<{ hasSecret: boolean }>)[0]?.hasSecret).toBe(true);
+
+    const fetched = await harness.call("GET", `${webhooksPath()}/${id}`);
+    expect(fetched.raw).not.toContain(SUPPLIED_SECRET);
+    expect(fetched.body.webhook).not.toHaveProperty("secret");
+    expect((fetched.body.webhook as { hasSecret: boolean }).hasSecret).toBe(true);
+  });
+
+  test("hasSecret is false when a stored record has none", () => {
+    const record = {
+      id: "h1",
+      workspaceId: "w1",
+      url: PUBLIC_URL,
+      events: ["*"],
+      active: true,
+      createdAt: 1,
+    };
+    expect(toPublicWebhook(record)).toEqual({ ...record, hasSecret: false });
+    expect(toPublicWebhook({ ...record, secret: "" }).hasSecret).toBe(false);
+  });
+
+  test("getWebhook 404s for an unknown id and across workspaces", async () => {
+    const harness = createHarness();
+    const created = await createWebhook(harness);
+    const id = (created.body.webhook as { id: string }).id;
+
+    await expect(harness.call("GET", `${webhooksPath()}/nope`))
+      .rejects.toMatchObject({ code: "webhook_not_found", status: 404 });
+    await expect(harness.call("GET", `${webhooksPath("w2")}/${id}`))
+      .rejects.toMatchObject({ code: "webhook_not_found", status: 404 });
+  });
+});
+
+describe("deleteWebhook", () => {
+  test("removes the subscription", async () => {
+    const harness = createHarness();
+    const created = await createWebhook(harness);
+    const id = (created.body.webhook as { id: string }).id;
+
+    const deleted = await harness.call("DELETE", `${webhooksPath()}/${id}`);
+    expect(deleted.body).toEqual({ deleted: true, id });
+
+    const listed = await harness.call("GET", webhooksPath());
+    expect(listed.body.webhooks).toEqual([]);
+    await expect(harness.call("DELETE", `${webhooksPath()}/${id}`))
+      .rejects.toMatchObject({ code: "webhook_not_found" });
+  });
+});
+
+describe("testWebhook", () => {
+  test("sends one signed ping and reports the outcome without leaking the secret", async () => {
+    const harness = createHarness();
+    const created = await createWebhook(harness, { secret: SUPPLIED_SECRET, events: ["task.failed"] });
+    const id = (created.body.webhook as { id: string }).id;
+
+    const tested = await harness.call("POST", `${webhooksPath()}/${id}/test`);
+    expect(tested.status).toBe(200);
+    expect(tested.raw).not.toContain(SUPPLIED_SECRET);
+
+    const delivery = tested.body.delivery as { ok: boolean; status: number; attempts: unknown[] };
+    expect(delivery.ok).toBe(true);
+    expect(delivery.status).toBe(200);
+    expect(delivery.attempts).toHaveLength(1);
+
+    expect(harness.calls).toHaveLength(1);
+    const call = harness.calls[0]!;
+    const headers = call.init.headers as Record<string, string>;
+    // The ping bypasses the event filter — this subscription only asked for task.failed.
+    expect(headers[WEBHOOK_EVENT_HEADER]).toBe(WEBHOOK_TEST_EVENT);
+    expect(verifyWebhookSignature(SUPPLIED_SECRET, String(call.init.body), headers[WEBHOOK_SIGNATURE_HEADER] ?? ""))
+      .toBe(true);
+  });
+
+  test("reports a rejecting subscriber as data rather than raising", async () => {
+    const harness = createHarness({ fetchStatus: 410 });
+    const created = await createWebhook(harness);
+    const id = (created.body.webhook as { id: string }).id;
+
+    const tested = await harness.call("POST", `${webhooksPath()}/${id}/test`);
+    expect(tested.status).toBe(200);
+    expect((tested.body.delivery as { ok: boolean; status: number }).ok).toBe(false);
+    expect((tested.body.delivery as { ok: boolean; status: number }).status).toBe(410);
+    // A 410 is not retryable, so a single attempt was made.
+    expect(harness.calls).toHaveLength(1);
+  });
+
+  test("refuses a stored url that the current policy no longer allows", async () => {
+    process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE = "1";
+    const harness = createHarness();
+    const created = await createWebhook(harness, { url: "http://127.0.0.1:8080/hook" });
+    const id = (created.body.webhook as { id: string }).id;
+
+    delete process.env.IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE;
+    await expect(harness.call("POST", `${webhooksPath()}/${id}/test`))
+      .rejects.toMatchObject({ code: "webhook_url_invalid", status: 400 });
+    expect(harness.calls).toHaveLength(0);
+  });
+
+  test("404s for an unknown webhook", async () => {
+    const harness = createHarness();
+    await expect(harness.call("POST", `${webhooksPath()}/nope/test`))
+      .rejects.toMatchObject({ code: "webhook_not_found", status: 404 });
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Dispatch                                                                   */
+/* -------------------------------------------------------------------------- */
+
+describe("dispatchWebhookEvent", () => {
+  const fetchOk = (calls: string[]) =>
+    (async (url: string | URL | Request) => {
+      calls.push(String(url));
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+  test("delivers to matching and wildcard subscriptions only", async () => {
+    const store = new MemoryWebhookStore();
+    await store.create({ workspaceId: "w1", url: "https://a.example.com/", events: ["task.created"] });
+    await store.create({ workspaceId: "w1", url: "https://b.example.com/", events: ["*"] });
+    await store.create({ workspaceId: "w1", url: "https://c.example.com/", events: ["task.failed"] });
+    await store.create({ workspaceId: "w2", url: "https://d.example.com/", events: ["*"] });
+
+    const calls: string[] = [];
+    const results = await dispatchWebhookEvent(
+      store,
+      { workspaceId: "w1", type: "task.created", data: { taskId: "t1" } },
+      { fetchImpl: fetchOk(calls), sleep: async () => {} },
+    );
+
+    expect(results).toHaveLength(2);
+    expect(calls.sort()).toEqual(["https://a.example.com/", "https://b.example.com/"]);
+  });
+
+  test("skips inactive subscriptions", async () => {
+    const store = new MemoryWebhookStore();
+    await store.create({ workspaceId: "w1", url: "https://a.example.com/", events: ["*"], active: false });
+    const calls: string[] = [];
+    expect(await dispatchWebhookEvent(
+      store,
+      { workspaceId: "w1", type: "task.created", data: {} },
+      { fetchImpl: fetchOk(calls), sleep: async () => {} },
+    )).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test("re-validates the stored url at send time", async () => {
+    const store = new MemoryWebhookStore();
+    // Created while the private opt-in was on; the policy has since tightened.
+    await store.create({ workspaceId: "w1", url: "http://169.254.169.254/", events: ["*"] });
+    await store.create({ workspaceId: "w1", url: "https://ok.example.com/", events: ["*"] });
+
+    const calls: string[] = [];
+    const results = await dispatchWebhookEvent(
+      store,
+      { workspaceId: "w1", type: "task.created", data: {} },
+      { fetchImpl: fetchOk(calls), sleep: async () => {} },
+    );
+    expect(results).toHaveLength(1);
+    expect(calls).toEqual(["https://ok.example.com/"]);
+  });
+
+  test("one unreachable subscriber does not stop the others", async () => {
+    const store = new MemoryWebhookStore();
+    await store.create({ workspaceId: "w1", url: "https://down.example.com/", events: ["*"] });
+    await store.create({ workspaceId: "w1", url: "https://up.example.com/", events: ["*"] });
+
+    const impl = (async (url: string | URL | Request) => {
+      if (String(url).includes("down")) throw new Error("ECONNREFUSED");
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const results = await dispatchWebhookEvent(
+      store,
+      { workspaceId: "w1", type: "task.created", data: {} },
+      { fetchImpl: impl, sleep: async () => {}, maxAttempts: 2 },
+    );
+    expect(results.map((result) => result.ok).sort()).toEqual([false, true]);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Persistence                                                                */
+/* -------------------------------------------------------------------------- */
+
+describe("WebhookStore persistence", () => {
+  test("resolves next to the server config, like the token store", () => {
+    delete process.env.IPOLLOWORK_WEBHOOK_STORE;
+    expect(resolveWebhookStorePath({ configPath: "/etc/ipollowork/config.json" } as ServerConfig))
+      .toBe("/etc/ipollowork/webhooks.json");
+
+    process.env.IPOLLOWORK_WEBHOOK_STORE = "/var/lib/hooks.json";
+    expect(resolveWebhookStorePath({ configPath: "/etc/ipollowork/config.json" } as ServerConfig))
+      .toBe("/var/lib/hooks.json");
+  });
+
+  test("round-trips through the file and keeps the secret on disk only", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ipollowork-webhooks-"));
+    try {
+      process.env.IPOLLOWORK_WEBHOOK_STORE = join(dir, "webhooks.json");
+      const store = new WebhookStore(config);
+      const created = await store.create({
+        workspaceId: "w1",
+        url: PUBLIC_URL,
+        events: ["task.created"],
+        secret: SUPPLIED_SECRET,
+      });
+
+      const onDisk = await readFile(join(dir, "webhooks.json"), "utf8");
+      expect(onDisk).toContain(SUPPLIED_SECRET);
+      // ...but the shape the API returns carries no secret at all.
+      expect(JSON.stringify(toPublicWebhook(created))).not.toContain(SUPPLIED_SECRET);
+
+      const reloaded = new WebhookStore(config);
+      const listed = await reloaded.list("w1");
+      expect(listed).toHaveLength(1);
+      expect(listed[0]?.secret).toBe(SUPPLIED_SECRET);
+      expect(await reloaded.get("w1", created.id)).not.toBeNull();
+      expect(await reloaded.get("w2", created.id)).toBeNull();
+
+      expect(await reloaded.delete("w1", created.id)).toBe(true);
+      expect(await new WebhookStore(config).list("w1")).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("a corrupt or missing store degrades to empty rather than throwing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ipollowork-webhooks-"));
+    try {
+      process.env.IPOLLOWORK_WEBHOOK_STORE = join(dir, "missing.json");
+      expect(await new WebhookStore(config).list("w1")).toEqual([]);
+
+      await Bun.write(join(dir, "corrupt.json"), "{not json");
+      process.env.IPOLLOWORK_WEBHOOK_STORE = join(dir, "corrupt.json");
+      expect(await new WebhookStore(config).list("w1")).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("concurrent creates all survive", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "ipollowork-webhooks-"));
+    try {
+      process.env.IPOLLOWORK_WEBHOOK_STORE = join(dir, "webhooks.json");
+      const store = new WebhookStore(config);
+      await Promise.all(
+        [0, 1, 2, 3, 4].map((index) =>
+          store.create({ workspaceId: "w1", url: `${PUBLIC_URL}/${index}`, events: ["*"] }),
+        ),
+      );
+      expect(await new WebhookStore(config).list("w1")).toHaveLength(5);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/server/src/api/modules/webhooks/module.ts
+++ b/apps/server/src/api/modules/webhooks/module.ts
@@ -1,0 +1,486 @@
+import { randomBytes } from "node:crypto";
+
+import { ApiError } from "../../../errors.js";
+import type { RequestContext } from "../../../routes/registry.js";
+import type { ApiModule, ApiModuleContext, ApiOperation, JsonSchema } from "../../module.js";
+import {
+  deliverWebhook,
+  validateWebhookUrl,
+  webhookPrivateNetworkAllowed,
+  WEBHOOK_MAX_ATTEMPTS,
+  WEBHOOK_URL_MAX_LENGTH,
+  type WebhookDeliveryOptions,
+  type WebhookDeliveryResult,
+} from "./delivery.js";
+import {
+  isKnownWebhookEvent,
+  toPublicWebhook,
+  WebhookStore,
+  WEBHOOK_EVENT_TYPES,
+  WEBHOOK_MAX_PER_WORKSPACE,
+  WEBHOOK_TEST_EVENT,
+  WEBHOOK_WILDCARD,
+  type CreateWebhookInput,
+  type WebhookStoreLike,
+} from "./store.js";
+
+/**
+ * The `webhooks` module: outbound event subscriptions for a workspace.
+ *
+ * This is the one API surface where the server makes an outbound request to an address
+ * the caller chose, so admission control (`validateWebhookUrl`) and authentication of the
+ * delivery (`signWebhookPayload`) live in `delivery.ts` as pure functions and are exercised
+ * directly by tests. The module here is deliberately thin: validate, store, hand off.
+ */
+
+/** Minimum length for a caller-supplied signing secret. */
+export const WEBHOOK_SECRET_MIN_LENGTH = 16;
+export const WEBHOOK_SECRET_MAX_LENGTH = 256;
+/** Bytes of entropy in a server-generated secret. */
+const GENERATED_SECRET_BYTES = 32;
+/** A test ping is a single shot: a caller waiting on the response must not wait out a retry ladder. */
+const TEST_DELIVERY_TIMEOUT_MS = 5_000;
+
+export interface ParsedCreateWebhookInput {
+  url: string;
+  events: string[];
+  secret?: string;
+  active: boolean;
+  /** True when the server minted the secret, which is the only case it is echoed back. */
+  generatedSecret: boolean;
+}
+
+/**
+ * Validates a `createWebhook` body.
+ *
+ * Exported and pure so the admission rules can be tested without a request. Every
+ * rejection carries a distinct code plus a machine-readable `details`, because a caller
+ * that submitted a blocked URL needs to know it was blocked as an address rather than
+ * malformed — those two lead to very different fixes.
+ */
+export function parseCreateWebhookInput(
+  body: Record<string, unknown>,
+  opts: { allowPrivate?: boolean } = {},
+): ParsedCreateWebhookInput {
+  const url = typeof body.url === "string" ? body.url.trim() : "";
+  if (!url) {
+    throw new ApiError(400, "webhook_url_invalid", "A webhook url is required", { reason: "missing_url" });
+  }
+
+  const verdict = validateWebhookUrl(url, { allowPrivate: opts.allowPrivate === true });
+  if (!verdict.ok) {
+    throw new ApiError(400, "webhook_url_invalid", `Webhook url is not allowed: ${verdict.reason}`, {
+      reason: verdict.reason,
+      ...(verdict.reason === "private_address" || verdict.reason === "blocked_hostname"
+        ? { hint: "Set IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE=1 to permit private destinations." }
+        : {}),
+    });
+  }
+
+  const rawEvents = body.events;
+  if (!Array.isArray(rawEvents) || rawEvents.length === 0) {
+    throw new ApiError(400, "webhook_events_invalid", "At least one event type is required", {
+      available: [WEBHOOK_WILDCARD, ...WEBHOOK_EVENT_TYPES],
+    });
+  }
+  const events: string[] = [];
+  for (const entry of rawEvents) {
+    if (typeof entry !== "string" || !entry.trim()) {
+      throw new ApiError(400, "webhook_events_invalid", "Event types must be non-empty strings");
+    }
+    const value = entry.trim();
+    if (!isKnownWebhookEvent(value)) {
+      throw new ApiError(400, "webhook_events_invalid", `Unknown event type: ${value}`, {
+        event: value,
+        available: [WEBHOOK_WILDCARD, ...WEBHOOK_EVENT_TYPES],
+      });
+    }
+    if (!events.includes(value)) events.push(value);
+  }
+
+  let secret: string | undefined;
+  let generatedSecret = false;
+  if (body.secret === undefined || body.secret === null) {
+    // Unsigned deliveries give a subscriber no way to tell iPolloWork from anyone who
+    // learned the URL, so a secret is always present — minted here when none was given.
+    secret = randomBytes(GENERATED_SECRET_BYTES).toString("hex");
+    generatedSecret = true;
+  } else if (typeof body.secret !== "string") {
+    throw new ApiError(400, "webhook_secret_invalid", "Webhook secret must be a string");
+  } else if (
+    body.secret.length < WEBHOOK_SECRET_MIN_LENGTH ||
+    body.secret.length > WEBHOOK_SECRET_MAX_LENGTH
+  ) {
+    throw new ApiError(
+      400,
+      "webhook_secret_invalid",
+      `Webhook secret must be between ${WEBHOOK_SECRET_MIN_LENGTH} and ${WEBHOOK_SECRET_MAX_LENGTH} characters`,
+      { minLength: WEBHOOK_SECRET_MIN_LENGTH, maxLength: WEBHOOK_SECRET_MAX_LENGTH },
+    );
+  } else {
+    secret = body.secret;
+  }
+
+  if (body.active !== undefined && typeof body.active !== "boolean") {
+    throw new ApiError(400, "webhook_active_invalid", "Webhook active must be a boolean");
+  }
+
+  return {
+    url,
+    events,
+    active: body.active !== false,
+    generatedSecret,
+    ...(secret ? { secret } : {}),
+  };
+}
+
+/**
+ * Fans one event out to every matching subscription in a workspace.
+ *
+ * Exported for the modules that produce events (sessions, tasks) so they do not each
+ * reimplement matching and delivery. The URL is re-validated at send time: a record may
+ * predate a tightening of the rules, or have been edited into the JSON store by hand, and
+ * a stored URL is not evidence that the URL is still allowed.
+ */
+export async function dispatchWebhookEvent(
+  store: WebhookStoreLike,
+  event: { workspaceId: string; type: string; data: unknown },
+  opts: WebhookDeliveryOptions & { allowPrivate?: boolean } = {},
+): Promise<WebhookDeliveryResult[]> {
+  const { allowPrivate, ...deliveryOptions } = opts;
+  const subscriptions = await store.listForEvent(event.workspaceId, event.type);
+  const allowed = subscriptions.filter(
+    (subscription) => validateWebhookUrl(subscription.url, { allowPrivate: allowPrivate === true }).ok,
+  );
+  return Promise.all(
+    allowed.map((subscription) =>
+      deliverWebhook(
+        {
+          url: subscription.url,
+          id: subscription.id,
+          ...(subscription.secret ? { secret: subscription.secret } : {}),
+        },
+        { type: event.type, data: event.data, workspaceId: event.workspaceId },
+        deliveryOptions,
+      ),
+    ),
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Schemas                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const publicWebhookSchema: JsonSchema = {
+  type: "object",
+  required: ["id", "workspaceId", "url", "events", "active", "createdAt", "hasSecret"],
+  properties: {
+    id: { type: "string" },
+    workspaceId: { type: "string" },
+    url: { type: "string", format: "uri" },
+    events: { type: "array", items: { type: "string" } },
+    active: { type: "boolean" },
+    createdAt: { type: "integer" },
+    hasSecret: {
+      type: "boolean",
+      description: "Whether a signing secret is configured. The secret is never returned.",
+    },
+  },
+};
+
+const deliveryResultSchema: JsonSchema = {
+  type: "object",
+  required: ["deliveryId", "event", "ok", "attempts"],
+  properties: {
+    deliveryId: { type: "string" },
+    event: { type: "string" },
+    ok: { type: "boolean" },
+    status: { type: "integer" },
+    error: { type: "string" },
+    attempts: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          attempt: { type: "integer" },
+          status: { type: "integer" },
+          error: { type: "string" },
+          retryDelayMs: { type: "integer" },
+        },
+      },
+    },
+  },
+};
+
+const createWebhookBodySchema: JsonSchema = {
+  type: "object",
+  required: ["url", "events"],
+  additionalProperties: false,
+  properties: {
+    url: {
+      type: "string",
+      format: "uri",
+      maxLength: WEBHOOK_URL_MAX_LENGTH,
+      description:
+        "http(s) endpoint. Loopback, link-local and private addresses are rejected unless "
+        + "IPOLLOWORK_WEBHOOK_ALLOW_PRIVATE=1 is set on the server.",
+    },
+    events: {
+      type: "array",
+      minItems: 1,
+      items: { type: "string", enum: [WEBHOOK_WILDCARD, ...WEBHOOK_EVENT_TYPES] },
+      description:
+        `Event types to receive. "${WEBHOOK_WILDCARD}" subscribes to all of them. `
+        + "Only task events are deliverable today; session-level engine events reach clients "
+        + "over SSE and are rejected here rather than accepted into a subscription that "
+        + "could never fire.",
+    },
+    secret: {
+      type: "string",
+      minLength: WEBHOOK_SECRET_MIN_LENGTH,
+      maxLength: WEBHOOK_SECRET_MAX_LENGTH,
+      description: "Signing key. Generated server-side when omitted, and returned once at creation.",
+    },
+    active: { type: "boolean", default: true },
+  },
+};
+
+const workspacePathParams: JsonSchema = {
+  type: "object",
+  required: ["workspaceId"],
+  properties: { workspaceId: { type: "string" } },
+};
+
+const webhookPathParams: JsonSchema = {
+  type: "object",
+  required: ["workspaceId", "webhookId"],
+  properties: { workspaceId: { type: "string" }, webhookId: { type: "string" } },
+};
+
+/* -------------------------------------------------------------------------- */
+/* Module                                                                     */
+/* -------------------------------------------------------------------------- */
+
+function resolveStore(context: ApiModuleContext): WebhookStoreLike {
+  const injected = context.services.webhookStore;
+  if (injected && typeof injected === "object") return injected as WebhookStoreLike;
+  return new WebhookStore(context.config);
+}
+
+function resolveFetch(context: ApiModuleContext): typeof fetch | undefined {
+  const injected = context.services.webhookFetch;
+  return typeof injected === "function" ? (injected as typeof fetch) : undefined;
+}
+
+async function resolveWorkspaceId(context: ApiModuleContext, ctx: RequestContext): Promise<string> {
+  const param = ctx.params.workspaceId ?? "";
+  const workspace = (await context.resolveWorkspace(context.config, param)) as { id?: unknown } | null;
+  const resolved = workspace && typeof workspace.id === "string" ? workspace.id : "";
+  return resolved || param;
+}
+
+export const webhooksModule: ApiModule = {
+  id: "webhooks",
+  title: "Webhooks",
+  description:
+    "Outbound event subscriptions for a workspace, with HMAC-signed deliveries and bounded retries.",
+  version: "1.0.0",
+  stability: "preview",
+
+  register(context: ApiModuleContext): ApiOperation[] {
+    // Resolved once per registration; the file-backed store keeps an in-process cache, so
+    // building a new one per request would re-read the JSON file on every call.
+    let store: WebhookStoreLike | undefined;
+    const getStore = (): WebhookStoreLike => (store ??= resolveStore(context));
+
+    // Read at request time rather than at registration: a test (and an operator reloading
+    // config) can flip the opt-in without rebuilding the route table.
+    const allowPrivate = (): boolean => webhookPrivateNetworkAllowed();
+
+    const requireWebhook = async (ctx: RequestContext) => {
+      const workspaceId = await resolveWorkspaceId(context, ctx);
+      const webhookId = ctx.params.webhookId ?? "";
+      const record = await getStore().get(workspaceId, webhookId);
+      if (!record) {
+        throw new ApiError(404, "webhook_not_found", "Webhook not found", { webhookId });
+      }
+      return { workspaceId, record };
+    };
+
+    return [
+      {
+        operationId: "createWebhook",
+        method: "POST",
+        path: "/api/v1/workspaces/:workspaceId/webhooks",
+        summary: "Create a webhook subscription",
+        description:
+          "Registers an endpoint to receive workspace events. The signing secret is returned only "
+          + "when the server generated it, and is never readable afterwards.",
+        effect: "write",
+        pathParams: workspacePathParams,
+        requestBody: createWebhookBodySchema,
+        responses: {
+          201: {
+            description: "The created subscription.",
+            schema: {
+              type: "object",
+              required: ["webhook"],
+              properties: {
+                webhook: publicWebhookSchema,
+                secret: {
+                  type: "string",
+                  description: "Present only when generated by the server. Shown once; store it now.",
+                },
+              },
+            },
+          },
+          400: { description: "The url, events or secret failed validation." },
+          409: { description: `The workspace already has ${WEBHOOK_MAX_PER_WORKSPACE} webhooks.` },
+        },
+        handler: async (ctx) => {
+          const workspaceId = await resolveWorkspaceId(context, ctx);
+          const body = await context.readJsonBody(ctx.request);
+          const input = parseCreateWebhookInput(body, { allowPrivate: allowPrivate() });
+          const createInput: CreateWebhookInput = {
+            workspaceId,
+            url: input.url,
+            events: input.events,
+            active: input.active,
+            ...(input.secret ? { secret: input.secret } : {}),
+          };
+          const record = await getStore().create(createInput);
+          return context.jsonResponse(
+            {
+              webhook: toPublicWebhook(record),
+              ...(input.generatedSecret && input.secret ? { secret: input.secret } : {}),
+            },
+            201,
+          );
+        },
+      },
+      {
+        operationId: "listWebhooks",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/webhooks",
+        summary: "List webhook subscriptions",
+        effect: "read",
+        pathParams: workspacePathParams,
+        responses: {
+          200: {
+            description: "Subscriptions for the workspace, without their secrets.",
+            schema: {
+              type: "object",
+              required: ["webhooks"],
+              properties: { webhooks: { type: "array", items: publicWebhookSchema } },
+            },
+          },
+        },
+        handler: async (ctx) => {
+          const workspaceId = await resolveWorkspaceId(context, ctx);
+          const records = await getStore().list(workspaceId);
+          return context.jsonResponse({ webhooks: records.map((record) => toPublicWebhook(record)) });
+        },
+      },
+      {
+        operationId: "getWebhook",
+        method: "GET",
+        path: "/api/v1/workspaces/:workspaceId/webhooks/:webhookId",
+        summary: "Get a webhook subscription",
+        effect: "read",
+        pathParams: webhookPathParams,
+        responses: {
+          200: {
+            description: "The subscription, without its secret.",
+            schema: { type: "object", required: ["webhook"], properties: { webhook: publicWebhookSchema } },
+          },
+          404: { description: "No such webhook in this workspace." },
+        },
+        handler: async (ctx) => {
+          const { record } = await requireWebhook(ctx);
+          return context.jsonResponse({ webhook: toPublicWebhook(record) });
+        },
+      },
+      {
+        operationId: "deleteWebhook",
+        method: "DELETE",
+        path: "/api/v1/workspaces/:workspaceId/webhooks/:webhookId",
+        summary: "Delete a webhook subscription",
+        effect: "destructive",
+        pathParams: webhookPathParams,
+        responses: {
+          200: {
+            description: "The subscription was removed.",
+            schema: {
+              type: "object",
+              required: ["deleted", "id"],
+              properties: { deleted: { type: "boolean" }, id: { type: "string" } },
+            },
+          },
+          404: { description: "No such webhook in this workspace." },
+        },
+        handler: async (ctx) => {
+          const { workspaceId, record } = await requireWebhook(ctx);
+          const deleted = await getStore().delete(workspaceId, record.id);
+          return context.jsonResponse({ deleted, id: record.id });
+        },
+      },
+      {
+        operationId: "testWebhook",
+        method: "POST",
+        path: "/api/v1/workspaces/:workspaceId/webhooks/:webhookId/test",
+        summary: "Send a test delivery to a webhook",
+        description:
+          `Sends a single signed ${WEBHOOK_TEST_EVENT} delivery, bypassing the event filter. `
+          + "One attempt only — this is an interactive check, not a queued delivery, so it does not "
+          + `run the ${WEBHOOK_MAX_ATTEMPTS}-attempt retry ladder.`,
+        effect: "write",
+        pathParams: webhookPathParams,
+        responses: {
+          200: {
+            description: "The delivery outcome. A non-2xx from the subscriber is reported here, not raised.",
+            schema: { type: "object", required: ["delivery"], properties: { delivery: deliveryResultSchema } },
+          },
+          400: { description: "The stored url is no longer allowed by the current SSRF policy." },
+          404: { description: "No such webhook in this workspace." },
+        },
+        handler: async (ctx) => {
+          const { workspaceId, record } = await requireWebhook(ctx);
+
+          const verdict = validateWebhookUrl(record.url, { allowPrivate: allowPrivate() });
+          if (!verdict.ok) {
+            throw new ApiError(400, "webhook_url_invalid", `Webhook url is not allowed: ${verdict.reason}`, {
+              reason: verdict.reason,
+            });
+          }
+
+          const fetchImpl = resolveFetch(context);
+          const delivery = await deliverWebhook(
+            {
+              url: record.url,
+              id: record.id,
+              ...(record.secret ? { secret: record.secret } : {}),
+            },
+            {
+              type: WEBHOOK_TEST_EVENT,
+              workspaceId,
+              data: {
+                webhookId: record.id,
+                events: record.events,
+                message: "Test delivery from iPolloWork.",
+              },
+            },
+            {
+              maxAttempts: 1,
+              timeoutMs: TEST_DELIVERY_TIMEOUT_MS,
+              ...(fetchImpl ? { fetchImpl } : {}),
+            },
+          );
+
+          return context.jsonResponse({ delivery });
+        },
+      },
+    ];
+  },
+};
+
+export default webhooksModule;

--- a/apps/server/src/api/modules/webhooks/store.ts
+++ b/apps/server/src/api/modules/webhooks/store.ts
@@ -1,0 +1,346 @@
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+
+import { ApiError } from "../../../errors.js";
+import type { ServerConfig } from "../../../types.js";
+import { ensureDir, exists } from "../../../utils.js";
+import { ENGINE_EVENT_TYPES } from "../../engine/types.js";
+
+/**
+ * Webhook subscription storage.
+ *
+ * Backed by a JSON file resolved exactly like the token store (`src/tokens.ts`): an
+ * explicit env override wins, otherwise the file sits next to the server config, falling
+ * back to `~/.config/ipollowork`. Reusing that convention matters more than the storage
+ * engine does — an operator who knows where `tokens.json` lives knows where the webhook
+ * secrets live, and can lock the directory down once for both.
+ */
+
+/* -------------------------------------------------------------------------- */
+/* Event catalogue                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** Task lifecycle events, owned by the tasks module but subscribable here. */
+export const WEBHOOK_TASK_EVENT_TYPES = [
+  "task.created",
+  "task.completed",
+  "task.failed",
+  "task.awaiting_approval",
+] as const;
+
+/**
+ * Everything a subscription may name.
+ *
+ * Only the task events are listed, because only the task store is bridged to delivery
+ * (`bridgeTaskEventsToWebhooks` in `../../index.ts`). Session-level engine events reach
+ * clients over SSE, and nothing forwards them to webhooks yet: publishing them here would
+ * accept a subscription to `message.delta` that could never fire, which is worse than not
+ * offering it — the caller has no way to tell "no activity" from "wired to nothing".
+ *
+ * Bridging engine events means holding a per-workspace engine subscription open for the
+ * life of the server; that belongs in its own change, and this list is what it should grow.
+ */
+export const WEBHOOK_EVENT_TYPES: readonly string[] = [...WEBHOOK_TASK_EVENT_TYPES];
+
+/**
+ * Engine events that are deliberately not subscribable yet, kept here so the reason is
+ * discoverable from the code rather than only from a changelog.
+ */
+export const WEBHOOK_UNBRIDGED_EVENT_TYPES: readonly string[] = [...ENGINE_EVENT_TYPES];
+
+/** Subscribes to every event, including ones added after the subscription was created. */
+export const WEBHOOK_WILDCARD = "*";
+
+/**
+ * Sent only by `testWebhook`. Deliberately not in `WEBHOOK_EVENT_TYPES`: it is not a
+ * product event, and a test ping is delivered to its target regardless of the filter.
+ */
+export const WEBHOOK_TEST_EVENT = "webhook.test";
+
+export function isKnownWebhookEvent(value: string): boolean {
+  return value === WEBHOOK_WILDCARD || WEBHOOK_EVENT_TYPES.includes(value);
+}
+
+/** True when `subscription` should receive `eventType`. */
+export function matchesWebhookEvent(events: readonly string[], eventType: string): boolean {
+  return events.includes(WEBHOOK_WILDCARD) || events.includes(eventType);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Records                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface WebhookSubscription {
+  id: string;
+  workspaceId: string;
+  url: string;
+  events: string[];
+  active: boolean;
+  createdAt: number;
+  /**
+   * Signing key. Present only in the on-disk record and in the delivery path — it is
+   * never part of an API response. See `toPublicWebhook`.
+   */
+  secret?: string;
+}
+
+export interface PublicWebhook {
+  id: string;
+  workspaceId: string;
+  url: string;
+  events: string[];
+  active: boolean;
+  createdAt: number;
+  /** Whether a signing secret is configured. The secret itself is never returned. */
+  hasSecret: boolean;
+}
+
+/**
+ * The only shape a read endpoint may return.
+ *
+ * A webhook secret is a bearer credential for impersonating iPolloWork to the subscriber:
+ * anyone holding it can forge a signed delivery. It is write-only by construction here —
+ * the field is dropped and replaced with a boolean — rather than by each handler
+ * remembering to redact, because a handler that forgets is a silent credential leak.
+ */
+export function toPublicWebhook(record: WebhookSubscription): PublicWebhook {
+  return {
+    id: record.id,
+    workspaceId: record.workspaceId,
+    url: record.url,
+    events: [...record.events],
+    active: record.active,
+    createdAt: record.createdAt,
+    hasSecret: typeof record.secret === "string" && record.secret.length > 0,
+  };
+}
+
+export interface CreateWebhookInput {
+  workspaceId: string;
+  url: string;
+  events: string[];
+  secret?: string;
+  active?: boolean;
+}
+
+/** What the module needs from storage, so tests can supply an in-memory implementation. */
+export interface WebhookStoreLike {
+  list(workspaceId: string): Promise<WebhookSubscription[]>;
+  get(workspaceId: string, id: string): Promise<WebhookSubscription | null>;
+  create(input: CreateWebhookInput): Promise<WebhookSubscription>;
+  delete(workspaceId: string, id: string): Promise<boolean>;
+  listForEvent(workspaceId: string, eventType: string): Promise<WebhookSubscription[]>;
+}
+
+/* -------------------------------------------------------------------------- */
+/* File-backed store                                                          */
+/* -------------------------------------------------------------------------- */
+
+interface WebhookStoreFile {
+  schemaVersion: number;
+  updatedAt: number;
+  webhooks: WebhookSubscription[];
+}
+
+/** Bounds the fan-out of a single event and the size of the store file. */
+export const WEBHOOK_MAX_PER_WORKSPACE = 50;
+
+export function resolveWebhookStorePath(config: ServerConfig): string {
+  const override = (process.env.IPOLLOWORK_WEBHOOK_STORE ?? "").trim();
+  if (override) return resolve(override);
+
+  const configPath = config.configPath?.trim();
+  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "ipollowork");
+  return join(configDir, "webhooks.json");
+}
+
+function parseRecord(value: unknown): WebhookSubscription | null {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Partial<WebhookSubscription>;
+  const id = typeof record.id === "string" ? record.id : "";
+  const workspaceId = typeof record.workspaceId === "string" ? record.workspaceId : "";
+  const url = typeof record.url === "string" ? record.url : "";
+  if (!id || !workspaceId || !url) return null;
+  const events = Array.isArray(record.events)
+    ? record.events.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+  if (events.length === 0) return null;
+  const secret = typeof record.secret === "string" && record.secret ? record.secret : undefined;
+  return {
+    id,
+    workspaceId,
+    url,
+    events,
+    active: record.active !== false,
+    createdAt: typeof record.createdAt === "number" ? record.createdAt : Date.now(),
+    ...(secret ? { secret } : {}),
+  };
+}
+
+async function readWebhookStore(path: string): Promise<WebhookStoreFile> {
+  if (!(await exists(path))) {
+    return { schemaVersion: 1, updatedAt: Date.now(), webhooks: [] };
+  }
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<WebhookStoreFile>;
+    const webhooks = Array.isArray(parsed.webhooks)
+      ? parsed.webhooks
+        .map((entry) => parseRecord(entry))
+        .filter((entry): entry is WebhookSubscription => Boolean(entry))
+      : [];
+    return {
+      schemaVersion: typeof parsed.schemaVersion === "number" ? parsed.schemaVersion : 1,
+      updatedAt: typeof parsed.updatedAt === "number" ? parsed.updatedAt : Date.now(),
+      webhooks,
+    };
+  } catch {
+    return { schemaVersion: 1, updatedAt: Date.now(), webhooks: [] };
+  }
+}
+
+async function writeWebhookStore(path: string, webhooks: WebhookSubscription[]): Promise<void> {
+  await ensureDir(dirname(path));
+  const payload: WebhookStoreFile = {
+    schemaVersion: 1,
+    updatedAt: Date.now(),
+    webhooks,
+  };
+  // 0600: the file holds signing secrets, so it is no more readable than the token store.
+  await writeFile(path, JSON.stringify(payload, null, 2) + "\n", { encoding: "utf8", mode: 0o600 });
+}
+
+export class WebhookStore implements WebhookStoreLike {
+  private path: string;
+  private loaded = false;
+  private webhooks: WebhookSubscription[] = [];
+  /** Serializes writes so two concurrent creates cannot each overwrite the other. */
+  private queue: Promise<unknown> = Promise.resolve();
+
+  constructor(config: ServerConfig) {
+    this.path = resolveWebhookStorePath(config);
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    const store = await readWebhookStore(this.path);
+    this.webhooks = store.webhooks;
+    this.loaded = true;
+  }
+
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const next = this.queue.then(task, task);
+    this.queue = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  async list(workspaceId: string): Promise<WebhookSubscription[]> {
+    await this.ensureLoaded();
+    return this.webhooks.filter((webhook) => webhook.workspaceId === workspaceId);
+  }
+
+  async get(workspaceId: string, id: string): Promise<WebhookSubscription | null> {
+    await this.ensureLoaded();
+    return this.webhooks.find((webhook) => webhook.workspaceId === workspaceId && webhook.id === id) ?? null;
+  }
+
+  async listForEvent(workspaceId: string, eventType: string): Promise<WebhookSubscription[]> {
+    const all = await this.list(workspaceId);
+    return all.filter((webhook) => webhook.active && matchesWebhookEvent(webhook.events, eventType));
+  }
+
+  create(input: CreateWebhookInput): Promise<WebhookSubscription> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const existing = this.webhooks.filter((webhook) => webhook.workspaceId === input.workspaceId);
+      if (existing.length >= WEBHOOK_MAX_PER_WORKSPACE) {
+        throw new ApiError(
+          409,
+          "webhook_limit_reached",
+          `Workspace already has ${WEBHOOK_MAX_PER_WORKSPACE} webhooks`,
+          { limit: WEBHOOK_MAX_PER_WORKSPACE },
+        );
+      }
+      const record: WebhookSubscription = {
+        id: randomUUID(),
+        workspaceId: input.workspaceId,
+        url: input.url,
+        events: [...input.events],
+        active: input.active !== false,
+        createdAt: Date.now(),
+        ...(input.secret ? { secret: input.secret } : {}),
+      };
+      this.webhooks = [record, ...this.webhooks];
+      await writeWebhookStore(this.path, this.webhooks);
+      return record;
+    });
+  }
+
+  delete(workspaceId: string, id: string): Promise<boolean> {
+    return this.enqueue(async () => {
+      await this.ensureLoaded();
+      const index = this.webhooks.findIndex(
+        (webhook) => webhook.workspaceId === workspaceId && webhook.id === id,
+      );
+      if (index === -1) return false;
+      this.webhooks.splice(index, 1);
+      await writeWebhookStore(this.path, this.webhooks);
+      return true;
+    });
+  }
+}
+
+/**
+ * Non-persistent store, used by tests and by any caller that wants webhook routing
+ * without touching the filesystem.
+ */
+export class MemoryWebhookStore implements WebhookStoreLike {
+  private webhooks: WebhookSubscription[] = [];
+
+  async list(workspaceId: string): Promise<WebhookSubscription[]> {
+    return this.webhooks.filter((webhook) => webhook.workspaceId === workspaceId);
+  }
+
+  async get(workspaceId: string, id: string): Promise<WebhookSubscription | null> {
+    return this.webhooks.find((webhook) => webhook.workspaceId === workspaceId && webhook.id === id) ?? null;
+  }
+
+  async listForEvent(workspaceId: string, eventType: string): Promise<WebhookSubscription[]> {
+    const all = await this.list(workspaceId);
+    return all.filter((webhook) => webhook.active && matchesWebhookEvent(webhook.events, eventType));
+  }
+
+  async create(input: CreateWebhookInput): Promise<WebhookSubscription> {
+    const existing = this.webhooks.filter((webhook) => webhook.workspaceId === input.workspaceId);
+    if (existing.length >= WEBHOOK_MAX_PER_WORKSPACE) {
+      throw new ApiError(
+        409,
+        "webhook_limit_reached",
+        `Workspace already has ${WEBHOOK_MAX_PER_WORKSPACE} webhooks`,
+        { limit: WEBHOOK_MAX_PER_WORKSPACE },
+      );
+    }
+    const record: WebhookSubscription = {
+      id: randomUUID(),
+      workspaceId: input.workspaceId,
+      url: input.url,
+      events: [...input.events],
+      active: input.active !== false,
+      createdAt: Date.now(),
+      ...(input.secret ? { secret: input.secret } : {}),
+    };
+    this.webhooks = [record, ...this.webhooks];
+    return record;
+  }
+
+  async delete(workspaceId: string, id: string): Promise<boolean> {
+    const index = this.webhooks.findIndex(
+      (webhook) => webhook.workspaceId === workspaceId && webhook.id === id,
+    );
+    if (index === -1) return false;
+    this.webhooks.splice(index, 1);
+    return true;
+  }
+}

--- a/apps/server/src/api/openapi.test.ts
+++ b/apps/server/src/api/openapi.test.ts
@@ -1,0 +1,497 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ApiModule, ApiOperation, RegisteredApiModule } from "./module.js";
+import { renderApiDocsHtml } from "./modules/openapi/module.js";
+import {
+  buildOpenApiDocument,
+  extractPathParameterNames,
+  toOpenApiPath,
+  type BuildOpenApiDocumentInput,
+} from "./openapi.js";
+
+function moduleOf(id: string, extra: Partial<ApiModule> = {}): ApiModule {
+  return {
+    id,
+    title: `${id} title`,
+    description: `${id} description`,
+    version: "1.2.3",
+    stability: "stable",
+    register: () => [],
+    ...extra,
+  };
+}
+
+const noop: ApiOperation["handler"] = async () => Response.json({});
+
+/**
+ * A fresh fixture on every call.
+ *
+ * Determinism is only meaningful if it survives fresh objects: reusing one frozen fixture
+ * would hide an accidental dependency on object identity or on a mutated map.
+ */
+function fixture(): BuildOpenApiDocumentInput {
+  const sessions: ApiOperation[] = [
+    {
+      operationId: "listSessions",
+      method: "GET",
+      path: "/api/v1/sessions",
+      summary: "List sessions",
+      description: "Lists sessions the token can see.",
+      effect: "read",
+      query: {
+        type: "object",
+        properties: {
+          cursor: { type: "string", description: "Opaque page cursor." },
+          limit: { type: "integer", minimum: 1, maximum: 200 },
+        },
+        required: ["cursor"],
+      },
+      handler: noop,
+    },
+    {
+      operationId: "getSession",
+      method: "GET",
+      path: "/api/v1/workspaces/:workspaceId/sessions/:id",
+      summary: "Get a session",
+      effect: "read",
+      pathParams: {
+        type: "object",
+        properties: {
+          workspaceId: { type: "string", description: "Workspace identifier." },
+        },
+      },
+      handler: noop,
+    },
+    {
+      operationId: "createSession",
+      method: "POST",
+      path: "/api/v1/workspaces/:workspaceId/sessions",
+      summary: "Create a session",
+      effect: "write",
+      requestBody: {
+        type: "object",
+        required: ["agent"],
+        properties: { agent: { type: "string" }, model: { type: "string" } },
+      },
+      handler: noop,
+    },
+    {
+      operationId: "streamSessionEvents",
+      method: "GET",
+      path: "/api/v1/workspaces/:workspaceId/sessions/:id/events",
+      summary: "Stream session events",
+      effect: "read",
+      streaming: "sse",
+      handler: noop,
+    },
+    {
+      operationId: "promptSessionLegacy",
+      method: "POST",
+      path: "/api/v1/sessions/:id/prompt",
+      summary: "Prompt a session (legacy alias)",
+      effect: "write",
+      deprecated: true,
+      handler: noop,
+    },
+    {
+      operationId: "debugSessionInternals",
+      method: "GET",
+      path: "/api/v1/internal/sessions/debug",
+      summary: "Internal debug dump",
+      effect: "read",
+      internal: true,
+      handler: noop,
+    },
+  ];
+
+  const tasks: ApiOperation[] = [
+    {
+      operationId: "deleteTask",
+      method: "DELETE",
+      path: "/api/v1/tasks/:taskId",
+      summary: "Delete a task",
+      effect: "destructive",
+      scope: "owner",
+      handler: noop,
+    },
+    {
+      operationId: "reloadTasks",
+      method: "POST",
+      path: "/api/v1/tasks/reload",
+      summary: "Reload the task table",
+      effect: "write",
+      auth: "host",
+      handler: noop,
+    },
+    {
+      operationId: "getTaskHealth",
+      method: "GET",
+      path: "/api/v1/tasks/health",
+      summary: "Task subsystem health",
+      effect: "read",
+      auth: "none",
+      handler: noop,
+    },
+  ];
+
+  // Registration order is deliberately not alphabetical, so a sorted output proves sorting.
+  const modules: RegisteredApiModule[] = [
+    { module: moduleOf("tasks", { stability: "preview", dependsOn: ["sessions"] }), operations: tasks },
+    { module: moduleOf("sessions"), operations: sessions },
+  ];
+
+  return {
+    operations: [...sessions, ...tasks],
+    modules,
+    serverVersion: "0.21.1",
+  };
+}
+
+const document = buildOpenApiDocument(fixture()) as Record<string, any>;
+const paths = document.paths as Record<string, any>;
+
+describe("path syntax conversion", () => {
+  test("converts :param to {param}", () => {
+    expect(toOpenApiPath("/api/v1/workspaces/:workspaceId/sessions/:id")).toBe(
+      "/api/v1/workspaces/{workspaceId}/sessions/{id}",
+    );
+    expect(toOpenApiPath("/api/v1/sessions")).toBe("/api/v1/sessions");
+  });
+
+  test("extracts parameter names in order, deduplicated", () => {
+    expect(extractPathParameterNames("/a/:one/b/:two/c/:one")).toEqual(["one", "two"]);
+    expect(extractPathParameterNames("/a/b")).toEqual([]);
+  });
+
+  test("the document keys use OpenAPI syntax", () => {
+    expect(Object.keys(paths)).toContain("/api/v1/workspaces/{workspaceId}/sessions/{id}");
+    expect(Object.keys(paths).some((path) => path.includes(":"))).toBe(false);
+  });
+});
+
+describe("document skeleton", () => {
+  test("is an OpenAPI 3.1.0 document carrying the server version", () => {
+    expect(document.openapi).toBe("3.1.0");
+    expect(document.jsonSchemaDialect).toBe("https://json-schema.org/draft/2020-12/schema");
+    expect(document.info.version).toBe("0.21.1");
+    expect(typeof document.info.title).toBe("string");
+    expect(Array.isArray(document.servers)).toBe(true);
+  });
+
+  test("tags come from the owning modules, sorted, with module metadata", () => {
+    expect((document.tags as any[]).map((tag) => tag.name)).toEqual(["sessions", "tasks"]);
+    const tasksTag = (document.tags as any[]).find((tag) => tag.name === "tasks");
+    expect(tasksTag.description).toBe("tasks description");
+    expect(tasksTag["x-ipollowork-stability"]).toBe("preview");
+    expect(tasksTag["x-ipollowork-depends-on"]).toEqual(["sessions"]);
+  });
+
+  test("each operation is tagged with its owning module", () => {
+    expect(paths["/api/v1/sessions"].get.tags).toEqual(["sessions"]);
+    expect(paths["/api/v1/tasks/{taskId}"].delete.tags).toEqual(["tasks"]);
+  });
+});
+
+describe("parameters", () => {
+  test("path parameters are extracted and marked required", () => {
+    const parameters = paths["/api/v1/workspaces/{workspaceId}/sessions/{id}"].get.parameters as any[];
+    expect(parameters.map((parameter) => parameter.name)).toEqual(["workspaceId", "id"]);
+    expect(parameters.every((parameter) => parameter.in === "path")).toBe(true);
+    expect(parameters.every((parameter) => parameter.required === true)).toBe(true);
+    // A declared pathParams schema enriches the parameter; the rest fall back to string.
+    expect(parameters[0].description).toBe("Workspace identifier.");
+    expect(parameters[1].schema).toEqual({ type: "string" });
+  });
+
+  test("query parameters come from the query schema with its required list", () => {
+    const parameters = paths["/api/v1/sessions"].get.parameters as any[];
+    expect(parameters).toEqual([
+      {
+        name: "cursor",
+        in: "query",
+        required: true,
+        description: "Opaque page cursor.",
+        schema: { type: "string", description: "Opaque page cursor." },
+      },
+      {
+        name: "limit",
+        in: "query",
+        required: false,
+        schema: { type: "integer", minimum: 1, maximum: 200 },
+      },
+    ]);
+  });
+
+  test("an operation with neither kind of parameter declares none", () => {
+    expect(paths["/api/v1/tasks/health"].get.parameters).toBeUndefined();
+  });
+});
+
+describe("request bodies", () => {
+  test("are emitted as required application/json with the declared schema", () => {
+    const body = paths["/api/v1/workspaces/{workspaceId}/sessions"].post.requestBody;
+    expect(body.required).toBe(true);
+    expect(body.content["application/json"].schema).toEqual({
+      type: "object",
+      required: ["agent"],
+      properties: { agent: { type: "string" }, model: { type: "string" } },
+    });
+  });
+
+  test("the emitted schema is a copy, not a reference to module state", () => {
+    const input = fixture();
+    const built = buildOpenApiDocument(input) as Record<string, any>;
+    const source = input.operations.find((operation) => operation.operationId === "createSession");
+    (source!.requestBody!.properties as Record<string, unknown>).injected = { type: "string" };
+    const emitted = built.paths["/api/v1/workspaces/{workspaceId}/sessions"].post.requestBody
+      .content["application/json"].schema.properties;
+    expect(Object.keys(emitted)).toEqual(["agent", "model"]);
+  });
+});
+
+describe("errors", () => {
+  test("the ApiError component matches the real error body shape", () => {
+    const schema = document.components.schemas.ApiError;
+    expect(schema.type).toBe("object");
+    expect(schema.required).toEqual(["code", "message"]);
+    expect(Object.keys(schema.properties)).toEqual(["code", "message", "details"]);
+    expect(schema.properties.code.type).toBe("string");
+    expect(schema.properties.message.type).toBe("string");
+  });
+
+  test("the shared error responses all reference the ApiError schema", () => {
+    const responses = document.components.responses;
+    expect(Object.keys(responses)).toEqual([
+      "BadRequest",
+      "Forbidden",
+      "InternalServerError",
+      "NotFound",
+      "Unauthorized",
+    ]);
+    for (const name of Object.keys(responses)) {
+      expect(responses[name].content["application/json"].schema).toEqual({
+        $ref: "#/components/schemas/ApiError",
+      });
+    }
+  });
+
+  test("operations reference the shared error responses", () => {
+    const responses = paths["/api/v1/workspaces/{workspaceId}/sessions/{id}"].get.responses;
+    expect(Object.keys(responses)).toEqual(["200", "400", "401", "403", "404", "500"]);
+    expect(responses["404"]).toEqual({ $ref: "#/components/responses/NotFound" });
+    expect(responses["500"]).toEqual({ $ref: "#/components/responses/InternalServerError" });
+  });
+
+  test("404 is only documented where a resource is addressed by path", () => {
+    expect(Object.keys(paths["/api/v1/sessions"].get.responses)).toEqual(["200", "400", "401", "403", "500"]);
+  });
+
+  test("an unauthenticated read documents no 401 or 403", () => {
+    expect(Object.keys(paths["/api/v1/tasks/health"].get.responses)).toEqual(["200", "500"]);
+  });
+});
+
+describe("security and scopes", () => {
+  test("a single http bearer scheme documents the three token scopes", () => {
+    const scheme = document.components.securitySchemes.bearerAuth;
+    expect(scheme.type).toBe("http");
+    expect(scheme.scheme).toBe("bearer");
+    for (const scope of ["viewer", "collaborator", "owner"]) {
+      expect(scheme.description).toContain(`\`${scope}\``);
+    }
+    expect(document.security).toEqual([{ bearerAuth: [] }]);
+  });
+
+  test("the minimum scope for each operation lands in its description", () => {
+    expect(paths["/api/v1/sessions"].get.description).toContain("Minimum scope: `viewer` or higher.");
+    expect(paths["/api/v1/workspaces/{workspaceId}/sessions"].post.description)
+      .toContain("Minimum scope: `collaborator` or higher.");
+    // An explicit scope overrides the effect default, and `owner` has nothing above it.
+    expect(paths["/api/v1/tasks/{taskId}"].delete.description).toContain("Minimum scope: `owner`.");
+    expect(paths["/api/v1/tasks/{taskId}"].delete.description).not.toContain("or higher");
+  });
+
+  test("the declared description is kept and the effect is spelled out", () => {
+    const description = paths["/api/v1/sessions"].get.description as string;
+    expect(description.startsWith("Lists sessions the token can see.")).toBe(true);
+    expect(paths["/api/v1/workspaces/{workspaceId}/sessions"].post.description).toContain("403 read_only");
+    expect(paths["/api/v1/tasks/{taskId}"].delete.description).toContain("Effect: `destructive`");
+  });
+
+  test("host operations are documented as host-authenticated", () => {
+    const operation = paths["/api/v1/tasks/reload"].post;
+    expect(operation.description).toContain("host credentials");
+    expect(operation["x-ipollowork-auth"]).toBe("host");
+    expect(operation["x-ipollowork-scope"]).toBeNull();
+    expect(operation.security).toEqual([{ bearerAuth: [] }]);
+  });
+
+  test("an operation with auth none opts out of security", () => {
+    expect(paths["/api/v1/tasks/health"].get.security).toEqual([]);
+    expect(paths["/api/v1/tasks/health"].get.description).toContain("Authentication: none.");
+  });
+});
+
+describe("streaming", () => {
+  test("sse operations are documented as text/event-stream", () => {
+    const operation = paths["/api/v1/workspaces/{workspaceId}/sessions/{id}/events"].get;
+    expect(operation["x-ipollowork-streaming"]).toBe("sse");
+    expect(operation.responses["200"].content["text/event-stream"].schema.type).toBe("string");
+    expect(operation.responses["200"].content["application/json"]).toBeUndefined();
+    expect(operation.description).toContain("text/event-stream");
+  });
+
+  test("non-streaming operations answer with application/json", () => {
+    expect(paths["/api/v1/sessions"].get.responses["200"].content["application/json"]).toBeDefined();
+  });
+});
+
+describe("declared responses", () => {
+  test("override the generated defaults and default to the error schema for 4xx", () => {
+    const built = buildOpenApiDocument({
+      ...fixture(),
+      operations: [
+        {
+          operationId: "getThing",
+          method: "GET",
+          path: "/api/v1/thing",
+          summary: "Get a thing",
+          effect: "read",
+          responses: {
+            200: { description: "The thing.", schema: { type: "object", properties: { id: { type: "string" } } } },
+            409: { description: "The thing is busy." },
+          },
+          handler: noop,
+        },
+      ],
+      modules: [],
+    }) as Record<string, any>;
+
+    const responses = built.paths["/api/v1/thing"].get.responses;
+    expect(Object.keys(responses)).toEqual(["200", "401", "403", "409", "500"]);
+    expect(responses["200"].description).toBe("The thing.");
+    expect(responses["200"].content["application/json"].schema.properties.id).toEqual({ type: "string" });
+    expect(responses["409"].content["application/json"].schema).toEqual({
+      $ref: "#/components/schemas/ApiError",
+    });
+    // No owning module, so no tag is invented.
+    expect(built.paths["/api/v1/thing"].get.tags).toBeUndefined();
+    expect(built.paths["/api/v1/thing"].get["x-ipollowork-module"]).toBeNull();
+  });
+});
+
+describe("internal and deprecated operations", () => {
+  test("internal operations are excluded from the document", () => {
+    expect(Object.keys(paths)).not.toContain("/api/v1/internal/sessions/debug");
+    expect(JSON.stringify(document)).not.toContain("debugSessionInternals");
+  });
+
+  test("deprecated operations are flagged", () => {
+    expect(paths["/api/v1/sessions/{id}/prompt"].post.deprecated).toBe(true);
+    expect(paths["/api/v1/sessions"].get.deprecated).toBeUndefined();
+  });
+});
+
+describe("determinism", () => {
+  test("two builds of an equivalent input are deep-equal and byte-equal", () => {
+    const first = buildOpenApiDocument(fixture());
+    const second = buildOpenApiDocument(fixture());
+    expect(first).toEqual(second);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  test("paths are sorted and unaffected by module registration order", () => {
+    const forward = fixture();
+    const reversed = { ...fixture(), modules: [...fixture().modules].reverse() };
+    const a = buildOpenApiDocument(forward) as Record<string, any>;
+    const b = buildOpenApiDocument(reversed) as Record<string, any>;
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+
+    const keys = Object.keys(a.paths);
+    expect(keys).toEqual([...keys].sort());
+  });
+
+  test("methods within a path follow a fixed order", () => {
+    const built = buildOpenApiDocument({
+      operations: [
+        { operationId: "d", method: "DELETE", path: "/api/v1/x", summary: "d", effect: "destructive", handler: noop },
+        { operationId: "g", method: "GET", path: "/api/v1/x", summary: "g", effect: "read", handler: noop },
+        { operationId: "p", method: "POST", path: "/api/v1/x", summary: "p", effect: "write", handler: noop },
+      ],
+      modules: [],
+      serverVersion: "1.0.0",
+    }) as Record<string, any>;
+    expect(Object.keys(built.paths["/api/v1/x"])).toEqual(["get", "post", "delete"]);
+  });
+
+  test("top-level keys keep a stable order", () => {
+    expect(Object.keys(document)).toEqual([
+      "openapi",
+      "jsonSchemaDialect",
+      "info",
+      "servers",
+      "security",
+      "tags",
+      "paths",
+      "components",
+    ]);
+  });
+
+  test("nothing time-varying leaks into the document", () => {
+    const serialized = JSON.stringify(document);
+    expect(serialized).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/);
+  });
+});
+
+describe("api docs page", () => {
+  const hostile = "</script><script>alert('xss')</script>";
+
+  function render(): string {
+    const input = fixture();
+    input.modules[1]!.module = moduleOf("sessions", { description: hostile });
+    return renderApiDocsHtml({
+      document: buildOpenApiDocument(input),
+      specUrl: "/api/v1/openapi.json",
+    });
+  }
+
+  test("is self-contained: no external asset is referenced", () => {
+    const html = render();
+    expect(html).not.toContain("src=");
+    expect(html).not.toContain("http://");
+    expect(html).not.toContain("https://unpkg");
+    expect(html).not.toContain("cdn.");
+    expect(html).toContain("<style>");
+  });
+
+  test("escapes a hostile string so it cannot break out of the embedded document", () => {
+    const html = render();
+    // The literal closing tag never appears, so the script block cannot be terminated early.
+    expect(html).not.toContain(hostile);
+    expect(html).not.toContain("<script>alert");
+    expect(html).toContain("\\u003c/script\\u003e");
+    // Exactly the three script elements the page itself declares.
+    expect(html.split("<script").length - 1).toBe(3);
+    expect(html.split("</script>").length - 1).toBe(3);
+  });
+
+  test("the embedded document is still valid JSON carrying the hostile string verbatim", () => {
+    const html = render();
+    const match = html.match(/<script type="application\/json" id="openapi-document">([\s\S]*?)<\/script>/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1] as string) as Record<string, any>;
+    expect(parsed.openapi).toBe("3.1.0");
+    const sessionsTag = (parsed.tags as any[]).find((tag) => tag.name === "sessions");
+    expect(sessionsTag.description).toBe(hostile);
+  });
+
+  test("renders through textContent only, never innerHTML", () => {
+    expect(render()).not.toContain("innerHTML");
+  });
+
+  test("points its refresh control at the spec endpoint", () => {
+    const html = renderApiDocsHtml({ document: { openapi: "3.1.0" }, specUrl: "/api/v1/openapi.json" });
+    expect(html).toContain('id="spec-url"');
+    expect(html).toContain("fetch(specUrl");
+  });
+});

--- a/apps/server/src/api/openapi.ts
+++ b/apps/server/src/api/openapi.ts
@@ -1,0 +1,485 @@
+import { ApiError } from "../errors.js";
+import type { AuthMode } from "../routes/registry.js";
+import type { TokenScope } from "../types.js";
+import {
+  defaultScopeForEffect,
+  type ApiEffect,
+  type ApiOperation,
+  type ApiResponseSpec,
+  type JsonSchema,
+  type RegisteredApiModule,
+} from "./module.js";
+
+/**
+ * OpenAPI generation from the module declarations.
+ *
+ * The declaration in `module.ts` is the single source of truth for the route table, so it
+ * is also the single source of truth for the published document: everything here is
+ * derived, nothing is hand-maintained, and the two therefore cannot drift.
+ *
+ * The output is a pure function of its input — no timestamps, no environment lookups, no
+ * iteration over unordered maps. `buildOpenApiDocument(x)` twice produces byte-identical
+ * JSON, so the spec can be committed and a diff in CI means the API actually changed.
+ */
+
+export const OPENAPI_VERSION = "3.1.0";
+export const JSON_SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema";
+
+/** Name of the single security scheme. Bearer tokens are the only client credential. */
+export const SECURITY_SCHEME_NAME = "bearerAuth";
+
+export const API_ERROR_SCHEMA_NAME = "ApiError";
+export const API_ERROR_SCHEMA_REF = `#/components/schemas/${API_ERROR_SCHEMA_NAME}`;
+
+export interface BuildOpenApiDocumentInput {
+  operations: ApiOperation[];
+  modules: RegisteredApiModule[];
+  serverVersion: string;
+  /** Defaults to `iPolloWork Server API`. */
+  title?: string;
+  /** Replaces the generated top-level description. */
+  description?: string;
+}
+
+export type OpenApiDocument = Record<string, unknown>;
+
+/** OpenAPI renders the methods of a path in this order; fixing it keeps diffs small. */
+const METHOD_ORDER = ["get", "put", "post", "delete", "patch"] as const;
+
+const SCOPE_RANK: Record<TokenScope, number> = { viewer: 0, collaborator: 1, owner: 2 };
+
+const SCOPE_DESCRIPTIONS: ReadonlyArray<readonly [TokenScope, string]> = [
+  ["viewer", "read-only access to the workspaces the token is scoped to"],
+  ["collaborator", "everything `viewer` allows, plus write and destructive operations"],
+  ["owner", "everything `collaborator` allows, plus host-level administration"],
+];
+
+/** Standard error responses, keyed by status. Emitted into `components.responses`. */
+const ERROR_RESPONSES: ReadonlyArray<{ status: number; name: string; description: string }> = [
+  {
+    status: 400,
+    name: "BadRequest",
+    description: "The request was malformed: an unparsable body, a missing required field, or an unusable parameter.",
+  },
+  {
+    status: 401,
+    name: "Unauthorized",
+    description: "The bearer token is missing, unknown, or revoked.",
+  },
+  {
+    status: 403,
+    name: "Forbidden",
+    description:
+      "The token scope is insufficient for this operation, or the server runs read-only (`read_only`) and the operation writes.",
+  },
+  {
+    status: 404,
+    name: "NotFound",
+    description: "The addressed resource does not exist, or the token cannot see it.",
+  },
+  {
+    status: 500,
+    name: "InternalServerError",
+    description: "Unexpected server error (`internal_error`).",
+  },
+];
+
+const ERROR_RESPONSE_BY_STATUS = new Map(ERROR_RESPONSES.map((entry) => [entry.status, entry]));
+
+/** Converts `addRoute` path syntax (`/a/:id`) to OpenAPI path syntax (`/a/{id}`). */
+export function toOpenApiPath(path: string): string {
+  return path.replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+}
+
+/** Path parameter names in the order they appear, deduplicated. */
+export function extractPathParameterNames(path: string): string[] {
+  const names: string[] = [];
+  const pattern = /:([A-Za-z0-9_]+)/g;
+  let match: RegExpExecArray | null = pattern.exec(path);
+  while (match) {
+    const name = match[1] as string;
+    if (!names.includes(name)) names.push(name);
+    match = pattern.exec(path);
+  }
+  return names;
+}
+
+export function buildOpenApiDocument(input: BuildOpenApiDocumentInput): OpenApiDocument {
+  const moduleByOperationId = new Map<string, RegisteredApiModule>();
+  for (const registered of input.modules) {
+    for (const operation of registered.operations) {
+      moduleByOperationId.set(operation.operationId, registered);
+    }
+  }
+
+  const documented = input.operations.filter((operation) => operation.internal !== true);
+
+  // Group by OpenAPI path, then order paths lexicographically and methods by METHOD_ORDER.
+  // Both inputs are arrays, so nothing here depends on object iteration order.
+  const byPath = new Map<string, Map<string, unknown>>();
+  const usedTags = new Set<string>();
+
+  for (const operation of documented) {
+    const openApiPath = toOpenApiPath(operation.path);
+    const registered = moduleByOperationId.get(operation.operationId);
+    if (registered) usedTags.add(registered.module.id);
+    let methods = byPath.get(openApiPath);
+    if (!methods) {
+      methods = new Map<string, unknown>();
+      byPath.set(openApiPath, methods);
+    }
+    methods.set(operation.method.toLowerCase(), buildOperationObject(operation, registered));
+  }
+
+  const paths: Record<string, unknown> = {};
+  for (const openApiPath of [...byPath.keys()].sort()) {
+    const methods = byPath.get(openApiPath) as Map<string, unknown>;
+    const item: Record<string, unknown> = {};
+    for (const method of METHOD_ORDER) {
+      const operation = methods.get(method);
+      if (operation !== undefined) item[method] = operation;
+    }
+    // Anything outside the canonical list (there is nothing today) still gets emitted,
+    // sorted, rather than silently dropped.
+    for (const method of [...methods.keys()].sort()) {
+      if (!(method in item)) item[method] = methods.get(method);
+    }
+    paths[openApiPath] = item;
+  }
+
+  const tags = input.modules
+    .filter((registered) => usedTags.has(registered.module.id))
+    .map((registered) => ({
+      name: registered.module.id,
+      description: registered.module.description,
+      "x-ipollowork-title": registered.module.title,
+      "x-ipollowork-version": registered.module.version,
+      "x-ipollowork-stability": registered.module.stability,
+      "x-ipollowork-depends-on": [...(registered.module.dependsOn ?? [])],
+    }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  return {
+    openapi: OPENAPI_VERSION,
+    jsonSchemaDialect: JSON_SCHEMA_DIALECT,
+    info: {
+      title: input.title ?? "iPolloWork Server API",
+      version: input.serverVersion,
+      description: input.description ?? defaultDescription(),
+    },
+    servers: [{ url: "/", description: "The iPolloWork server this document was served from." }],
+    security: [{ [SECURITY_SCHEME_NAME]: [] }],
+    tags,
+    paths,
+    components: buildComponents(),
+  };
+}
+
+function defaultDescription(): string {
+  const scopes = SCOPE_DESCRIPTIONS.map(([scope, text]) => `- \`${scope}\`: ${text}`).join("\n");
+  return [
+    "Generated from the API module declarations. Every operation below is registered from the",
+    "same declaration that produces the live route table, so this document cannot drift from",
+    "the running server.",
+    "",
+    "Authentication is a bearer token. Three token scopes exist, each a superset of the one above it:",
+    "",
+    scopes,
+    "",
+    "Each operation documents the minimum scope it requires. Write and destructive operations are",
+    "additionally rejected with `403 read_only` when the server runs read-only.",
+  ].join("\n");
+}
+
+function buildOperationObject(operation: ApiOperation, registered: RegisteredApiModule | undefined): Record<string, unknown> {
+  const auth: AuthMode = operation.auth ?? "client";
+  const scope = operation.scope ?? defaultScopeForEffect(operation.effect);
+  const pathParameterNames = extractPathParameterNames(operation.path);
+  const parameters = [
+    ...buildPathParameters(pathParameterNames, operation.pathParams),
+    ...buildQueryParameters(operation.query),
+  ];
+
+  const result: Record<string, unknown> = {
+    operationId: operation.operationId,
+    summary: operation.summary,
+    description: buildOperationDescription(operation, auth, scope),
+  };
+
+  if (registered) result.tags = [registered.module.id];
+  if (operation.deprecated === true) result.deprecated = true;
+  if (parameters.length > 0) result.parameters = parameters;
+
+  if (operation.requestBody) {
+    result.requestBody = {
+      // A body whose every field is optional is itself optional — `createSession` and
+      // `cancelTask` both work with no body at all. Marking those `required` would make a
+      // generated client demand an argument the server does not need.
+      required: hasRequiredFields(operation.requestBody),
+      content: { "application/json": { schema: cloneJsonSchema(operation.requestBody, operation.operationId) } },
+    };
+  }
+
+  result.responses = buildResponses(operation, auth, parameters.length > 0);
+  result.security = auth === "none" ? [] : [{ [SECURITY_SCHEME_NAME]: [] }];
+
+  result["x-ipollowork-module"] = registered ? registered.module.id : null;
+  result["x-ipollowork-effect"] = operation.effect;
+  result["x-ipollowork-auth"] = auth;
+  result["x-ipollowork-scope"] = auth === "client" ? scope : null;
+  if (operation.streaming) result["x-ipollowork-streaming"] = operation.streaming;
+
+  return result;
+}
+
+function buildOperationDescription(operation: ApiOperation, auth: AuthMode, scope: TokenScope): string {
+  const lines: string[] = [];
+  const declared = operation.description?.trim();
+  if (declared) lines.push(declared);
+
+  if (auth === "none") {
+    lines.push("Authentication: none. This operation is reachable without a token.");
+  } else if (auth === "client") {
+    const suffix = SCOPE_RANK[scope] < SCOPE_RANK.owner ? " or higher" : "";
+    lines.push(`Authentication: bearer token. Minimum scope: \`${scope}\`${suffix}.`);
+  } else {
+    lines.push(
+      `Authentication: host credentials (\`${auth}\`) — the \`x-ipollowork-host-token\` header or an \`owner\` bearer token. Client token scopes do not apply.`,
+    );
+  }
+
+  lines.push(effectSentence(operation.effect));
+
+  if (operation.streaming === "sse") {
+    lines.push(
+      "Streams `text/event-stream`. Each frame carries an `event`, a JSON `data` payload, and an `id` that is the cursor to resume from.",
+    );
+  }
+
+  return lines.join("\n\n");
+}
+
+function effectSentence(effect: ApiEffect): string {
+  if (effect === "read") return "Effect: `read`. The operation does not modify server state.";
+  if (effect === "write") {
+    return "Effect: `write`. Rejected with `403 read_only` when the server runs read-only.";
+  }
+  return "Effect: `destructive`. Removes or overwrites state, and is rejected with `403 read_only` when the server runs read-only.";
+}
+
+function buildPathParameters(names: string[], pathParams: JsonSchema | undefined): Record<string, unknown>[] {
+  const properties = schemaProperties(pathParams);
+  return names.map((name) => {
+    const declared = properties?.[name];
+    const parameter: Record<string, unknown> = {
+      name,
+      in: "path",
+      // A path parameter is part of the route pattern, so it is always required.
+      required: true,
+    };
+    const description = declared && typeof declared.description === "string" ? declared.description : undefined;
+    if (description) parameter.description = description;
+    parameter.schema = declared ? cloneJsonSchema(declared, name) : { type: "string" };
+    return parameter;
+  });
+}
+
+function buildQueryParameters(query: JsonSchema | undefined): Record<string, unknown>[] {
+  const properties = schemaProperties(query);
+  if (!properties) return [];
+  const required = new Set(
+    Array.isArray(query?.required) ? (query.required as unknown[]).filter((entry): entry is string => typeof entry === "string") : [],
+  );
+  // Declared property order, not `Object.keys` of a mutated object: the schema literal in
+  // the module declaration is static, so this is stable across builds.
+  return Object.keys(properties).map((name) => {
+    const declared = properties[name] as Record<string, unknown>;
+    const parameter: Record<string, unknown> = {
+      name,
+      in: "query",
+      required: required.has(name),
+    };
+    if (typeof declared.description === "string") parameter.description = declared.description;
+    parameter.schema = cloneJsonSchema(declared, name);
+    return parameter;
+  });
+}
+
+function schemaProperties(schema: JsonSchema | undefined): Record<string, Record<string, unknown>> | null {
+  if (!schema || typeof schema !== "object") return null;
+  const properties = (schema as Record<string, unknown>).properties;
+  if (!properties || typeof properties !== "object" || Array.isArray(properties)) return null;
+  return properties as Record<string, Record<string, unknown>>;
+}
+
+function buildResponses(operation: ApiOperation, auth: AuthMode, hasParameters: boolean): Record<string, unknown> {
+  const entries = new Map<number, unknown>();
+
+  for (const [status, spec] of Object.entries(operation.responses ?? {})) {
+    entries.set(Number(status), buildResponseObject(spec, operation, Number(status)));
+  }
+
+  if (![...entries.keys()].some((status) => status < 400)) {
+    entries.set(200, defaultSuccessResponse(operation));
+  }
+
+  for (const status of applicableErrorStatuses(operation, auth, hasParameters)) {
+    if (entries.has(status)) continue;
+    const error = ERROR_RESPONSE_BY_STATUS.get(status);
+    if (!error) continue;
+    entries.set(status, { $ref: `#/components/responses/${error.name}` });
+  }
+
+  const responses: Record<string, unknown> = {};
+  for (const status of [...entries.keys()].sort((a, b) => a - b)) {
+    responses[String(status)] = entries.get(status);
+  }
+  return responses;
+}
+
+function applicableErrorStatuses(operation: ApiOperation, auth: AuthMode, hasParameters: boolean): number[] {
+  const statuses: number[] = [];
+  if (operation.requestBody || hasParameters) statuses.push(400);
+  if (auth !== "none") {
+    statuses.push(401);
+    statuses.push(403);
+  } else if (operation.effect !== "read") {
+    // Unauthenticated writes still hit the read-only gate.
+    statuses.push(403);
+  }
+  if (extractPathParameterNames(operation.path).length > 0) statuses.push(404);
+  statuses.push(500);
+  return statuses;
+}
+
+function defaultSuccessResponse(operation: ApiOperation): Record<string, unknown> {
+  if (operation.streaming === "sse") {
+    return {
+      description: "An open `text/event-stream` connection.",
+      content: {
+        "text/event-stream": {
+          schema: {
+            type: "string",
+            description: "A sequence of SSE frames: `id: <cursor>`, `event: <type>`, `data: <json>`.",
+          },
+        },
+      },
+    };
+  }
+  return {
+    description: "Success.",
+    content: { "application/json": { schema: {} } },
+  };
+}
+
+function buildResponseObject(spec: ApiResponseSpec, operation: ApiOperation, status: number): Record<string, unknown> {
+  const contentType = spec.contentType
+    ?? (status < 400 && operation.streaming === "sse" ? "text/event-stream" : "application/json");
+  const schema = spec.schema
+    ? cloneJsonSchema(spec.schema, `${operation.operationId}:${status}`)
+    : status >= 400
+      ? { $ref: API_ERROR_SCHEMA_REF }
+      : {};
+  return {
+    description: spec.description,
+    content: { [contentType]: { schema } },
+  };
+}
+
+function buildComponents(): Record<string, unknown> {
+  const responses: Record<string, unknown> = {};
+  for (const entry of [...ERROR_RESPONSES].sort((a, b) => (a.name < b.name ? -1 : 1))) {
+    responses[entry.name] = {
+      description: entry.description,
+      content: { "application/json": { schema: { $ref: API_ERROR_SCHEMA_REF } } },
+    };
+  }
+
+  return {
+    schemas: {
+      [API_ERROR_SCHEMA_NAME]: {
+        type: "object",
+        title: "ApiError",
+        description:
+          "The body of every failing response, produced by `formatError` in `src/errors.ts`. `details` is omitted when the error carries no structured context.",
+        required: ["code", "message"],
+        properties: {
+          code: {
+            type: "string",
+            description: "Stable machine-readable error code, e.g. `read_only` or `not_found`.",
+            examples: ["not_found"],
+          },
+          message: {
+            type: "string",
+            description: "Human-readable explanation. Not stable — never match on it.",
+          },
+          details: {
+            description: "Optional structured context. The shape depends on `code`.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+    responses,
+    securitySchemes: {
+      [SECURITY_SCHEME_NAME]: {
+        type: "http",
+        scheme: "bearer",
+        description: [
+          "A client token, sent as `Authorization: Bearer <token>`.",
+          "",
+          ...SCOPE_DESCRIPTIONS.map(([scope, text]) => `- \`${scope}\`: ${text}`),
+          "",
+          "Each operation states the minimum scope it requires; a token with a higher scope also passes.",
+        ].join("\n"),
+      },
+    },
+  };
+}
+
+/**
+ * Deep clone of an author-supplied JSON Schema.
+ *
+ * Copying rather than referencing means the emitted document is a value, not a view onto
+ * mutable module state, and dropping non-JSON values here (instead of letting
+ * `JSON.stringify` do it later) keeps the in-memory document and its serialization
+ * identical. Key order is preserved as declared, which is what makes two builds byte-equal.
+ */
+/** True when the body schema names at least one field the caller must supply. */
+function hasRequiredFields(schema: JsonSchema): boolean {
+  const required = schema.required;
+  return Array.isArray(required) && required.length > 0;
+}
+
+function cloneJsonSchema(schema: JsonSchema, label: string): unknown {
+  return cloneJsonValue(schema, label, new Set<unknown>());
+}
+
+function cloneJsonValue(value: unknown, label: string, seen: Set<unknown>): unknown {
+  if (value === null) return null;
+  const type = typeof value;
+  if (type === "string" || type === "boolean") return value;
+  if (type === "number") return Number.isFinite(value as number) ? value : null;
+  if (type !== "object") return undefined;
+
+  if (seen.has(value)) {
+    throw new ApiError(500, "openapi_schema_cyclic", `Cyclic JSON schema in ${label}`, { schema: label });
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((entry) => {
+        const cloned = cloneJsonValue(entry, label, seen);
+        return cloned === undefined ? null : cloned;
+      });
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      const cloned = cloneJsonValue((value as Record<string, unknown>)[key], label, seen);
+      if (cloned !== undefined) result[key] = cloned;
+    }
+    return result;
+  } finally {
+    seen.delete(value);
+  }
+}

--- a/apps/server/src/api/plugin-manifest.test.ts
+++ b/apps/server/src/api/plugin-manifest.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { validatePluginPackageManifest } from "@ipollowork/types/plugins";
+import { describe, expect, test } from "bun:test";
+
+import { API_MODULES } from "./index.js";
+
+/**
+ * The plugin-package manifest that declares this API component as an installable piece.
+ *
+ * `server-route` is a declared contribution type with no runtime consumer yet, so the
+ * manifest documents intent rather than driving behaviour. That makes it exactly the kind
+ * of file that rots silently, which is why it is validated against the real schema here and
+ * cross-checked against the module catalogue rather than against a copied list.
+ */
+const MANIFEST_PATH = fileURLToPath(
+  new URL("../../../../examples/plugin-packages/public-api/ipollowork.plugin.json", import.meta.url),
+);
+
+function readManifest(): unknown {
+  return JSON.parse(readFileSync(MANIFEST_PATH, "utf8")) as unknown;
+}
+
+describe("public-api plugin manifest", () => {
+  test("passes the shipped plugin package schema", () => {
+    const result = validatePluginPackageManifest(readManifest());
+    if (!result.success) {
+      throw new Error(result.issues.map((issue) => `${issue.path || "manifest"}: ${issue.message}`).join("; "));
+    }
+    expect(result.success).toBe(true);
+  });
+
+  test("declares one server-route contribution per API module", () => {
+    const result = validatePluginPackageManifest(readManifest());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    const contributions = result.manifest.contributions ?? [];
+    expect(contributions.every((contribution) => contribution.type === "server-route")).toBe(true);
+    expect(contributions.every((contribution) => contribution.location === "server")).toBe(true);
+    expect(contributions.map((contribution) => contribution.ref)).toEqual(
+      API_MODULES.map((module) => module.id),
+    );
+  });
+
+  test("identifies itself as a builtin server component", () => {
+    const result = validatePluginPackageManifest(readManifest());
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.manifest.id).toBe("public-api");
+    expect(result.manifest.source.origin).toBe("builtin");
+    expect(result.manifest.package?.updateId).toBe("ipollowork/public-api");
+    // The component contributes routes, not files: a resource here would claim a payload
+    // the package does not carry.
+    expect(result.manifest.resources).toEqual([]);
+  });
+});

--- a/apps/server/src/api/sse.test.ts
+++ b/apps/server/src/api/sse.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+
+import { createSseResponse, formatSseFrame, SSE_HEADERS } from "./sse.js";
+
+async function readAll(response: Response, limit?: number): Promise<string> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+    if (limit !== undefined && out.length >= limit) {
+      await reader.cancel();
+      break;
+    }
+  }
+  return out;
+}
+
+describe("formatSseFrame", () => {
+  test("emits event and data lines", () => {
+    expect(formatSseFrame({ event: "session.idle", data: { sessionId: "s1" } }))
+      .toBe('event: session.idle\ndata: {"sessionId":"s1"}\n\n');
+  });
+
+  test("emits the id line first when a cursor is present", () => {
+    expect(formatSseFrame({ event: "message.delta", data: { d: 1 }, id: "42" }))
+      .toBe('id: 42\nevent: message.delta\ndata: {"d":1}\n\n');
+  });
+
+  test("omits an empty id", () => {
+    expect(formatSseFrame({ event: "x", data: null, id: "" })).toBe("event: x\ndata: null\n\n");
+  });
+
+  test("splits a multi-line string payload across data lines", () => {
+    expect(formatSseFrame({ event: "log", data: "line one\nline two" }))
+      .toBe("event: log\ndata: line one\ndata: line two\n\n");
+  });
+
+  test("strips newlines from the event name so a payload cannot forge SSE fields", () => {
+    const frame = formatSseFrame({ event: "evil\ndata: injected", data: { ok: true } });
+    expect(frame).toBe('event: evil data: injected\ndata: {"ok":true}\n\n');
+    expect(frame.split("\n").filter((line) => line.startsWith("data:"))).toHaveLength(1);
+  });
+
+  test("strips newlines from the id for the same reason", () => {
+    expect(formatSseFrame({ event: "x", data: 1, id: "1\nevent: forged" }))
+      .toBe("id: 1 event: forged\nevent: x\ndata: 1\n\n");
+  });
+
+  test("serializes undefined data as null rather than dropping the field", () => {
+    expect(formatSseFrame({ event: "x", data: undefined })).toBe("event: x\ndata: null\n\n");
+  });
+});
+
+describe("createSseResponse", () => {
+  test("sets streaming headers", () => {
+    const response = createSseResponse({ start: async () => {}, keepAliveMs: 0 });
+    for (const [key, value] of Object.entries(SSE_HEADERS)) {
+      expect(response.headers.get(key)).toBe(value);
+    }
+  });
+
+  test("streams emitted frames and closes when the producer resolves", async () => {
+    const response = createSseResponse({
+      keepAliveMs: 0,
+      start: async (emit) => {
+        emit({ event: "a", data: 1 });
+        emit({ event: "b", data: 2, id: "7" });
+      },
+    });
+
+    expect(await readAll(response)).toBe("event: a\ndata: 1\n\nid: 7\nevent: b\ndata: 2\n\n");
+  });
+
+  test("writes the hello frame before the producer runs", async () => {
+    const response = createSseResponse({
+      keepAliveMs: 0,
+      hello: { event: "stream.open", data: { after: null } },
+      start: async (emit) => emit({ event: "a", data: 1 }),
+    });
+
+    expect(await readAll(response)).toBe(
+      'event: stream.open\ndata: {"after":null}\n\nevent: a\ndata: 1\n\n',
+    );
+  });
+
+  test("reports a producer failure as a stream.error frame instead of a broken stream", async () => {
+    const response = createSseResponse({
+      keepAliveMs: 0,
+      start: async () => {
+        throw new Error("engine exploded");
+      },
+    });
+
+    expect(await readAll(response)).toBe(
+      'event: stream.error\ndata: {"code":"stream_failed","message":"engine exploded"}\n\n',
+    );
+  });
+
+  test("aborts the producer when the client disconnects", async () => {
+    const clientGone = new AbortController();
+    let producerObservedAbort = false;
+
+    const response = createSseResponse({
+      keepAliveMs: 0,
+      signal: clientGone.signal,
+      start: async (emit, signal) => {
+        emit({ event: "first", data: 1 });
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => {
+            producerObservedAbort = true;
+            resolve();
+          }, { once: true });
+        });
+      },
+    });
+
+    const reader = response.body!.getReader();
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toBe("event: first\ndata: 1\n\n");
+
+    clientGone.abort();
+    await reader.read().catch(() => undefined);
+
+    expect(producerObservedAbort).toBe(true);
+  });
+
+  test("returns an already-closed stream when the client aborted before subscribing", async () => {
+    const aborted = AbortSignal.abort();
+    let producerRan = false;
+
+    const response = createSseResponse({
+      keepAliveMs: 0,
+      signal: aborted,
+      start: async () => {
+        producerRan = true;
+      },
+    });
+
+    expect(await readAll(response)).toBe("");
+    expect(producerRan).toBe(false);
+  });
+
+  test("a late emit after the stream ends is dropped rather than throwing", async () => {
+    let lateEmit: (() => void) | undefined;
+
+    const response = createSseResponse({
+      keepAliveMs: 0,
+      start: async (emit) => {
+        emit({ event: "a", data: 1 });
+        lateEmit = () => emit({ event: "late", data: 2 });
+      },
+    });
+
+    expect(await readAll(response)).toBe("event: a\ndata: 1\n\n");
+    expect(() => lateEmit?.()).not.toThrow();
+  });
+
+  test("sends keepalive comments while the producer is idle", async () => {
+    const done = new AbortController();
+    const response = createSseResponse({
+      keepAliveMs: 5,
+      signal: done.signal,
+      start: async (_emit, signal) => {
+        await new Promise<void>((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
+      },
+    });
+
+    const reader = response.body!.getReader();
+    const chunk = await reader.read();
+    expect(new TextDecoder().decode(chunk.value)).toBe(": keepalive\n\n");
+
+    done.abort();
+    await reader.read().catch(() => undefined);
+  });
+});

--- a/apps/server/src/api/sse.ts
+++ b/apps/server/src/api/sse.ts
@@ -1,0 +1,172 @@
+/**
+ * Server-sent events for the public API.
+ *
+ * The server has no first-party SSE stream to copy: `/workspace/:id/events` is a polling
+ * endpoint returning `{items, cursor}` (`routes/operations.ts:31`), and the DeepSeek
+ * Harness route only forwards an upstream body verbatim (`routes/deepseek-harness.ts:113`).
+ * So this is the one place where the streaming contract is defined, and everything that
+ * streams — sessions, tasks — goes through it, rather than each module hand-rolling a
+ * stream with its own subtly different abort and keepalive behaviour.
+ */
+
+export interface SseFrame {
+  /** Becomes the SSE `event:` line. */
+  event: string;
+  data: unknown;
+  /** Becomes the SSE `id:` line — the cursor a client resumes from. */
+  id?: string;
+}
+
+/**
+ * Formats one frame.
+ *
+ * Multi-line payloads need one `data:` line each, or the client sees a truncated event;
+ * `JSON.stringify` normally emits a single line, but a hand-built string payload may not.
+ */
+export function formatSseFrame(frame: SseFrame): string {
+  const payload = typeof frame.data === "string" ? frame.data : JSON.stringify(frame.data ?? null);
+  const lines: string[] = [];
+  if (frame.id !== undefined && frame.id !== "") {
+    lines.push(`id: ${sanitizeSseValue(frame.id)}`);
+  }
+  lines.push(`event: ${sanitizeSseValue(frame.event)}`);
+  for (const line of String(payload).split("\n")) {
+    lines.push(`data: ${line}`);
+  }
+  return `${lines.join("\n")}\n\n`;
+}
+
+/**
+ * Strips CR/LF from a single-line SSE field.
+ *
+ * An event type or id carrying a newline would otherwise let a payload forge extra SSE
+ * fields — the stream equivalent of header injection.
+ */
+function sanitizeSseValue(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").trim();
+}
+
+export const SSE_HEADERS: Record<string, string> = {
+  "content-type": "text/event-stream",
+  "cache-control": "no-cache, no-transform",
+  connection: "keep-alive",
+  // Proxies that buffer by default will otherwise hold the stream until it ends.
+  "x-accel-buffering": "no",
+};
+
+export interface SseStreamOptions {
+  /**
+   * Produces the stream. Call `emit` for each frame; resolve to end the stream.
+   * `signal` aborts when the client disconnects.
+   */
+  start: (emit: (frame: SseFrame) => void, signal: AbortSignal) => Promise<void>;
+  /** Client disconnect signal, normally `ctx.request.signal`. */
+  signal?: AbortSignal;
+  /** Comment heartbeat interval. Set to 0 to disable. */
+  keepAliveMs?: number;
+  /** Frame sent before the producer starts, so clients see an immediately open stream. */
+  hello?: SseFrame;
+}
+
+const DEFAULT_KEEPALIVE_MS = 15_000;
+
+/**
+ * Builds a streaming `Response`.
+ *
+ * Two failure modes drive the shape of this function. A producer that keeps running after
+ * the client has gone leaks an upstream subscription, so the client's abort is propagated
+ * inward through an `AbortController` the producer is handed. And enqueueing onto a closed
+ * controller throws, so every write goes through a guard that goes quiet once the stream is
+ * done — otherwise a late event from the engine turns into an unhandled rejection.
+ */
+export function createSseResponse(options: SseStreamOptions): Response {
+  const { start, signal, keepAliveMs = DEFAULT_KEEPALIVE_MS, hello } = options;
+  const encoder = new TextEncoder();
+  const controller = new AbortController();
+
+  let closed = false;
+  let keepAlive: ReturnType<typeof setInterval> | undefined;
+  let onAbort: (() => void) | undefined;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      const write = (chunk: string): void => {
+        if (closed) return;
+        try {
+          streamController.enqueue(encoder.encode(chunk));
+        } catch {
+          // The consumer went away between our `closed` check and the enqueue.
+          closed = true;
+        }
+      };
+
+      const finish = (error?: unknown): void => {
+        if (closed) return;
+        closed = true;
+        if (keepAlive !== undefined) clearInterval(keepAlive);
+        if (onAbort && signal) signal.removeEventListener("abort", onAbort);
+        controller.abort();
+        try {
+          if (error !== undefined) streamController.error(error);
+          else streamController.close();
+        } catch {
+          // Already closed by the runtime.
+        }
+      };
+
+      if (signal) {
+        if (signal.aborted) {
+          finish();
+          return;
+        }
+        onAbort = () => finish();
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      if (hello) write(formatSseFrame(hello));
+
+      if (keepAliveMs > 0) {
+        keepAlive = setInterval(() => {
+          // A comment line keeps intermediaries from timing the connection out
+          // without being delivered to the client as an event.
+          write(": keepalive\n\n");
+        }, keepAliveMs);
+        // Do not hold the process open for an idle stream.
+        (keepAlive as unknown as { unref?: () => void }).unref?.();
+      }
+
+      const emit = (frame: SseFrame): void => {
+        write(formatSseFrame(frame));
+      };
+
+      start(emit, controller.signal)
+        .then(() => finish())
+        .catch((error: unknown) => {
+          // A disconnect surfaces here as an abort; that is a normal end, not a failure.
+          if (controller.signal.aborted || closed) {
+            finish();
+            return;
+          }
+          write(formatSseFrame({
+            event: "stream.error",
+            data: { code: "stream_failed", message: errorMessage(error) },
+          }));
+          finish();
+        });
+    },
+    cancel() {
+      closed = true;
+      if (keepAlive !== undefined) clearInterval(keepAlive);
+      if (onAbort && signal) signal.removeEventListener("abort", onAbort);
+      controller.abort();
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Stream failed";
+}

--- a/apps/server/src/serve-node.test.ts
+++ b/apps/server/src/serve-node.test.ts
@@ -120,4 +120,117 @@ describe("serve", () => {
       await server.stop();
     }
   });
+
+  // A long-lived response has no other way to learn its reader is gone. Without these two
+  // signals an SSE producer keeps streaming into a dead socket for the life of the process,
+  // holding its upstream engine subscription open with it.
+  test("aborts request.signal when the client hangs up mid-stream", async () => {
+    const encoder = new TextEncoder();
+    let aborted = false;
+    let sawRequest = (): void => {};
+    const requestSeen = new Promise<void>((resolve) => {
+      sawRequest = resolve;
+    });
+
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(encoder.encode("open\n"));
+              sawRequest();
+              request.signal.addEventListener("abort", () => {
+                aborted = true;
+                try {
+                  controller.close();
+                } catch {
+                  // Already closed by the transport.
+                }
+              }, { once: true });
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    });
+
+    try {
+      const controller = new AbortController();
+      const response = await fetch(`http://127.0.0.1:${server.port}/stream`, { signal: controller.signal });
+      await response.body!.getReader().read();
+      await requestSeen;
+
+      controller.abort();
+      for (let attempt = 0; attempt < 50 && !aborted; attempt += 1) await delay(10);
+
+      expect(aborted).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("cancels the response stream when the client hangs up mid-stream", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    let sawRequest = (): void => {};
+    const requestSeen = new Promise<void>((resolve) => {
+      sawRequest = resolve;
+    });
+
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(encoder.encode("open\n"));
+              sawRequest();
+            },
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+    });
+
+    try {
+      const controller = new AbortController();
+      const response = await fetch(`http://127.0.0.1:${server.port}/stream`, { signal: controller.signal });
+      await response.body!.getReader().read();
+      await requestSeen;
+
+      controller.abort();
+      for (let attempt = 0; attempt < 50 && !cancelled; attempt += 1) await delay(10);
+
+      expect(cancelled).toBe(true);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("a normal response still completes and does not report a disconnect", async () => {
+    let aborted = false;
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        request.signal.addEventListener("abort", () => {
+          aborted = true;
+        }, { once: true });
+        return Response.json({ ok: true });
+      },
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/health`);
+      expect(await response.json()).toEqual({ ok: true });
+      await delay(50);
+      expect(aborted).toBe(false);
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -79,7 +79,31 @@ async function waitForDrainOrClose(nodeRes: ServerResponse): Promise<void> {
 /**
  * Convert a Node.js IncomingMessage into a Web API Request.
  */
-function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number): Request {
+/**
+ * Signals that the client went away.
+ *
+ * `close` also fires on a perfectly normal response, so the finished flag is what
+ * separates "the exchange completed" from "the socket died under us". Without this a
+ * long-lived response — an SSE stream — has no way to learn its reader is gone, and its
+ * producer keeps running for the life of the process.
+ */
+function createDisconnectSignal(nodeReq: IncomingMessage, nodeRes: ServerResponse): AbortSignal {
+  const controller = new AbortController();
+  const abort = (): void => {
+    if (nodeRes.writableFinished) return;
+    if (!controller.signal.aborted) controller.abort();
+  };
+  nodeRes.once("close", abort);
+  nodeReq.once("aborted", abort);
+  return controller.signal;
+}
+
+function toWebRequest(
+  nodeReq: IncomingMessage,
+  hostname: string,
+  port: number,
+  signal?: AbortSignal,
+): Request {
   const url = `http://${hostname}:${port}${nodeReq.url ?? "/"}`;
   const method = nodeReq.method ?? "GET";
   const headers = new Headers();
@@ -106,6 +130,7 @@ function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number):
     method,
     headers,
     body,
+    ...(signal ? { signal } : {}),
     // @ts-expect-error duplex is required for streaming request bodies in Node
     duplex: hasBody ? "half" : undefined,
   });
@@ -114,7 +139,11 @@ function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number):
 /**
  * Write a Web API Response to a Node.js ServerResponse.
  */
-async function writeWebResponse(webRes: Response, nodeRes: ServerResponse): Promise<void> {
+async function writeWebResponse(
+  webRes: Response,
+  nodeRes: ServerResponse,
+  disconnected?: AbortSignal,
+): Promise<void> {
   const headersObj: Record<string, string | string[]> = {};
   webRes.headers.forEach((value, key) => {
     const existing = headersObj[key];
@@ -135,17 +164,36 @@ async function writeWebResponse(webRes: Response, nodeRes: ServerResponse): Prom
   }
 
   const reader = webRes.body.getReader();
+  let drained = false;
+
+  // An idle stream parks in `reader.read()` with nothing to wake it, so noticing the
+  // disconnect between chunks is not enough — the read itself has to be cut short.
+  // Cancelling does both: it resolves the pending read and reaches the stream's
+  // `cancel()` callback, which is how the producer learns to release its upstream.
+  const cancelOnDisconnect = (): void => {
+    void reader.cancel().catch(() => undefined);
+  };
+  disconnected?.addEventListener("abort", cancelOnDisconnect, { once: true });
+
   try {
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        drained = true;
+        break;
+      }
       if (!isResponseWritable(nodeRes)) break;
       if (!nodeRes.write(value)) {
         await waitForDrainOrClose(nodeRes);
       }
     }
   } finally {
-    reader.releaseLock();
+    disconnected?.removeEventListener("abort", cancelOnDisconnect);
+    if (!drained) {
+      await reader.cancel().catch(() => undefined);
+    } else {
+      reader.releaseLock();
+    }
     endResponse(nodeRes);
   }
 }
@@ -168,9 +216,10 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
     });
 
     try {
-      const webReq = toWebRequest(nodeReq, hostname, boundPort);
+      const disconnected = createDisconnectSignal(nodeReq, nodeRes);
+      const webReq = toWebRequest(nodeReq, hostname, boundPort, disconnected);
       const webRes = await fetchHandler(webReq);
-      await writeWebResponse(webRes, nodeRes);
+      await writeWebResponse(webRes, nodeRes, disconnected);
     } catch (error) {
       if (isExpectedConnectionAbort(error)) {
         if (isResponseWritable(nodeRes) && !nodeRes.headersSent) {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -98,6 +98,7 @@ import {
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
 import { serve, type ServeResult } from "./serve-node.js";
+import { registerApiV1 } from "./api/index.js";
 import { registerCoreRoutes } from "./routes/core.js";
 import { registerFileRoutes } from "./routes/files.js";
 import { registerOperationRoutes } from "./routes/operations.js";
@@ -3213,6 +3214,23 @@ function createRoutes(
       timestamp: Date.now(),
     });
     return jsonResponse(result);
+  });
+
+  // Mounted last: `matchRoute` returns the first match, so appending /api/v1 cannot shadow
+  // a legacy route, and the compat module's late-bound `legacyRoutes` sees the whole table.
+  registerApiV1({
+    routes,
+    config,
+    serverVersion: SERVER_VERSION,
+    ensureWritable,
+    requireClientScope,
+    jsonResponse,
+    readJsonBody,
+    resolveWorkspace,
+    createWorkspaceOpencodeClient,
+    unwrapOpencodeResult,
+    deepseekHarness,
+    legacyRoutes: () => routes,
   });
 
   return routes;

--- a/apps/server/src/tokens.ts
+++ b/apps/server/src/tokens.ts
@@ -138,6 +138,21 @@ export class TokenService {
     return true;
   }
 
+  /**
+   * Resolves the record behind an already-hashed token, so callers holding an
+   * `Actor.tokenHash` can recover the token id without ever seeing the secret.
+   * Returns `null` for the shared config token, which has no stored record.
+   */
+  async findByHash(hash: string): Promise<Omit<TokenRecord, "hash"> | null> {
+    const trimmed = hash.trim();
+    if (!trimmed) return null;
+    await this.ensureLoaded();
+    const found = this.byHash.get(trimmed);
+    if (!found) return null;
+    const { hash: _hash, ...rest } = found;
+    return rest;
+  }
+
   async scopeForToken(token: string): Promise<TokenScope | null> {
     const trimmed = token.trim();
     if (!trimmed) return null;

--- a/examples/plugin-packages/public-api/ipollowork.plugin.json
+++ b/examples/plugin-packages/public-api/ipollowork.plugin.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 2,
+  "id": "public-api",
+  "name": "iPolloWork Public API",
+  "description": "把 iPolloWork 服务端的 /api/v1 公共 API 声明为可组合的组件：统一会话、任务、Webhook、令牌策略、OpenAPI 描述与旧路由兼容层，每个模块都可以独立开关。",
+  "category": "开发者工具与集成",
+  "preview": true,
+  "source": {
+    "format": "ipollowork-builtin",
+    "origin": "builtin",
+    "trusted": true,
+    "reference": "apps/server/src/api"
+  },
+  "icon": { "simpleIconSlug": "openapiinitiative" },
+  "setup": {
+    "instructions": "无需安装：组件随 ipollowork-server 一同发布，由 registerApiV1() 挂载到路由表。用 IPOLLOWORK_API_MODULES / IPOLLOWORK_API_MODULES_DISABLED 选择启用的模块，用 GET /api/v1/modules 查看当前生效的清单。",
+    "primaryCta": "查看 API 文档",
+    "secondaryCta": "查看已启用模块",
+    "requiredEnv": ["IPOLLOWORK_API_MODULES", "IPOLLOWORK_API_MODULES_DISABLED"]
+  },
+  "resources": [],
+  "contributions": [
+    {
+      "type": "server-route",
+      "ref": "sessions",
+      "label": "Sessions",
+      "description": "GET/POST /api/v1/workspaces/{workspaceId}/sessions 及其子路由：创建、查询、发送提示、打断、SSE 事件流、回复权限与提问。引擎无关，OpenCode 与 DeepSeek Harness 共用同一套请求。",
+      "location": "server"
+    },
+    {
+      "type": "server-route",
+      "ref": "tasks",
+      "label": "Tasks",
+      "description": "/api/v1/workspaces/{workspaceId}/tasks：把一个目标提交为后台任务，轮询或流式跟踪到 done / failed / cancelled。任务记录仅存于内存，重启后丢失。依赖 sessions 模块。",
+      "location": "server"
+    },
+    {
+      "type": "server-route",
+      "ref": "webhooks",
+      "label": "Webhooks",
+      "description": "/api/v1/workspaces/{workspaceId}/webhooks：工作区级出站事件订阅，HMAC 签名投递、有限次重试，并拒绝指向私有网段的地址。",
+      "location": "server"
+    },
+    {
+      "type": "server-route",
+      "ref": "policy",
+      "label": "Token policy",
+      "description": "GET /api/v1/whoami 返回调用方身份；GET/PUT /api/v1/tokens/{tokenId}/policy（host 鉴权）读写单个令牌的工作区绑定、审批策略与过期时间。",
+      "location": "server"
+    },
+    {
+      "type": "server-route",
+      "ref": "openapi",
+      "label": "API description",
+      "description": "GET /api/v1/openapi.json、/api/v1/docs、/api/v1/modules：由模块声明直接生成的 OpenAPI 3.1 文档、零依赖 HTML 参考页和已启用模块清单。",
+      "location": "server"
+    },
+    {
+      "type": "server-route",
+      "ref": "compat",
+      "label": "Legacy compatibility",
+      "description": "把旧版路由以别名形式重新发布到 /api/v1 前缀下，请求转派回旧处理器；旧路径保持可用。玩具 UI、/opencode/* 原始代理、浏览器 OAuth 回调等非公共契约不在别名范围内。",
+      "location": "server"
+    }
+  ],
+  "localization": {
+    "defaultLocale": "zh",
+    "translations": {
+      "en": {
+        "description": "Declares the iPolloWork server's /api/v1 public API as a composable component: unified sessions, tasks, webhooks, token policy, the OpenAPI description, and the legacy compatibility layer, each independently toggleable.",
+        "category": "Developer Tools & Integrations",
+        "setup": {
+          "instructions": "Nothing to install: the component ships inside ipollowork-server and is mounted by registerApiV1(). Choose the enabled modules with IPOLLOWORK_API_MODULES / IPOLLOWORK_API_MODULES_DISABLED, and read the live catalogue from GET /api/v1/modules.",
+          "primaryCta": "Open the API reference",
+          "secondaryCta": "List enabled modules"
+        }
+      }
+    }
+  },
+  "package": {
+    "version": "1.0.0",
+    "publisher": {
+      "id": "ipollowork",
+      "name": "iPolloWork"
+    },
+    "compatibility": {
+      "ipollowork": ">=0.21.0"
+    },
+    "updateId": "ipollowork/public-api"
+  },
+  "platform": ["darwin", "linux", "windows"],
+  "permissions": [
+    {
+      "id": "network",
+      "reason": "对外投递 Webhook 事件，并接受来自本机以外的 API 客户端请求。"
+    },
+    {
+      "id": "workspace-read",
+      "reason": "读取工作区会话、任务与配置以响应 API 请求。"
+    },
+    {
+      "id": "workspace-write",
+      "reason": "创建会话、发送提示并执行任务，需要写入工作区。"
+    }
+  ]
+}

--- a/examples/public-api/01-stream-session.ts
+++ b/examples/public-api/01-stream-session.ts
@@ -1,0 +1,63 @@
+/**
+ * Create a session, send a prompt, and stream the reply as it is generated.
+ *
+ * Run:
+ *   export IPOLLOWORK_BASE_URL=http://127.0.0.1:8787
+ *   export IPOLLOWORK_TOKEN=<client token>
+ *   node --experimental-strip-types examples/public-api/01-stream-session.ts
+ */
+
+import { IPolloWorkClient } from "@ipollowork/api-sdk";
+
+const client = new IPolloWorkClient({
+  baseUrl: process.env.IPOLLOWORK_BASE_URL ?? "http://127.0.0.1:8787",
+  token: process.env.IPOLLOWORK_TOKEN,
+});
+
+const { items: workspaces } = await client.listWorkspaces();
+const workspace = workspaces[0];
+if (!workspace) throw new Error("No workspace configured on this server");
+
+console.log(`workspace: ${workspace.id}`);
+
+const { session, engine, capabilities } = await client.createSession(workspace.id, { title: "API example" });
+console.log(`session:   ${session.id}`);
+console.log(`engine:    ${engine} (resumable stream: ${capabilities.resumableStreaming})\n`);
+
+await client.promptText(
+  workspace.id,
+  session.id,
+  "List the files in this project and describe what it does in two sentences.",
+);
+
+// `seq` is the durable cursor. Keeping the latest one means a dropped connection can be
+// resumed with `{ after: cursor }` instead of replaying the whole session.
+let cursor: string | undefined;
+
+for await (const event of client.streamSession(workspace.id, session.id)) {
+  cursor = event.seq ?? cursor;
+
+  switch (event.type) {
+    case "message.delta":
+      // Reasoning deltas arrive on the same channel; only print the answer itself.
+      if (event.kind === "text") process.stdout.write(event.delta);
+      break;
+
+    case "tool.called":
+      console.log(`\n[tool] ${event.tool}`);
+      break;
+
+    case "tool.completed":
+      console.log(`[tool] ${event.tool} → ${event.status}`);
+      break;
+
+    case "session.error":
+      console.error(`\nerror: ${event.error.message}`);
+      process.exit(1);
+      break;
+
+    case "session.idle":
+      console.log(`\n\ndone. resume cursor: ${cursor ?? "(none)"}`);
+      process.exit(0);
+  }
+}

--- a/examples/public-api/02-handle-permissions.ts
+++ b/examples/public-api/02-handle-permissions.ts
@@ -1,0 +1,94 @@
+/**
+ * Answer tool-permission requests programmatically.
+ *
+ * With `--approval manual`, the agent stops and asks before each tool use. An API client
+ * that ignores those requests will appear to hang: the run is waiting on an answer that
+ * never comes. This is the pattern for deciding in code instead — the basis of any
+ * unattended integration that still wants a policy tighter than "approve everything".
+ *
+ * Run:
+ *   export IPOLLOWORK_BASE_URL=http://127.0.0.1:8787
+ *   export IPOLLOWORK_TOKEN=<client token>
+ *   node --experimental-strip-types examples/public-api/02-handle-permissions.ts
+ */
+
+import { IPolloWorkClient, type Permission } from "@ipollowork/api-sdk";
+
+const client = new IPolloWorkClient({
+  baseUrl: process.env.IPOLLOWORK_BASE_URL ?? "http://127.0.0.1:8787",
+  token: process.env.IPOLLOWORK_TOKEN,
+});
+
+/**
+ * Decide what the agent may do.
+ *
+ * "once" allows this call, "always" allows it for the rest of the session, and "reject"
+ * refuses. Prefer "once" for anything that writes: "always" hands over the rest of the
+ * session, and the next request under that grant may not resemble this one.
+ */
+function decide(permission: Permission): "once" | "always" | "reject" {
+  const target = permission.resources.join(" ");
+
+  // Reads anywhere in the workspace are safe to allow for the session.
+  if (permission.kind === "read") return "always";
+
+  // Writes are allowed one at a time, and only under src/.
+  if (permission.kind === "write" || permission.kind === "edit") {
+    return permission.resources.every((resource) => resource.startsWith("src/")) ? "once" : "reject";
+  }
+
+  // Shell commands: allow a known-safe read-only command, refuse everything else.
+  if (permission.kind === "bash") {
+    return /^(git (status|diff|log)|ls|cat|rg|grep)\b/.test(target) ? "once" : "reject";
+  }
+
+  // Anything unrecognized is refused — an allowlist fails closed, a denylist does not.
+  return "reject";
+}
+
+const { items: workspaces } = await client.listWorkspaces();
+const workspace = workspaces[0];
+if (!workspace) throw new Error("No workspace configured on this server");
+
+const { session } = await client.createSession(workspace.id, { title: "Permission handling" });
+console.log(`session: ${session.id}\n`);
+
+await client.promptText(
+  workspace.id,
+  session.id,
+  "Check whether the tests pass, and fix any obvious failure in src/.",
+);
+
+for await (const event of client.streamSession(workspace.id, session.id)) {
+  switch (event.type) {
+    case "permission.asked": {
+      const reply = decide(event.permission);
+      const target = event.permission.resources.join(", ") || "(no resource)";
+      console.log(`[permission] ${event.permission.kind} ${target} → ${reply}`);
+      await client.replyPermission(workspace.id, session.id, event.permission.id, reply);
+      break;
+    }
+
+    case "question.asked": {
+      // The agent can also ask the operator a question. Answering with the first option
+      // keeps an unattended run moving; a real integration should encode a real choice.
+      const answers = event.question.questions.map((question) => [question.options[0]?.label ?? ""]);
+      console.log(`[question] ${event.question.questions[0]?.question ?? ""}`);
+      await client.replyQuestion(workspace.id, session.id, event.question.id, answers);
+      break;
+    }
+
+    case "message.delta":
+      if (event.kind === "text") process.stdout.write(event.delta);
+      break;
+
+    case "session.error":
+      console.error(`\nerror: ${event.error.message}`);
+      process.exit(1);
+      break;
+
+    case "session.idle":
+      console.log("\n\ndone.");
+      process.exit(0);
+  }
+}

--- a/examples/public-api/03-run-task.py
+++ b/examples/public-api/03-run-task.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Submit a goal and block until it finishes.
+
+The task API is the one-shot surface: hand it a goal, get back a result. Everything
+underneath — creating a session, prompting, answering tool permissions, detecting
+completion — is handled server-side.
+
+Run:
+    export IPOLLOWORK_BASE_URL=http://127.0.0.1:8787
+    export IPOLLOWORK_TOKEN=<client token>
+    python3 examples/public-api/03-run-task.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "packages", "ipollowork-api-sdk-python"))
+
+from ipollowork_api import IPolloWorkApiError, IPolloWorkClient
+
+
+def main() -> int:
+    client = IPolloWorkClient(
+        os.environ.get("IPOLLOWORK_BASE_URL", "http://127.0.0.1:8787"),
+        token=os.environ.get("IPOLLOWORK_TOKEN"),
+    )
+
+    workspaces = client.list_workspaces()["items"]
+    if not workspaces:
+        print("No workspace configured on this server", file=sys.stderr)
+        return 1
+
+    workspace_id = workspaces[0]["id"]
+    print(f"workspace: {workspace_id}")
+
+    def on_event(name: str, data: object) -> None:
+        if isinstance(data, dict) and data.get("state"):
+            print(f"  [{name}] {data['state']}")
+        else:
+            print(f"  [{name}]")
+
+    try:
+        task = client.run_task(
+            workspace_id,
+            goal="Read README.md and write a one-paragraph summary of what this project does.",
+            # "auto" approves tool use without a human. For anything that writes, prefer a
+            # token-scoped approval policy so the blast radius stays bounded.
+            approval_policy="auto",
+            timeout_ms=600_000,
+            on_event=on_event,
+        )
+    except IPolloWorkApiError as error:
+        print(f"API error [{error.code}]: {error.message}", file=sys.stderr)
+        return 1
+
+    print(f"\nstate: {task['state']}")
+    if task.get("summary"):
+        print(f"\n{task['summary']}")
+    if task.get("error"):
+        print(f"\nerror: {task['error'].get('message')}", file=sys.stderr)
+
+    return 0 if task["state"] == "done" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/public-api/04-ci-review.sh
+++ b/examples/public-api/04-ci-review.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# CI code review over the public API, using nothing but curl and jq.
+#
+# Reviews the diff against a base ref and fails the build when the agent reports a
+# blocking issue. Demonstrates the API surface a CI job actually needs: mint a scoped
+# token, submit a task, wait for it, read the result.
+#
+# Usage: bash 04-ci-review.sh [base-ref]
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+BASE_URL="${IPOLLOWORK_BASE_URL:-http://127.0.0.1:8787}"
+TOKEN="${IPOLLOWORK_TOKEN:?IPOLLOWORK_TOKEN is required}"
+
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl --silent --show-error --fail-with-body \
+    -X "$method" "${BASE_URL}${path}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "$@"
+}
+
+echo "==> Checking server"
+api GET /api/v1/health | jq -e '.ok == true' >/dev/null
+
+WORKSPACE_ID="$(api GET /api/v1/workspaces | jq -r '.items[0].id')"
+if [ -z "$WORKSPACE_ID" ] || [ "$WORKSPACE_ID" = "null" ]; then
+  echo "No workspace configured on the server" >&2
+  exit 1
+fi
+echo "    workspace: ${WORKSPACE_ID}"
+
+DIFF="$(git diff "${BASE_REF}"...HEAD)"
+if [ -z "$DIFF" ]; then
+  echo "==> No changes against ${BASE_REF}; nothing to review"
+  exit 0
+fi
+
+echo "==> Submitting review task"
+# jq --arg does the quoting, so a diff containing quotes or newlines cannot break the JSON.
+REQUEST="$(jq -n --arg diff "$DIFF" --arg base "$BASE_REF" '{
+  goal: ("Review this diff against \($base) for correctness bugs, security issues, and missing tests. " +
+         "End your reply with a line reading exactly VERDICT: PASS or VERDICT: FAIL.\n\n```diff\n" + $diff + "\n```"),
+  approvalPolicy: "auto",
+  timeoutMs: 900000,
+  metadata: { source: "ci", base: $base }
+}')"
+
+TASK="$(api POST "/api/v1/workspaces/${WORKSPACE_ID}/tasks" -d "$REQUEST")"
+TASK_ID="$(jq -r '.id' <<<"$TASK")"
+echo "    task: ${TASK_ID}"
+
+echo "==> Waiting for completion"
+# The event stream ends when the task reaches a terminal state, so following it to EOF
+# is the wait — no polling loop, no arbitrary sleep.
+curl --silent --show-error --no-buffer \
+  "${BASE_URL}/api/v1/workspaces/${WORKSPACE_ID}/tasks/${TASK_ID}/events" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: text/event-stream" \
+  | while IFS= read -r line; do
+      case "$line" in
+        data:*) jq -r '.state // empty' <<<"${line#data:}" 2>/dev/null | sed 's/^/    state: /' ;;
+      esac
+    done
+
+RESULT="$(api GET "/api/v1/workspaces/${WORKSPACE_ID}/tasks/${TASK_ID}")"
+STATE="$(jq -r '.state' <<<"$RESULT")"
+SUMMARY="$(jq -r '.summary // ""' <<<"$RESULT")"
+
+echo
+echo "==> Review complete (${STATE})"
+echo "$SUMMARY"
+echo
+
+if [ "$STATE" != "done" ]; then
+  echo "Task did not complete: ${STATE}" >&2
+  jq -r '.error.message // empty' <<<"$RESULT" >&2
+  exit 1
+fi
+
+if grep -qi "VERDICT: FAIL" <<<"$SUMMARY"; then
+  echo "Review found blocking issues." >&2
+  exit 1
+fi
+
+echo "Review passed."

--- a/examples/public-api/05-webhook-receiver.ts
+++ b/examples/public-api/05-webhook-receiver.ts
@@ -1,0 +1,95 @@
+/**
+ * A webhook receiver that verifies signatures before trusting a delivery.
+ *
+ * The signature check is the whole point: the endpoint is public, so anyone can POST to
+ * it. Without verification a forged "task done" payload is indistinguishable from a real
+ * one.
+ *
+ * Run:
+ *   export IPOLLOWORK_WEBHOOK_SECRET=<the secret you registered>
+ *   node --experimental-strip-types examples/public-api/05-webhook-receiver.ts
+ *
+ * Then register it (from a machine the server can reach):
+ *   curl -X POST "$IPOLLOWORK_BASE_URL/api/v1/workspaces/$WS/webhooks" \
+ *     -H "Authorization: Bearer $IPOLLOWORK_TOKEN" \
+ *     -H "Content-Type: application/json" \
+ *     -d '{"url":"https://your-host/hooks/ipollowork","events":["task.completed","task.failed"],"secret":"'"$IPOLLOWORK_WEBHOOK_SECRET"'"}'
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { createServer } from "node:http";
+
+const SECRET = process.env.IPOLLOWORK_WEBHOOK_SECRET;
+if (!SECRET) throw new Error("IPOLLOWORK_WEBHOOK_SECRET is required");
+
+const PORT = Number(process.env.PORT ?? 8790);
+
+/** Deliveries older than this are rejected, so a captured payload cannot be replayed later. */
+const MAX_SKEW_SECONDS = 300;
+
+function verify(signatureHeader: string | undefined, body: string): boolean {
+  if (!signatureHeader) return false;
+
+  let timestamp = "";
+  const provided: string[] = [];
+  for (const segment of signatureHeader.split(",")) {
+    const index = segment.indexOf("=");
+    if (index === -1) continue;
+    const key = segment.slice(0, index).trim();
+    const value = segment.slice(index + 1).trim();
+    if (key === "t") timestamp = value;
+    else if (key === "v1" && value) provided.push(value);
+  }
+  if (!timestamp || provided.length === 0) return false;
+
+  const age = Math.abs(Math.floor(Date.now() / 1000) - Number(timestamp));
+  if (!Number.isFinite(age) || age > MAX_SKEW_SECONDS) return false;
+
+  const expected = createHmac("sha256", SECRET!).update(`${timestamp}.${body}`, "utf8").digest("hex");
+  const expectedBytes = Buffer.from(expected, "hex");
+
+  // Compare in constant time; a fast-exit compare leaks the signature one byte at a time.
+  return provided.some((candidate) => {
+    const candidateBytes = Buffer.from(candidate, "hex");
+    return candidateBytes.length === expectedBytes.length && timingSafeEqual(candidateBytes, expectedBytes);
+  });
+}
+
+const server = createServer((request, response) => {
+  if (request.method !== "POST") {
+    response.writeHead(405).end();
+    return;
+  }
+
+  const chunks: Buffer[] = [];
+  request.on("data", (chunk: Buffer) => chunks.push(chunk));
+  request.on("end", () => {
+    const body = Buffer.concat(chunks).toString("utf8");
+    const signature = request.headers["x-ipollowork-signature"];
+
+    if (!verify(Array.isArray(signature) ? signature[0] : signature, body)) {
+      console.warn("rejected an unsigned or invalid delivery");
+      response.writeHead(401).end();
+      return;
+    }
+
+    const eventType = request.headers["x-ipollowork-event"];
+    const deliveryId = request.headers["x-ipollowork-delivery"];
+
+    // Deliveries retry on failure, so the same id can arrive more than once. Real
+    // receivers should record handled ids and skip duplicates.
+    console.log(`[${String(eventType)}] delivery=${String(deliveryId)}`);
+    try {
+      console.log(JSON.stringify(JSON.parse(body), null, 2));
+    } catch {
+      console.log(body);
+    }
+
+    // Answer immediately; do the slow work out of band, or the sender will time out and retry.
+    response.writeHead(204).end();
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`listening for iPolloWork webhooks on http://127.0.0.1:${PORT}`);
+});

--- a/examples/public-api/README.md
+++ b/examples/public-api/README.md
@@ -1,0 +1,64 @@
+# Public API examples
+
+Runnable examples for driving iPolloWork over HTTP, with no desktop UI involved.
+
+## Setup
+
+Start a server against a workspace:
+
+```bash
+npm install -g ipollowork-server
+ipollowork-server --workspace /path/to/workspace --approval auto
+```
+
+The first boot prints a client token. Export it:
+
+```bash
+export IPOLLOWORK_BASE_URL=http://127.0.0.1:8787
+export IPOLLOWORK_TOKEN=<the token printed above>
+```
+
+`--approval auto` approves tool use automatically, which is what you want for a first run.
+For unattended production use, prefer a per-token approval policy over the global switch —
+see `04-ci-review.sh`.
+
+## Examples
+
+| File | Shows |
+|---|---|
+| `01-stream-session.ts` | Create a session, send a prompt, stream the reply token by token |
+| `02-handle-permissions.ts` | Answer tool-permission requests programmatically |
+| `03-run-task.py` | Submit a goal and block until it finishes (Python) |
+| `04-ci-review.sh` | A pure-curl CI job: review a diff and fail the build on findings |
+| `05-webhook-receiver.ts` | Verify webhook signatures and react to task events |
+
+## Running
+
+TypeScript examples (from the repo root):
+
+```bash
+pnpm --filter @ipollowork/api-sdk build
+node --experimental-strip-types examples/public-api/01-stream-session.ts
+```
+
+Python example:
+
+```bash
+python3 examples/public-api/03-run-task.py
+```
+
+Shell example:
+
+```bash
+bash examples/public-api/04-ci-review.sh origin/main
+```
+
+## Discovering the API
+
+The server documents itself, so these examples never go stale relative to your build:
+
+```bash
+curl -H "Authorization: Bearer $IPOLLOWORK_TOKEN" $IPOLLOWORK_BASE_URL/api/v1/modules
+curl -H "Authorization: Bearer $IPOLLOWORK_TOKEN" $IPOLLOWORK_BASE_URL/api/v1/openapi.json
+open $IPOLLOWORK_BASE_URL/api/v1/docs
+```

--- a/packages/ipollowork-api-sdk-python/README.md
+++ b/packages/ipollowork-api-sdk-python/README.md
@@ -1,0 +1,137 @@
+# ipollowork-api
+
+Official Python client for the iPolloWork public API. Standard library only — no
+dependencies to install in a CI job.
+
+## Install
+
+```bash
+pip install ipollowork-api
+```
+
+## Quick start
+
+Start a server and mint a token:
+
+```bash
+ipollowork-server --workspace /path/to/workspace --approval auto
+```
+
+The server prints a client token on first boot. Then:
+
+```python
+import os
+from ipollowork_api import IPolloWorkClient
+
+client = IPolloWorkClient("http://127.0.0.1:8787", token=os.environ["IPOLLOWORK_TOKEN"])
+
+workspace = client.list_workspaces()["items"][0]
+
+# Session responses are an envelope: the session plus the engine and its capabilities.
+created = client.create_session(workspace["id"], title="Release notes")
+session_id = created["session"]["id"]
+
+client.prompt_text(
+    workspace["id"],
+    session_id,
+    "Summarize the changes since v0.20 into release notes.",
+)
+
+for event in client.stream_session(workspace["id"], session_id):
+    if event["type"] == "message.delta":
+        print(event["delta"], end="", flush=True)
+    elif event["type"] == "session.idle":
+        break
+```
+
+## Streaming and resumption
+
+Every streamed event carries a `seq` cursor. Pass the last one you handled as `after` to
+resume after a dropped connection without losing events:
+
+```python
+cursor = None
+try:
+    for event in client.stream_session(ws, sid, after=cursor):
+        cursor = event.get("seq", cursor)
+        handle(event)
+except Exception:
+    # Reconnect from `cursor`; events between the drop and the retry are replayed.
+    ...
+```
+
+Resumption requires an engine that supports it: the OpenCode engine has durable cursors,
+DeepSeek Harness does not.
+
+## Approving tool use
+
+When the server runs with manual approvals, the agent pauses and emits a permission
+request. Answer it to let the run continue:
+
+```python
+for event in client.stream_session(ws, sid):
+    if event["type"] == "permission.asked":
+        permission = event["permission"]
+        reply = "once" if permission["kind"] == "read" else "reject"
+        client.reply_permission(ws, sid, permission["id"], reply)
+```
+
+## Tasks
+
+For unattended automation, `run_task` submits a goal and blocks until it finishes:
+
+```python
+task = client.run_task(
+    workspace["id"],
+    goal="Fix the failing tests in src/parser",
+    approval_policy="auto",
+    on_event=lambda name, data: print(name, data),
+)
+
+print(task["state"], task.get("summary"))
+```
+
+Tasks are held in memory by the server and do not survive a restart. For long or critical
+runs, drive sessions directly and keep your own record.
+
+## Errors
+
+Failures raise `IPolloWorkApiError`. Branch on `code`, which is stable; `message` is not.
+
+```python
+from ipollowork_api import IPolloWorkApiError
+
+try:
+    client.get_session(ws, "missing")
+except IPolloWorkApiError as error:
+    if error.code == "session_not_found":
+        ...
+    elif error.is_auth_error:
+        raise RuntimeError("Token lacks the required scope")
+    elif error.is_retryable:
+        retry()
+    else:
+        raise
+```
+
+## Token scopes
+
+| Scope | Can do |
+|---|---|
+| `viewer` | Read sessions, messages, and events |
+| `collaborator` | Everything above, plus prompt, interrupt, and answer permissions |
+| `owner` | Everything above, plus token and policy management |
+
+## API reference
+
+The server publishes its own spec — always accurate for the version you are running:
+
+- `GET /api/v1/openapi.json` — OpenAPI 3.1 document
+- `GET /api/v1/docs` — browsable documentation
+- `GET /api/v1/modules` — which API modules are enabled
+
+## Tests
+
+```bash
+python3 -m unittest discover -s tests
+```

--- a/packages/ipollowork-api-sdk-python/ipollowork_api/__init__.py
+++ b/packages/ipollowork-api-sdk-python/ipollowork_api/__init__.py
@@ -1,0 +1,19 @@
+"""Official Python client for the iPolloWork public API.
+
+Depends only on the standard library, so it drops into a CI job or a script without
+pulling anything in.
+"""
+
+from .client import IPolloWorkClient
+from .errors import IPolloWorkApiError
+from .sse import SseEvent, SseParser
+
+__all__ = [
+    "IPolloWorkClient",
+    "IPolloWorkApiError",
+    "SseEvent",
+    "SseParser",
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/packages/ipollowork-api-sdk-python/ipollowork_api/client.py
+++ b/packages/ipollowork-api-sdk-python/ipollowork_api/client.py
@@ -1,0 +1,371 @@
+"""HTTP client for the iPolloWork public API.
+
+Standard library only (``urllib``), so the SDK installs with no dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Dict, Iterator, List, Optional
+
+from .errors import IPolloWorkApiError
+from .sse import read_sse_stream
+
+DEFAULT_TIMEOUT = 30.0
+TERMINAL_TASK_STATES = frozenset({"done", "failed", "cancelled"})
+
+# Distinguishes "caller said nothing" from "caller asked for no timeout at all".
+# A long-lived SSE stream needs the latter, and ``None`` is how urllib spells it.
+_UNSET = object()
+
+
+class IPolloWorkClient:
+    """Client for a running ``ipollowork-server``.
+
+    Example::
+
+        client = IPolloWorkClient("http://127.0.0.1:8787", token="...")
+        created = client.create_session("my-workspace")
+        session_id = created["session"]["id"]
+        client.prompt_text("my-workspace", session_id, "Summarize README.md")
+        for event in client.stream_session("my-workspace", session_id):
+            if event.get("type") == "session.idle":
+                break
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        opener: Optional[urllib.request.OpenerDirector] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        if not base_url or not base_url.strip():
+            raise ValueError("base_url is required")
+        self.base_url = base_url.strip().rstrip("/")
+        self.token = token.strip() if token and token.strip() else None
+        self.timeout = timeout
+        # Injectable so tests exercise the real request-building path without a network.
+        self._opener = opener or urllib.request.build_opener()
+        self._headers = dict(headers or {})
+
+    # ------------------------------------------------------------- transport
+
+    def _build_request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: Any = None,
+        query: Optional[Dict[str, Any]] = None,
+        stream: bool = False,
+    ) -> urllib.request.Request:
+        url = f"{self.base_url}{path}"
+        if query:
+            filtered = {k: v for k, v in query.items() if v is not None}
+            if filtered:
+                url = f"{url}?{urllib.parse.urlencode(filtered)}"
+
+        data = None
+        headers = {"accept": "text/event-stream" if stream else "application/json"}
+        headers.update(self._headers)
+        if self.token:
+            headers["authorization"] = f"Bearer {self.token}"
+        if body is not None:
+            data = json.dumps(body).encode("utf-8")
+            headers["content-type"] = "application/json"
+
+        return urllib.request.Request(url, data=data, headers=headers, method=method)
+
+    def _open(self, request: urllib.request.Request, *, timeout: Any = _UNSET) -> Any:
+        path = urllib.parse.urlparse(request.full_url).path
+        effective = self.timeout if timeout is _UNSET else timeout
+        try:
+            return self._opener.open(request, timeout=effective)
+        except urllib.error.HTTPError as exc:
+            raise IPolloWorkApiError.from_response(exc.code, exc.read(), path) from None
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: Any = None,
+        query: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        response = self._open(self._build_request(path, method=method, body=body, query=query))
+        try:
+            status = getattr(response, "status", 200)
+            raw = response.read()
+        finally:
+            response.close()
+        if status == 204 or not raw:
+            return None
+        return json.loads(raw.decode("utf-8"))
+
+    # --------------------------------------------------------------- service
+
+    def health(self) -> Dict[str, Any]:
+        return self._request("/api/v1/health")
+
+    def whoami(self) -> Dict[str, Any]:
+        return self._request("/api/v1/whoami")
+
+    def list_modules(self) -> Dict[str, Any]:
+        return self._request("/api/v1/modules")
+
+    def openapi(self) -> Dict[str, Any]:
+        return self._request("/api/v1/openapi.json")
+
+    def list_workspaces(self) -> Dict[str, Any]:
+        return self._request("/api/v1/workspaces")
+
+    # -------------------------------------------------------------- sessions
+
+    def create_session(
+        self,
+        workspace_id: str,
+        *,
+        title: Optional[str] = None,
+        agent: Optional[str] = None,
+        model: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Create a session.
+
+        Returns the envelope ``{"session": {...}, "engine": str, "capabilities": {...}}``.
+        The capabilities are worth reading before assuming ``?after=`` resumption or a
+        ``system`` prompt will work — the engines differ.
+        """
+        body = {k: v for k, v in {"title": title, "agent": agent, "model": model}.items() if v is not None}
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/sessions", method="POST", body=body)
+
+    def get_session(self, workspace_id: str, session_id: str) -> Dict[str, Any]:
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}")
+
+    def delete_session(self, workspace_id: str, session_id: str) -> None:
+        self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}",
+            method="DELETE",
+        )
+
+    def prompt(
+        self,
+        workspace_id: str,
+        session_id: str,
+        *,
+        parts: List[Dict[str, Any]],
+        model: Optional[Dict[str, str]] = None,
+        agent: Optional[str] = None,
+        system: Optional[str] = None,
+        delivery: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"parts": parts}
+        for key, value in (("model", model), ("agent", agent), ("system", system), ("delivery", delivery)):
+            if value is not None:
+                body[key] = value
+        return self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}/prompt",
+            method="POST",
+            body=body,
+        )
+
+    def prompt_text(self, workspace_id: str, session_id: str, text: str, **kwargs: Any) -> Dict[str, Any]:
+        """Send a single text message."""
+        return self.prompt(workspace_id, session_id, parts=[{"type": "text", "text": text}], **kwargs)
+
+    def interrupt(self, workspace_id: str, session_id: str) -> Dict[str, Any]:
+        return self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}/interrupt",
+            method="POST",
+        )
+
+    def list_permissions(self, workspace_id: str, session_id: str) -> Dict[str, Any]:
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}/permissions")
+
+    def reply_permission(self, workspace_id: str, session_id: str, permission_id: str, reply: str) -> None:
+        if reply not in ("once", "always", "reject"):
+            raise ValueError("reply must be 'once', 'always' or 'reject'")
+        self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}"
+            f"/permissions/{_enc(permission_id)}",
+            method="POST",
+            body={"reply": reply},
+        )
+
+    def list_questions(self, workspace_id: str, session_id: str) -> Dict[str, Any]:
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}/questions")
+
+    def reply_question(
+        self,
+        workspace_id: str,
+        session_id: str,
+        question_id: str,
+        answers: List[List[str]],
+    ) -> None:
+        self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}"
+            f"/questions/{_enc(question_id)}",
+            method="POST",
+            body={"answers": answers},
+        )
+
+    def stream_session(
+        self,
+        workspace_id: str,
+        session_id: str,
+        *,
+        after: Optional[str] = None,
+    ) -> Iterator[Dict[str, Any]]:
+        """Yield normalized session events.
+
+        Pass the ``seq`` of the last event you handled as ``after`` to resume a dropped
+        connection without losing events.
+        """
+        request = self._build_request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/sessions/{_enc(session_id)}/events",
+            query={"after": after},
+            stream=True,
+        )
+        # A long-lived stream must not inherit the per-request timeout.
+        response = self._open(request, timeout=None)
+        try:
+            for frame in read_sse_stream(response):
+                event = _parse_event(frame.event, frame.data, frame.id)
+                if event is not None:
+                    yield event
+        finally:
+            response.close()
+
+    # ----------------------------------------------------------------- tasks
+
+    def create_task(
+        self,
+        workspace_id: str,
+        *,
+        goal: str,
+        agent: Optional[str] = None,
+        model: Optional[Dict[str, str]] = None,
+        approval_policy: Optional[str] = None,
+        timeout_ms: Optional[int] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"goal": goal}
+        for key, value in (
+            ("agent", agent),
+            ("model", model),
+            ("approvalPolicy", approval_policy),
+            ("timeoutMs", timeout_ms),
+            ("metadata", metadata),
+        ):
+            if value is not None:
+                body[key] = value
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/tasks", method="POST", body=body)
+
+    def list_tasks(self, workspace_id: str, *, state: Optional[str] = None) -> Dict[str, Any]:
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/tasks", query={"state": state})
+
+    def get_task(self, workspace_id: str, task_id: str) -> Dict[str, Any]:
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/tasks/{_enc(task_id)}")
+
+    def cancel_task(self, workspace_id: str, task_id: str) -> Dict[str, Any]:
+        return self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/tasks/{_enc(task_id)}/cancel",
+            method="POST",
+        )
+
+    def stream_task(self, workspace_id: str, task_id: str) -> Iterator[Dict[str, Any]]:
+        request = self._build_request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/tasks/{_enc(task_id)}/events",
+            stream=True,
+        )
+        response = self._open(request, timeout=None)
+        try:
+            for frame in read_sse_stream(response):
+                yield {"event": frame.event, "data": _safe_json(frame.data)}
+        finally:
+            response.close()
+
+    def run_task(self, workspace_id: str, *, goal: str, on_event: Any = None, **kwargs: Any) -> Dict[str, Any]:  # noqa: D417
+        """Submit a task and block until it reaches a terminal state.
+
+        Follows the event stream rather than polling, then re-reads the task so a run
+        that finished before the stream attached is still reported correctly.
+        """
+        task = self.create_task(workspace_id, goal=goal, **kwargs)
+        if task.get("state") in TERMINAL_TASK_STATES:
+            return task
+
+        for event in self.stream_task(workspace_id, task["id"]):
+            if on_event is not None:
+                on_event(event["event"], event["data"])
+            state = _read_state(event["data"])
+            if state in TERMINAL_TASK_STATES:
+                break
+
+        return self.get_task(workspace_id, task["id"])
+
+    # -------------------------------------------------------------- webhooks
+
+    def create_webhook(
+        self,
+        workspace_id: str,
+        *,
+        url: str,
+        events: List[str],
+        secret: Optional[str] = None,
+        active: bool = True,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {"url": url, "events": events, "active": active}
+        if secret is not None:
+            body["secret"] = secret
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/webhooks", method="POST", body=body)
+
+    def list_webhooks(self, workspace_id: str) -> Dict[str, Any]:
+        return self._request(f"/api/v1/workspaces/{_enc(workspace_id)}/webhooks")
+
+    def delete_webhook(self, workspace_id: str, webhook_id: str) -> None:
+        self._request(
+            f"/api/v1/workspaces/{_enc(workspace_id)}/webhooks/{_enc(webhook_id)}",
+            method="DELETE",
+        )
+
+
+def _enc(value: str) -> str:
+    return urllib.parse.quote(str(value), safe="")
+
+
+def _safe_json(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except ValueError:
+        return value
+
+
+def _parse_event(event_name: str, data: str, event_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    parsed = _safe_json(data)
+    if not isinstance(parsed, dict):
+        return None
+    if not isinstance(parsed.get("type"), str):
+        if not event_name:
+            return None
+        parsed["type"] = event_name
+    if event_id is not None and "seq" not in parsed:
+        parsed["seq"] = event_id
+    return parsed
+
+
+def _read_state(data: Any) -> Optional[str]:
+    if not isinstance(data, dict):
+        return None
+    state = data.get("state")
+    if isinstance(state, str):
+        return state
+    task = data.get("task")
+    if isinstance(task, dict) and isinstance(task.get("state"), str):
+        return task["state"]
+    return None

--- a/packages/ipollowork-api-sdk-python/ipollowork_api/errors.py
+++ b/packages/ipollowork-api-sdk-python/ipollowork_api/errors.py
@@ -1,0 +1,70 @@
+"""Error type for the iPolloWork API."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+
+class IPolloWorkApiError(Exception):
+    """A non-2xx response.
+
+    The server always answers with ``{code, message, details}``. Branch on ``code``:
+    it is part of the contract, while ``message`` is free text that may change.
+    """
+
+    def __init__(
+        self,
+        *,
+        status: int,
+        code: str,
+        message: str,
+        details: Any = None,
+        request_path: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.message = message
+        self.details = details
+        self.request_path = request_path
+
+    @property
+    def is_retryable(self) -> bool:
+        """True for transient upstream and rate-limit conditions."""
+        return self.status in (429, 502, 503, 504)
+
+    @property
+    def is_auth_error(self) -> bool:
+        """True when the token is missing, expired, or lacks the required scope."""
+        return self.status in (401, 403)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"IPolloWorkApiError(status={self.status!r}, code={self.code!r}, "
+            f"message={self.message!r}, path={self.request_path!r})"
+        )
+
+    @classmethod
+    def from_response(cls, status: int, body: bytes, request_path: str) -> "IPolloWorkApiError":
+        code = f"http_{status}"
+        message = "Request failed"
+        details: Optional[Any] = None
+        try:
+            parsed = json.loads(body.decode("utf-8"))
+            if isinstance(parsed, dict):
+                if isinstance(parsed.get("code"), str):
+                    code = parsed["code"]
+                if isinstance(parsed.get("message"), str):
+                    message = parsed["message"]
+                details = parsed.get("details")
+        except (ValueError, UnicodeDecodeError):
+            # A proxy error page rather than the API's JSON body.
+            pass
+        return cls(
+            status=status,
+            code=code,
+            message=message,
+            details=details,
+            request_path=request_path,
+        )

--- a/packages/ipollowork-api-sdk-python/ipollowork_api/sse.py
+++ b/packages/ipollowork-api-sdk-python/ipollowork_api/sse.py
@@ -1,0 +1,100 @@
+"""Incremental SSE parsing.
+
+Separate from the HTTP client and written as a pure parser, because the failure it has
+to survive is a network chunk boundary landing in the middle of a frame — a bug that
+only appears under load and cannot be tested if the parsing lives inside a read loop.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import IO, Iterator, List, Optional
+
+
+@dataclass(frozen=True)
+class SseEvent:
+    event: str
+    data: str
+    id: Optional[str] = None
+
+
+class SseParser:
+    """Feed raw text in, get whole frames out."""
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def push(self, chunk: str) -> List[SseEvent]:
+        self._buffer += chunk
+        # Normalize CRLF and lone CR so frame splitting is uniform.
+        self._buffer = self._buffer.replace("\r\n", "\n").replace("\r", "\n")
+
+        events: List[SseEvent] = []
+        while True:
+            boundary = self._buffer.find("\n\n")
+            if boundary == -1:
+                break
+            raw = self._buffer[:boundary]
+            self._buffer = self._buffer[boundary + 2 :]
+            event = _parse_frame(raw)
+            if event is not None:
+                events.append(event)
+        return events
+
+    def flush(self) -> List[SseEvent]:
+        """Emit a trailing frame that was never terminated by a blank line."""
+        raw, self._buffer = self._buffer, ""
+        event = _parse_frame(raw)
+        return [event] if event is not None else []
+
+
+def _parse_frame(raw: str) -> Optional[SseEvent]:
+    if not raw.strip():
+        return None
+
+    event = "message"
+    event_id: Optional[str] = None
+    data: List[str] = []
+
+    for line in raw.split("\n"):
+        if not line or line.startswith(":"):
+            continue
+        field, sep, value = line.partition(":")
+        if not sep:
+            field, value = line, ""
+        if value.startswith(" "):
+            value = value[1:]
+
+        if field == "event":
+            event = value
+        elif field == "data":
+            data.append(value)
+        elif field == "id":
+            event_id = value
+
+    if not data and event == "message":
+        return None
+    return SseEvent(event=event, data="\n".join(data), id=event_id)
+
+
+def read_sse_stream(stream: IO[bytes], chunk_size: int = 8192) -> Iterator[SseEvent]:
+    """Yield frames from a byte stream (an ``http.client.HTTPResponse``, typically)."""
+    parser = SseParser()
+    decoder_buffer = b""
+    while True:
+        chunk = stream.read(chunk_size)
+        if not chunk:
+            break
+        decoder_buffer += chunk
+        # Decode only complete UTF-8 sequences; a multi-byte character can straddle
+        # a chunk boundary, and decoding eagerly would corrupt it.
+        try:
+            text = decoder_buffer.decode("utf-8")
+            decoder_buffer = b""
+        except UnicodeDecodeError as exc:
+            text = decoder_buffer[: exc.start].decode("utf-8")
+            decoder_buffer = decoder_buffer[exc.start :]
+        for event in parser.push(text):
+            yield event
+    for event in parser.flush():
+        yield event

--- a/packages/ipollowork-api-sdk-python/pyproject.toml
+++ b/packages/ipollowork-api-sdk-python/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ipollowork-api"
+version = "0.1.0"
+description = "Official Python client for the iPolloWork public API"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "SEE LICENSE IN ../../LICENSE" }
+authors = [{ name = "iPolloWork", email = "support@ipolloworklabs.com" }]
+keywords = ["ipollowork", "api", "sdk", "client", "ai-agent"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Intended Audience :: Developers",
+]
+# Standard library only, on purpose: the SDK should drop into a CI job with no install step.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/Devin-AXIS/iPolloWork/tree/main/packages/ipollowork-api-sdk-python"
+Repository = "https://github.com/Devin-AXIS/iPolloWork"
+Issues = "https://github.com/Devin-AXIS/iPolloWork/issues"
+
+[tool.setuptools.packages.find]
+include = ["ipollowork_api*"]

--- a/packages/ipollowork-api-sdk-python/tests/test_sdk.py
+++ b/packages/ipollowork-api-sdk-python/tests/test_sdk.py
@@ -1,0 +1,300 @@
+"""Tests for the iPolloWork Python SDK. Run with: python3 -m unittest discover -s tests"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import unittest
+import urllib.error
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from ipollowork_api import IPolloWorkApiError, IPolloWorkClient, SseParser  # noqa: E402
+from ipollowork_api.sse import read_sse_stream  # noqa: E402
+
+
+class FakeResponse(io.BytesIO):
+    def __init__(self, payload: bytes, status: int = 200) -> None:
+        super().__init__(payload)
+        self.status = status
+
+
+class RecordingOpener:
+    """Stands in for urllib's opener and records what the client sent."""
+
+    def __init__(self, responder) -> None:
+        self.responder = responder
+        self.requests = []
+
+    def open(self, request, timeout=None):
+        self.requests.append((request, timeout))
+        return self.responder(request)
+
+
+def json_opener(payload, status=200):
+    return RecordingOpener(lambda _req: FakeResponse(json.dumps(payload).encode(), status))
+
+
+def session_envelope():
+    """The exact envelope the server returns, so stubs cannot drift from it."""
+    return {
+        "session": {"id": "s1", "title": "Session one"},
+        "engine": "opencode",
+        "capabilities": {
+            "streaming": True,
+            "resumableStreaming": True,
+            "permissions": True,
+            "questions": True,
+            "interrupt": True,
+            "wait": True,
+            "promptOptions": {"system": False, "reasoningEffort": False, "variant": True},
+        },
+    }
+
+
+class SseParserTests(unittest.TestCase):
+    def test_parses_single_frame(self):
+        events = SseParser().push('event: a\ndata: {"x":1}\n\n')
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].event, "a")
+        self.assertEqual(events[0].data, '{"x":1}')
+
+    def test_keeps_id(self):
+        events = SseParser().push("id: 7\nevent: a\ndata: 1\n\n")
+        self.assertEqual(events[0].id, "7")
+
+    def test_reassembles_frame_split_across_chunks(self):
+        parser = SseParser()
+        self.assertEqual(parser.push("event: a\nda"), [])
+        self.assertEqual(parser.push("ta: hello\n"), [])
+        events = parser.push("\n")
+        self.assertEqual(events[0].data, "hello")
+
+    def test_multiple_frames_in_one_chunk(self):
+        events = SseParser().push("event: a\ndata: 1\n\nevent: b\ndata: 2\n\n")
+        self.assertEqual([e.event for e in events], ["a", "b"])
+
+    def test_joins_multiple_data_lines(self):
+        events = SseParser().push("event: log\ndata: one\ndata: two\n\n")
+        self.assertEqual(events[0].data, "one\ntwo")
+
+    def test_ignores_keepalive_comments(self):
+        events = SseParser().push(": keepalive\n\nevent: a\ndata: 1\n\n")
+        self.assertEqual(len(events), 1)
+
+    def test_normalizes_crlf(self):
+        events = SseParser().push("event: a\r\ndata: 1\r\n\r\n")
+        self.assertEqual(events[0].data, "1")
+
+    def test_strips_only_one_leading_space(self):
+        events = SseParser().push("event: a\ndata:  two\n\n")
+        self.assertEqual(events[0].data, " two")
+
+    def test_flush_emits_unterminated_frame(self):
+        parser = SseParser()
+        self.assertEqual(parser.push("event: a\ndata: 1"), [])
+        self.assertEqual(parser.flush()[0].data, "1")
+
+    def test_flush_on_empty_buffer(self):
+        self.assertEqual(SseParser().flush(), [])
+
+
+class ReadSseStreamTests(unittest.TestCase):
+    def test_yields_frames_in_order(self):
+        stream = io.BytesIO(b"event: a\ndata: 1\n\nevent: b\ndata: 2\n\n")
+        self.assertEqual([e.event for e in read_sse_stream(stream)], ["a", "b"])
+
+    def test_survives_multibyte_split_across_chunks(self):
+        # The frame carries a Chinese character whose UTF-8 bytes are split by the
+        # 8-byte read size, which would corrupt it if decoded eagerly.
+        payload = "event: a\ndata: 数据\n\n".encode("utf-8")
+        stream = io.BytesIO(payload)
+        events = list(read_sse_stream(stream, chunk_size=8))
+        self.assertEqual(events[0].data, "数据")
+
+
+class ClientTests(unittest.TestCase):
+    def test_requires_base_url(self):
+        with self.assertRaises(ValueError):
+            IPolloWorkClient("   ")
+
+    def test_sends_bearer_token_and_trims_base_url(self):
+        opener = json_opener({"ok": True})
+        IPolloWorkClient("http://host:8787/", token="tok", opener=opener).health()
+
+        request, _timeout = opener.requests[0]
+        self.assertEqual(request.full_url, "http://host:8787/api/v1/health")
+        self.assertEqual(request.get_header("Authorization"), "Bearer tok")
+
+    def test_omits_authorization_without_token(self):
+        opener = json_opener({"ok": True})
+        IPolloWorkClient("http://host", opener=opener).health()
+        self.assertIsNone(opener.requests[0][0].get_header("Authorization"))
+
+    def test_percent_encodes_path_segments(self):
+        opener = json_opener(session_envelope())
+        IPolloWorkClient("http://host", opener=opener).get_session("work space/1", "sess/2")
+
+        self.assertTrue(
+            opener.requests[0][0].full_url.endswith(
+                "/api/v1/workspaces/work%20space%2F1/sessions/sess%2F2"
+            )
+        )
+
+    def test_prompt_text_builds_documented_body(self):
+        opener = json_opener({"messageId": "m1"})
+        IPolloWorkClient("http://host", opener=opener).prompt_text("w1", "s1", "ship it", agent="build")
+
+        request = opener.requests[0][0]
+        self.assertEqual(request.method, "POST")
+        self.assertEqual(
+            json.loads(request.data.decode()),
+            {"parts": [{"type": "text", "text": "ship it"}], "agent": "build"},
+        )
+
+    def test_drops_none_query_parameters(self):
+        opener = json_opener({"items": []})
+        IPolloWorkClient("http://host", opener=opener).list_tasks("w1")
+        self.assertNotIn("?", opener.requests[0][0].full_url)
+
+    def test_includes_query_parameters_when_set(self):
+        opener = json_opener({"items": []})
+        IPolloWorkClient("http://host", opener=opener).list_tasks("w1", state="running")
+        self.assertIn("state=running", opener.requests[0][0].full_url)
+
+    def test_rejects_invalid_permission_reply(self):
+        client = IPolloWorkClient("http://host", opener=json_opener({}))
+        with self.assertRaises(ValueError):
+            client.reply_permission("w1", "s1", "p1", "allow")
+
+    def test_create_session_returns_the_envelope(self):
+        opener = json_opener(session_envelope())
+        created = IPolloWorkClient("http://host", opener=opener).create_session("w1", title="Session one")
+
+        # The id lives under "session"; reading it flat would send the next request to
+        # /sessions/None/prompt.
+        self.assertEqual(created["session"]["id"], "s1")
+        self.assertEqual(created["engine"], "opencode")
+        self.assertFalse(created["capabilities"]["promptOptions"]["system"])
+
+    def test_list_permissions_uses_the_permissions_key(self):
+        opener = json_opener({"permissions": [{"id": "p1"}]})
+        result = IPolloWorkClient("http://host", opener=opener).list_permissions("w1", "s1")
+        self.assertEqual(len(result["permissions"]), 1)
+
+    def test_list_webhooks_never_returns_a_secret(self):
+        opener = json_opener({"webhooks": [{"id": "wh1", "hasSecret": True}]})
+        result = IPolloWorkClient("http://host", opener=opener).list_webhooks("w1")
+        self.assertTrue(result["webhooks"][0]["hasSecret"])
+        self.assertNotIn("secret", result["webhooks"][0])
+
+    def test_maps_error_body_to_typed_error(self):
+        def responder(request):
+            raise urllib.error.HTTPError(
+                request.full_url,
+                404,
+                "Not Found",
+                {},
+                io.BytesIO(json.dumps(
+                    {"code": "session_not_found", "message": "Session not found", "details": {"id": "s1"}}
+                ).encode()),
+            )
+
+        client = IPolloWorkClient("http://host", opener=RecordingOpener(responder))
+        with self.assertRaises(IPolloWorkApiError) as ctx:
+            client.get_session("w1", "s1")
+
+        error = ctx.exception
+        self.assertEqual(error.status, 404)
+        self.assertEqual(error.code, "session_not_found")
+        self.assertEqual(error.details, {"id": "s1"})
+        self.assertFalse(error.is_retryable)
+        self.assertEqual(error.request_path, "/api/v1/workspaces/w1/sessions/s1")
+
+    def test_synthesizes_code_for_non_json_error(self):
+        def responder(request):
+            raise urllib.error.HTTPError(
+                request.full_url, 502, "Bad Gateway", {}, io.BytesIO(b"<html>502</html>")
+            )
+
+        client = IPolloWorkClient("http://host", opener=RecordingOpener(responder))
+        with self.assertRaises(IPolloWorkApiError) as ctx:
+            client.health()
+
+        self.assertEqual(ctx.exception.code, "http_502")
+        self.assertTrue(ctx.exception.is_retryable)
+
+    def test_classifies_auth_errors(self):
+        def responder(request):
+            raise urllib.error.HTTPError(
+                request.full_url, 403, "Forbidden", {},
+                io.BytesIO(json.dumps({"code": "forbidden", "message": "Insufficient token scope"}).encode()),
+            )
+
+        client = IPolloWorkClient("http://host", opener=RecordingOpener(responder))
+        with self.assertRaises(IPolloWorkApiError) as ctx:
+            client.health()
+
+        self.assertTrue(ctx.exception.is_auth_error)
+
+    def test_returns_none_for_204(self):
+        opener = RecordingOpener(lambda _req: FakeResponse(b"", 204))
+        self.assertIsNone(IPolloWorkClient("http://host", opener=opener).delete_session("w1", "s1"))
+
+    def test_stream_session_applies_cursor_and_seq(self):
+        frames = (
+            b'id: 1\nevent: message.delta\ndata: {"type":"message.delta","sessionId":"s1"}\n\n'
+            b": keepalive\n\n"
+            b'id: 2\nevent: session.idle\ndata: {"type":"session.idle","sessionId":"s1"}\n\n'
+        )
+        opener = RecordingOpener(lambda _req: FakeResponse(frames))
+
+        client = IPolloWorkClient("http://host", opener=opener)
+        events = list(client.stream_session("w1", "s1", after="0"))
+
+        self.assertIn("after=0", opener.requests[0][0].full_url)
+        self.assertEqual(opener.requests[0][0].get_header("Accept"), "text/event-stream")
+        self.assertEqual([e["type"] for e in events], ["message.delta", "session.idle"])
+        self.assertEqual([e["seq"] for e in events], ["1", "2"])
+
+    def test_stream_disables_the_request_timeout(self):
+        opener = RecordingOpener(lambda _req: FakeResponse(b"event: a\ndata: {}\n\n"))
+        list(IPolloWorkClient("http://host", opener=opener).stream_session("w1", "s1"))
+        self.assertIsNone(opener.requests[0][1])
+
+    def test_run_task_returns_immediately_when_already_terminal(self):
+        opener = RecordingOpener(
+            lambda _req: FakeResponse(json.dumps({"id": "t1", "state": "done"}).encode())
+        )
+        task = IPolloWorkClient("http://host", opener=opener).run_task("w1", goal="g")
+
+        self.assertEqual(task["state"], "done")
+        self.assertEqual(len(opener.requests), 1)
+
+    def test_run_task_follows_stream_then_rereads(self):
+        def responder(request):
+            path = request.full_url
+            if path.endswith("/tasks") and request.method == "POST":
+                return FakeResponse(json.dumps({"id": "t1", "state": "queued"}).encode())
+            if path.endswith("/events"):
+                return FakeResponse(
+                    b'event: task.updated\ndata: {"state":"running"}\n\n'
+                    b'event: task.updated\ndata: {"state":"done"}\n\n'
+                )
+            return FakeResponse(json.dumps({"id": "t1", "state": "done"}).encode())
+
+        opener = RecordingOpener(responder)
+        seen = []
+        task = IPolloWorkClient("http://host", opener=opener).run_task(
+            "w1", goal="g", on_event=lambda _name, data: seen.append(data["state"])
+        )
+
+        self.assertEqual(seen, ["running", "done"])
+        self.assertEqual(task["state"], "done")
+        self.assertEqual(len(opener.requests), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/ipollowork-api-sdk/README.md
+++ b/packages/ipollowork-api-sdk/README.md
@@ -1,0 +1,147 @@
+# @ipollowork/api-sdk
+
+Official TypeScript client for the iPolloWork public API. Zero runtime dependencies.
+
+## Install
+
+```bash
+npm install @ipollowork/api-sdk
+```
+
+## Quick start
+
+Start a server and mint a token:
+
+```bash
+ipollowork-server --workspace /path/to/workspace --approval auto
+```
+
+The server prints a client token on first boot. Then:
+
+```ts
+import { IPolloWorkClient } from "@ipollowork/api-sdk";
+
+const client = new IPolloWorkClient({
+  baseUrl: "http://127.0.0.1:8787",
+  token: process.env.IPOLLOWORK_TOKEN,
+});
+
+const [workspace] = (await client.listWorkspaces()).items;
+
+// Session responses are an envelope: the session plus the engine and its capabilities.
+const { session, capabilities } = await client.createSession(workspace.id, { title: "Release notes" });
+
+await client.promptText(workspace.id, session.id, "Summarize the changes since v0.20 into release notes.");
+
+for await (const event of client.streamSession(workspace.id, session.id)) {
+  if (event.type === "message.delta") process.stdout.write(event.delta);
+  if (event.type === "session.idle") break;
+}
+```
+
+## Streaming and resumption
+
+Every streamed event carries a `seq` cursor. Pass the last one you handled as `after` to
+resume after a dropped connection without losing events:
+
+```ts
+let cursor: string | undefined;
+try {
+  for await (const event of client.streamSession(ws, sid, { after: cursor })) {
+    cursor = event.seq ?? cursor;
+    handle(event);
+  }
+} catch {
+  // Reconnect from `cursor`; events between the drop and the retry are replayed.
+}
+```
+
+Resumption requires an engine that supports it. Check
+`GET /api/v1/workspaces/:id/sessions/:sid` or the engine capability list — the OpenCode
+engine has durable cursors, DeepSeek Harness does not.
+
+## Engine differences
+
+The API is engine-agnostic, but two prompt options are not universally supported. Rather
+than accept and ignore them, the server rejects them with `501
+engine_prompt_option_unsupported` and names the fields in `details.unsupported`:
+
+```ts
+try {
+  await client.prompt(ws, sid, { parts: [{ type: "text", text: "…" }], system: "Be terse" });
+} catch (error) {
+  if (error instanceof IPolloWorkApiError && error.code === "engine_prompt_option_unsupported") {
+    // OpenCode's v2 prompt endpoint has no system-prompt field. Fold the instruction into
+    // the message text, or set it on the agent instead.
+  }
+}
+```
+
+`createSession` and `getSession` both report what the engine actually applies under
+`capabilities.promptOptions`.
+
+## Approving tool use
+
+When the server runs with manual approvals, the agent pauses and emits a permission
+request. Answer it to let the run continue:
+
+```ts
+for await (const event of client.streamSession(ws, sid)) {
+  if (event.type === "permission.asked") {
+    const safe = event.permission.kind === "read";
+    await client.replyPermission(ws, sid, event.permission.id, safe ? "once" : "reject");
+  }
+}
+```
+
+## Tasks
+
+For unattended automation, `runTask` submits a goal and resolves when it finishes:
+
+```ts
+const task = await client.runTask(
+  workspace.id,
+  { goal: "Fix the failing tests in src/parser", approvalPolicy: "auto" },
+  { onEvent: (name, data) => console.log(name, data) },
+);
+
+console.log(task.state, task.summary);
+```
+
+Tasks are held in memory by the server and do not survive a restart. For long or critical
+runs, drive sessions directly and keep your own record.
+
+## Errors
+
+Failures throw `IPolloWorkApiError`. Branch on `code`, which is stable; `message` is not.
+
+```ts
+import { IPolloWorkApiError } from "@ipollowork/api-sdk";
+
+try {
+  await client.getSession(ws, "missing");
+} catch (error) {
+  if (error instanceof IPolloWorkApiError) {
+    if (error.code === "session_not_found") return null;
+    if (error.isAuthError) throw new Error("Token lacks the required scope");
+    if (error.isRetryable) return retry();
+  }
+  throw error;
+}
+```
+
+## Token scopes
+
+| Scope | Can do |
+|---|---|
+| `viewer` | Read sessions, messages, and events |
+| `collaborator` | Everything above, plus prompt, interrupt, and answer permissions |
+| `owner` | Everything above, plus token and policy management |
+
+## API reference
+
+The server publishes its own spec — always accurate for the version you are running:
+
+- `GET /api/v1/openapi.json` — OpenAPI 3.1 document
+- `GET /api/v1/docs` — browsable documentation
+- `GET /api/v1/modules` — which API modules are enabled

--- a/packages/ipollowork-api-sdk/package.json
+++ b/packages/ipollowork-api-sdk/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@ipollowork/api-sdk",
+  "version": "0.1.0",
+  "description": "Official TypeScript client for the iPolloWork public API",
+  "author": "iPolloWork <support@ipolloworklabs.com>",
+  "license": "SEE LICENSE IN ../../LICENSE",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "development": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "src",
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "bun test src"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Devin-AXIS/iPolloWork.git",
+    "directory": "packages/ipollowork-api-sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/Devin-AXIS/iPolloWork/issues"
+  },
+  "homepage": "https://github.com/Devin-AXIS/iPolloWork/tree/main/packages/ipollowork-api-sdk",
+  "keywords": [
+    "ipollowork",
+    "api",
+    "sdk",
+    "client",
+    "ai-agent"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/packages/ipollowork-api-sdk/src/client.ts
+++ b/packages/ipollowork-api-sdk/src/client.ts
@@ -1,0 +1,409 @@
+import { errorFromResponse, IPolloWorkApiError } from "./errors.js";
+import { readSseStream } from "./sse.js";
+import type {
+  ApiModuleDescriptor,
+  Identity,
+  ModelRef,
+  Permission,
+  PermissionReply,
+  PromptPart,
+  Question,
+  Session,
+  SessionEnvelope,
+  SessionEvent,
+  Task,
+  TaskState,
+  Webhook,
+  Workspace,
+} from "./types.js";
+
+export interface IPolloWorkClientOptions {
+  /** Server base URL, e.g. `http://127.0.0.1:8787`. */
+  baseUrl: string;
+  /** Bearer token issued by `POST /tokens`. */
+  token?: string;
+  /** Injectable for tests and for runtimes with a custom fetch. */
+  fetch?: typeof fetch;
+  /** Per-request timeout. Streaming requests are exempt. Defaults to 30s. */
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+}
+
+interface RequestOptions {
+  method?: string;
+  body?: unknown;
+  query?: Record<string, string | number | boolean | undefined>;
+  signal?: AbortSignal;
+  /** Streaming requests skip the timeout and return the raw response. */
+  stream?: boolean;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export class IPolloWorkClient {
+  readonly #baseUrl: string;
+  readonly #token?: string;
+  readonly #fetch: typeof fetch;
+  readonly #timeoutMs: number;
+  readonly #headers: Record<string, string>;
+
+  constructor(options: IPolloWorkClientOptions) {
+    if (!options.baseUrl?.trim()) throw new Error("baseUrl is required");
+    this.#baseUrl = options.baseUrl.trim().replace(/\/+$/, "");
+    this.#token = options.token?.trim() || undefined;
+    this.#fetch = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.#headers = options.headers ?? {};
+  }
+
+  // ---------------------------------------------------------------- transport
+
+  async #request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+    const response = await this.#raw(path, options);
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  async #raw(path: string, options: RequestOptions = {}): Promise<Response> {
+    const url = new URL(`${this.#baseUrl}${path}`);
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, String(value));
+    }
+
+    const headers: Record<string, string> = { accept: "application/json", ...this.#headers };
+    if (this.#token) headers.authorization = `Bearer ${this.#token}`;
+    if (options.body !== undefined) headers["content-type"] = "application/json";
+    if (options.stream) headers.accept = "text/event-stream";
+
+    // A timeout must not silently swallow a caller's own cancellation, so the two
+    // signals are combined rather than one replacing the other.
+    const timeout = options.stream ? undefined : new AbortController();
+    const timer = timeout ? setTimeout(() => timeout.abort(), this.#timeoutMs) : undefined;
+    const signal = combineSignals([options.signal, timeout?.signal]);
+
+    try {
+      const response = await this.#fetch(url.toString(), {
+        method: options.method ?? "GET",
+        headers,
+        ...(options.body !== undefined ? { body: JSON.stringify(options.body) } : {}),
+        ...(signal ? { signal } : {}),
+      });
+      if (!response.ok) throw await errorFromResponse(response, url.pathname);
+      return response;
+    } catch (error) {
+      if (error instanceof IPolloWorkApiError) throw error;
+      if (timeout?.signal.aborted && !options.signal?.aborted) {
+        throw new IPolloWorkApiError({
+          status: 408,
+          code: "request_timeout",
+          message: `Request timed out after ${this.#timeoutMs}ms`,
+          requestPath: url.pathname,
+        });
+      }
+      throw error;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  // ------------------------------------------------------------------ service
+
+  health(): Promise<{ ok: boolean }> {
+    return this.#request("/api/v1/health");
+  }
+
+  whoami(): Promise<Identity> {
+    return this.#request("/api/v1/whoami");
+  }
+
+  /** Returns the module catalogue as a bare array, matching `GET /api/v1/modules`. */
+  listModules(): Promise<ApiModuleDescriptor[]> {
+    return this.#request("/api/v1/modules");
+  }
+
+  openapi(): Promise<Record<string, unknown>> {
+    return this.#request("/api/v1/openapi.json");
+  }
+
+  listWorkspaces(): Promise<{ items: Workspace[] }> {
+    return this.#request("/api/v1/workspaces");
+  }
+
+  // ----------------------------------------------------------------- sessions
+
+  /**
+   * Creates a session.
+   *
+   * Returns the full envelope, so the engine's `capabilities` are available at the point
+   * you would decide whether to stream with `?after=` or pass a `system` prompt. Use
+   * `.session` for the session itself.
+   */
+  createSession(
+    workspaceId: string,
+    input: { title?: string; agent?: string; model?: ModelRef } = {},
+  ): Promise<SessionEnvelope> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions`, { method: "POST", body: input });
+  }
+
+  getSession(workspaceId: string, sessionId: string): Promise<SessionEnvelope> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}`);
+  }
+
+  updateSession(workspaceId: string, sessionId: string, input: { title: string }): Promise<SessionEnvelope> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}`, {
+      method: "PATCH",
+      body: input,
+    });
+  }
+
+  deleteSession(workspaceId: string, sessionId: string): Promise<{ deleted: boolean; sessionId: string }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}`, { method: "DELETE" });
+  }
+
+  /**
+   * Sends a turn.
+   *
+   * `system` and `reasoningEffort` are engine-dependent: an engine that cannot apply them
+   * answers `501 engine_prompt_option_unsupported` rather than accepting and ignoring
+   * them. `getSession(...).capabilities.promptOptions` reports which are honoured.
+   */
+  prompt(
+    workspaceId: string,
+    sessionId: string,
+    input: {
+      parts: PromptPart[];
+      model?: ModelRef;
+      agent?: string;
+      system?: string;
+      reasoningEffort?: string;
+      variant?: string;
+      delivery?: "steer" | "queue";
+    },
+  ): Promise<{ accepted: boolean; sessionId: string; messageId: string | null }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/prompt`, {
+      method: "POST",
+      body: input,
+    });
+  }
+
+  /** Convenience wrapper for the common "send one text message" case. */
+  promptText(
+    workspaceId: string,
+    sessionId: string,
+    text: string,
+    input: { model?: ModelRef; agent?: string } = {},
+  ): Promise<{ accepted: boolean; sessionId: string; messageId: string | null }> {
+    return this.prompt(workspaceId, sessionId, { parts: [{ type: "text", text }], ...input });
+  }
+
+  interrupt(workspaceId: string, sessionId: string): Promise<{ interrupted: boolean; sessionId: string }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/interrupt`, {
+      method: "POST",
+    });
+  }
+
+  listPermissions(workspaceId: string, sessionId: string): Promise<{ permissions: Permission[] }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/permissions`);
+  }
+
+  replyPermission(
+    workspaceId: string,
+    sessionId: string,
+    permissionId: string,
+    reply: PermissionReply,
+  ): Promise<{ ok: boolean; permissionId: string; reply: PermissionReply }> {
+    return this.#request(
+      `/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/permissions/${enc(permissionId)}`,
+      { method: "POST", body: { reply } },
+    );
+  }
+
+  listQuestions(workspaceId: string, sessionId: string): Promise<{ questions: Question[] }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/questions`);
+  }
+
+  replyQuestion(
+    workspaceId: string,
+    sessionId: string,
+    questionId: string,
+    answers: string[][],
+  ): Promise<{ ok: boolean; questionId: string }> {
+    return this.#request(
+      `/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/questions/${enc(questionId)}`,
+      { method: "POST", body: { answers } },
+    );
+  }
+
+  /**
+   * Streams session events.
+   *
+   * Pass the `seq` of the last event you handled as `after` to resume without gaps.
+   */
+  async *streamSession(
+    workspaceId: string,
+    sessionId: string,
+    options: { after?: string; signal?: AbortSignal } = {},
+  ): AsyncGenerator<SessionEvent, void, unknown> {
+    const response = await this.#raw(
+      `/api/v1/workspaces/${enc(workspaceId)}/sessions/${enc(sessionId)}/events`,
+      { stream: true, query: { after: options.after }, signal: options.signal },
+    );
+
+    for await (const frame of readSseStream(response, options.signal)) {
+      const event = parseEventFrame(frame.event, frame.data, frame.id);
+      if (event) yield event;
+    }
+  }
+
+  // -------------------------------------------------------------------- tasks
+
+  createTask(
+    workspaceId: string,
+    input: {
+      goal: string;
+      agent?: string;
+      model?: ModelRef;
+      approvalPolicy?: "auto" | "manual";
+      timeoutMs?: number;
+      metadata?: Record<string, unknown>;
+    },
+  ): Promise<Task> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/tasks`, { method: "POST", body: input });
+  }
+
+  listTasks(
+    workspaceId: string,
+    query: { state?: TaskState } = {},
+  ): Promise<{ items: Task[]; count: number; durable: boolean }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/tasks`, { query });
+  }
+
+  getTask(workspaceId: string, taskId: string): Promise<Task> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/tasks/${enc(taskId)}`);
+  }
+
+  cancelTask(workspaceId: string, taskId: string): Promise<Task> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/tasks/${enc(taskId)}/cancel`, { method: "POST" });
+  }
+
+  async *streamTask(
+    workspaceId: string,
+    taskId: string,
+    options: { signal?: AbortSignal } = {},
+  ): AsyncGenerator<{ event: string; data: unknown }, void, unknown> {
+    const response = await this.#raw(`/api/v1/workspaces/${enc(workspaceId)}/tasks/${enc(taskId)}/events`, {
+      stream: true,
+      signal: options.signal,
+    });
+
+    for await (const frame of readSseStream(response, options.signal)) {
+      yield { event: frame.event, data: safeParse(frame.data) };
+    }
+  }
+
+  /**
+   * Submits a task and resolves once it reaches a terminal state.
+   *
+   * Drives off the event stream rather than polling, and falls back to a final read so a
+   * task that finished before the stream attached is still reported correctly.
+   */
+  async runTask(
+    workspaceId: string,
+    input: Parameters<IPolloWorkClient["createTask"]>[1],
+    options: { signal?: AbortSignal; onEvent?: (event: string, data: unknown) => void } = {},
+  ): Promise<Task> {
+    const task = await this.createTask(workspaceId, input);
+    const terminal: TaskState[] = ["done", "failed", "cancelled"];
+    if (terminal.includes(task.state)) return task;
+
+    for await (const event of this.streamTask(workspaceId, task.id, { signal: options.signal })) {
+      options.onEvent?.(event.event, event.data);
+      const state = readTaskState(event.data);
+      if (state && terminal.includes(state)) break;
+    }
+
+    return this.getTask(workspaceId, task.id);
+  }
+
+  // ----------------------------------------------------------------- webhooks
+
+  /**
+   * Registers a webhook.
+   *
+   * `secret` comes back only when the server generated one — it is never readable
+   * afterwards, so store it now if you need to verify signatures.
+   */
+  createWebhook(
+    workspaceId: string,
+    input: { url: string; events: string[]; secret?: string; active?: boolean },
+  ): Promise<{ webhook: Webhook; secret?: string }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/webhooks`, { method: "POST", body: input });
+  }
+
+  listWebhooks(workspaceId: string): Promise<{ webhooks: Webhook[] }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/webhooks`);
+  }
+
+  getWebhook(workspaceId: string, webhookId: string): Promise<{ webhook: Webhook }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/webhooks/${enc(webhookId)}`);
+  }
+
+  deleteWebhook(workspaceId: string, webhookId: string): Promise<{ deleted: boolean; id: string }> {
+    return this.#request(`/api/v1/workspaces/${enc(workspaceId)}/webhooks/${enc(webhookId)}`, { method: "DELETE" });
+  }
+}
+
+function enc(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function safeParse(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function readTaskState(data: unknown): TaskState | null {
+  if (!data || typeof data !== "object") return null;
+  const record = data as Record<string, unknown>;
+  const state = typeof record.state === "string"
+    ? record.state
+    : typeof (record.task as Record<string, unknown> | undefined)?.state === "string"
+      ? ((record.task as Record<string, unknown>).state as string)
+      : null;
+  return state as TaskState | null;
+}
+
+/** Reattaches the SSE `id:` line as the event's `seq`, so callers can resume from it. */
+export function parseEventFrame(eventName: string, data: string, id?: string): SessionEvent | null {
+  const parsed = safeParse(data);
+  if (!parsed || typeof parsed !== "object") return null;
+  const event = parsed as Record<string, unknown>;
+  if (typeof event.type !== "string") {
+    if (!eventName) return null;
+    event.type = eventName;
+  }
+  if (id !== undefined && event.seq === undefined) event.seq = id;
+  return event as unknown as SessionEvent;
+}
+
+function combineSignals(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const active = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (active.length === 0) return undefined;
+  if (active.length === 1) return active[0];
+  // `AbortSignal.any` is Node 20+; the manual path keeps older runtimes working.
+  const anyOf = (AbortSignal as unknown as { any?: (list: AbortSignal[]) => AbortSignal }).any;
+  if (typeof anyOf === "function") return anyOf(active);
+
+  const controller = new AbortController();
+  for (const signal of active) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      break;
+    }
+    signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true });
+  }
+  return controller.signal;
+}

--- a/packages/ipollowork-api-sdk/src/errors.ts
+++ b/packages/ipollowork-api-sdk/src/errors.ts
@@ -1,0 +1,50 @@
+import type { ApiErrorBody } from "./types.js";
+
+/**
+ * A non-2xx response from the API.
+ *
+ * The server always answers with `{code, message, details}`, so the code is the thing to
+ * branch on — it is stable, while the message is not.
+ */
+export class IPolloWorkApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details?: unknown;
+  readonly requestPath: string;
+
+  constructor(input: { status: number; code: string; message: string; details?: unknown; requestPath: string }) {
+    super(input.message);
+    this.name = "IPolloWorkApiError";
+    this.status = input.status;
+    this.code = input.code;
+    this.details = input.details;
+    this.requestPath = input.requestPath;
+  }
+
+  /** The request can be retried as-is: a transient upstream or rate-limit condition. */
+  get isRetryable(): boolean {
+    return this.status === 429 || this.status === 502 || this.status === 503 || this.status === 504;
+  }
+
+  /** The token is missing, expired, or lacks the required scope. */
+  get isAuthError(): boolean {
+    return this.status === 401 || this.status === 403;
+  }
+}
+
+export async function errorFromResponse(response: Response, requestPath: string): Promise<IPolloWorkApiError> {
+  let body: Partial<ApiErrorBody> = {};
+  try {
+    const parsed: unknown = await response.json();
+    if (parsed && typeof parsed === "object") body = parsed as Partial<ApiErrorBody>;
+  } catch {
+    // A non-JSON error body (a proxy error page, say) leaves the defaults below in place.
+  }
+  return new IPolloWorkApiError({
+    status: response.status,
+    code: typeof body.code === "string" ? body.code : `http_${response.status}`,
+    message: typeof body.message === "string" ? body.message : response.statusText || "Request failed",
+    details: body.details,
+    requestPath,
+  });
+}

--- a/packages/ipollowork-api-sdk/src/index.ts
+++ b/packages/ipollowork-api-sdk/src/index.ts
@@ -1,0 +1,23 @@
+export { IPolloWorkClient, parseEventFrame, type IPolloWorkClientOptions } from "./client.js";
+export { errorFromResponse, IPolloWorkApiError } from "./errors.js";
+export { readSseStream, SseParser, type SseEvent } from "./sse.js";
+export type {
+  ApiErrorBody,
+  ApiModuleDescriptor,
+  Message,
+  MessagePart,
+  ModelRef,
+  Permission,
+  PermissionReply,
+  PromptPart,
+  Question,
+  QuestionInfo,
+  QuestionOption,
+  Session,
+  SessionEvent,
+  SessionStatus,
+  Task,
+  TaskState,
+  TokenScope,
+  Workspace,
+} from "./types.js";

--- a/packages/ipollowork-api-sdk/src/sdk.test.ts
+++ b/packages/ipollowork-api-sdk/src/sdk.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "bun:test";
+
+import { IPolloWorkClient, parseEventFrame } from "./client.js";
+import { IPolloWorkApiError } from "./errors.js";
+import { readSseStream, SseParser } from "./sse.js";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json" } });
+}
+
+function sseResponse(chunks: string[]): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(stream, { headers: { "content-type": "text/event-stream" } });
+}
+
+/** Records what the client sent so tests can assert on the wire format. */
+function recordingFetch(handler: (url: URL, init: RequestInit) => Response | Promise<Response>) {
+  const calls: Array<{ url: URL; init: RequestInit }> = [];
+  const impl = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url);
+    calls.push({ url, init: init ?? {} });
+    return handler(url, init ?? {});
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+/** The exact envelope `POST|GET /sessions` returns, so the stubs cannot drift from it. */
+function sessionEnvelope() {
+  return {
+    session: { id: "s1", title: "Session one" },
+    engine: "opencode",
+    capabilities: {
+      streaming: true,
+      resumableStreaming: true,
+      permissions: true,
+      questions: true,
+      interrupt: true,
+      wait: true,
+      promptOptions: { system: false, reasoningEffort: false, variant: true },
+    },
+  };
+}
+
+describe("SseParser", () => {
+  test("parses a single frame", () => {
+    expect(new SseParser().push("event: a\ndata: {\"x\":1}\n\n"))
+      .toEqual([{ event: "a", data: '{"x":1}' }]);
+  });
+
+  test("keeps the id line", () => {
+    expect(new SseParser().push("id: 7\nevent: a\ndata: 1\n\n"))
+      .toEqual([{ event: "a", data: "1", id: "7" }]);
+  });
+
+  test("reassembles a frame split across chunks", () => {
+    const parser = new SseParser();
+    expect(parser.push("event: a\nda")).toEqual([]);
+    expect(parser.push("ta: hello\n")).toEqual([]);
+    expect(parser.push("\n")).toEqual([{ event: "a", data: "hello" }]);
+  });
+
+  test("handles several frames in one chunk", () => {
+    expect(new SseParser().push("event: a\ndata: 1\n\nevent: b\ndata: 2\n\n"))
+      .toEqual([{ event: "a", data: "1" }, { event: "b", data: "2" }]);
+  });
+
+  test("joins multiple data lines with newlines", () => {
+    expect(new SseParser().push("event: log\ndata: one\ndata: two\n\n"))
+      .toEqual([{ event: "log", data: "one\ntwo" }]);
+  });
+
+  test("ignores keepalive comments", () => {
+    expect(new SseParser().push(": keepalive\n\nevent: a\ndata: 1\n\n"))
+      .toEqual([{ event: "a", data: "1" }]);
+  });
+
+  test("normalizes CRLF line endings", () => {
+    expect(new SseParser().push("event: a\r\ndata: 1\r\n\r\n"))
+      .toEqual([{ event: "a", data: "1" }]);
+  });
+
+  test("strips only one leading space after the colon", () => {
+    expect(new SseParser().push("event: a\ndata:  two-spaces\n\n"))
+      .toEqual([{ event: "a", data: " two-spaces" }]);
+  });
+
+  test("flush emits a frame that was never terminated", () => {
+    const parser = new SseParser();
+    expect(parser.push("event: a\ndata: 1")).toEqual([]);
+    expect(parser.flush()).toEqual([{ event: "a", data: "1" }]);
+  });
+
+  test("flush on an empty buffer yields nothing", () => {
+    expect(new SseParser().flush()).toEqual([]);
+  });
+});
+
+describe("readSseStream", () => {
+  test("yields every frame in order", async () => {
+    const events = [];
+    for await (const event of readSseStream(sseResponse(["event: a\ndata: 1\n\n", "event: b\ndata: 2\n\n"]))) {
+      events.push(event);
+    }
+    expect(events).toEqual([{ event: "a", data: "1" }, { event: "b", data: "2" }]);
+  });
+
+  test("stops when the caller aborts", async () => {
+    const controller = new AbortController();
+    const stream = new ReadableStream<Uint8Array>({
+      start(streamController) {
+        streamController.enqueue(new TextEncoder().encode("event: a\ndata: 1\n\n"));
+        // Deliberately left open, so only the abort can end the loop.
+      },
+    });
+
+    const events = [];
+    for await (const event of readSseStream(new Response(stream), controller.signal)) {
+      events.push(event);
+      controller.abort();
+    }
+    expect(events).toEqual([{ event: "a", data: "1" }]);
+  });
+});
+
+describe("parseEventFrame", () => {
+  test("returns the typed event payload", () => {
+    expect(parseEventFrame("session.idle", '{"type":"session.idle","sessionId":"s1"}'))
+      .toEqual({ type: "session.idle", sessionId: "s1" } as never);
+  });
+
+  test("adopts the SSE id as the resume cursor", () => {
+    expect(parseEventFrame("message.delta", '{"type":"message.delta","sessionId":"s1"}', "42"))
+      .toMatchObject({ seq: "42" });
+  });
+
+  test("does not overwrite a seq the payload already carries", () => {
+    expect(parseEventFrame("x", '{"type":"x","seq":"9"}', "42")).toMatchObject({ seq: "9" });
+  });
+
+  test("falls back to the SSE event name when the payload omits a type", () => {
+    expect(parseEventFrame("session.idle", '{"sessionId":"s1"}')).toMatchObject({ type: "session.idle" });
+  });
+
+  test("rejects a non-JSON payload", () => {
+    expect(parseEventFrame("a", "not json")).toBeNull();
+  });
+});
+
+describe("IPolloWorkClient", () => {
+  test("requires a base URL", () => {
+    expect(() => new IPolloWorkClient({ baseUrl: "  " })).toThrow(/baseUrl is required/);
+  });
+
+  test("sends the bearer token and trims a trailing slash from the base URL", async () => {
+    const { impl, calls } = recordingFetch(() => jsonResponse({ ok: true }));
+    await new IPolloWorkClient({ baseUrl: "http://host:8787/", token: "tok", fetch: impl }).health();
+
+    expect(calls[0]!.url.toString()).toBe("http://host:8787/api/v1/health");
+    expect((calls[0]!.init.headers as Record<string, string>).authorization).toBe("Bearer tok");
+  });
+
+  test("omits the authorization header when no token is configured", async () => {
+    const { impl, calls } = recordingFetch(() => jsonResponse({ ok: true }));
+    await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl }).health();
+    expect((calls[0]!.init.headers as Record<string, string>).authorization).toBeUndefined();
+  });
+
+  test("percent-encodes path segments", async () => {
+    const { impl, calls } = recordingFetch(() => jsonResponse(sessionEnvelope()));
+    await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .getSession("work space/1", "sess/2");
+
+    expect(calls[0]!.url.pathname).toBe("/api/v1/workspaces/work%20space%2F1/sessions/sess%2F2");
+  });
+
+  test("posts a prompt body in the documented shape", async () => {
+    const { impl, calls } = recordingFetch(() =>
+      jsonResponse({ accepted: true, sessionId: "s1", messageId: "m1" }));
+    await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .promptText("w1", "s1", "ship it", { agent: "build" });
+
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.init.body as string))
+      .toEqual({ parts: [{ type: "text", text: "ship it" }], agent: "build" });
+  });
+
+  test("drops undefined query parameters instead of sending 'undefined'", async () => {
+    const { impl, calls } = recordingFetch(() => jsonResponse({ items: [] }));
+    await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl }).listTasks("w1");
+    expect(calls[0]!.url.search).toBe("");
+  });
+
+  test("createSession returns the envelope, not a bare session", async () => {
+    const { impl } = recordingFetch(() => jsonResponse(sessionEnvelope()));
+    const result = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .createSession("w1", { title: "Session one" });
+
+    // The whole point: `result.session.id` is the id. A flat `result.id` would send the
+    // next request to `/sessions/undefined/prompt`.
+    expect(result.session.id).toBe("s1");
+    expect(result.engine).toBe("opencode");
+    expect(result.capabilities.promptOptions.system).toBe(false);
+  });
+
+  test("listPermissions returns the `permissions` key the server sends", async () => {
+    const { impl } = recordingFetch(() => jsonResponse({ permissions: [{ id: "p1" }] }));
+    const result = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .listPermissions("w1", "s1");
+    expect(result.permissions).toHaveLength(1);
+  });
+
+  test("listModules returns the bare array the server sends", async () => {
+    const { impl } = recordingFetch(() => jsonResponse([{ id: "sessions" }]));
+    const result = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl }).listModules();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0]!.id).toBe("sessions");
+  });
+
+  test("listWebhooks returns the `webhooks` key and never a secret", async () => {
+    const { impl } = recordingFetch(() =>
+      jsonResponse({ webhooks: [{ id: "wh1", url: "https://x.test", events: ["*"], hasSecret: true, active: true }] }));
+    const result = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl }).listWebhooks("w1");
+
+    expect(result.webhooks[0]!.hasSecret).toBe(true);
+    expect(result.webhooks[0]).not.toHaveProperty("secret");
+  });
+
+  test("createWebhook surfaces the one-time secret alongside the record", async () => {
+    const { impl } = recordingFetch(() =>
+      jsonResponse({ webhook: { id: "wh1", hasSecret: true }, secret: "shh" }));
+    const result = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .createWebhook("w1", { url: "https://x.test", events: ["*"] });
+
+    expect(result.webhook.id).toBe("wh1");
+    expect(result.secret).toBe("shh");
+  });
+
+  test("turns an error body into a typed ApiError", async () => {
+    const { impl } = recordingFetch(() =>
+      jsonResponse({ code: "session_not_found", message: "Session not found", details: { id: "s1" } }, 404));
+
+    const client = new IPolloWorkClient({ baseUrl: "http://host", fetch: impl });
+    const error = await client.getSession("w1", "s1").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(IPolloWorkApiError);
+    expect(error).toMatchObject({ status: 404, code: "session_not_found", details: { id: "s1" } });
+    expect((error as IPolloWorkApiError).isRetryable).toBe(false);
+  });
+
+  test("synthesizes a code when the error body is not JSON", async () => {
+    const { impl } = recordingFetch(() => new Response("<html>502</html>", { status: 502 }));
+    const error = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .health().catch((e: unknown) => e as IPolloWorkApiError);
+
+    expect(error.code).toBe("http_502");
+    expect(error.isRetryable).toBe(true);
+  });
+
+  test("classifies auth failures", async () => {
+    const { impl } = recordingFetch(() => jsonResponse({ code: "forbidden", message: "Insufficient token scope" }, 403));
+    const error = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .health().catch((e: unknown) => e as IPolloWorkApiError);
+
+    expect(error.isAuthError).toBe(true);
+    expect(error.isRetryable).toBe(false);
+  });
+
+  test("returns undefined for a 204 rather than failing to parse an empty body", async () => {
+    const { impl } = recordingFetch(() => new Response(null, { status: 204 }));
+    await expect(new IPolloWorkClient({ baseUrl: "http://host", fetch: impl }).deleteSession("w1", "s1"))
+      .resolves.toBeUndefined();
+  });
+
+  test("reports a timeout as a 408 ApiError", async () => {
+    const impl = (async (_input: unknown, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+      })) as unknown as typeof fetch;
+
+    const error = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl, timeoutMs: 10 })
+      .health().catch((e: unknown) => e as IPolloWorkApiError);
+
+    expect(error).toBeInstanceOf(IPolloWorkApiError);
+    expect(error.status).toBe(408);
+    expect(error.code).toBe("request_timeout");
+  });
+
+  test("streams session events with the resume cursor applied", async () => {
+    const { impl, calls } = recordingFetch(() =>
+      sseResponse([
+        'id: 1\nevent: message.delta\ndata: {"type":"message.delta","sessionId":"s1","delta":"He"}\n\n',
+        ': keepalive\n\n',
+        'id: 2\nevent: session.idle\ndata: {"type":"session.idle","sessionId":"s1"}\n\n',
+      ]));
+
+    const client = new IPolloWorkClient({ baseUrl: "http://host", fetch: impl });
+    const events = [];
+    for await (const event of client.streamSession("w1", "s1", { after: "0" })) events.push(event);
+
+    expect(calls[0]!.url.searchParams.get("after")).toBe("0");
+    expect((calls[0]!.init.headers as Record<string, string>).accept).toBe("text/event-stream");
+    expect(events).toEqual([
+      { type: "message.delta", sessionId: "s1", delta: "He", seq: "1" },
+      { type: "session.idle", sessionId: "s1", seq: "2" },
+    ] as never);
+  });
+
+  test("runTask returns immediately when the task is already terminal", async () => {
+    let createCalls = 0;
+    const impl = (async (input: string | URL) => {
+      const url = new URL(String(input));
+      if (url.pathname.endsWith("/tasks")) {
+        createCalls += 1;
+        return jsonResponse({ id: "t1", state: "done", goal: "g", workspaceId: "w1", createdAt: 1, updatedAt: 2 });
+      }
+      throw new Error(`unexpected call to ${url.pathname}`);
+    }) as unknown as typeof fetch;
+
+    const task = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .runTask("w1", { goal: "g" });
+
+    expect(createCalls).toBe(1);
+    expect(task.state).toBe("done");
+  });
+
+  test("runTask follows the stream to completion and re-reads the final task", async () => {
+    const seen: string[] = [];
+    const impl = (async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(String(input));
+      seen.push(`${init?.method ?? "GET"} ${url.pathname}`);
+      if (url.pathname.endsWith("/tasks") && init?.method === "POST") {
+        return jsonResponse({ id: "t1", state: "queued", goal: "g", workspaceId: "w1", createdAt: 1, updatedAt: 1 });
+      }
+      if (url.pathname.endsWith("/events")) {
+        return sseResponse([
+          'event: task.updated\ndata: {"state":"running"}\n\n',
+          'event: task.updated\ndata: {"state":"done"}\n\n',
+        ]);
+      }
+      return jsonResponse({ id: "t1", state: "done", goal: "g", workspaceId: "w1", createdAt: 1, updatedAt: 9 });
+    }) as unknown as typeof fetch;
+
+    const states: string[] = [];
+    const task = await new IPolloWorkClient({ baseUrl: "http://host", fetch: impl })
+      .runTask("w1", { goal: "g" }, { onEvent: (_name, data) => states.push((data as { state: string }).state) });
+
+    expect(states).toEqual(["running", "done"]);
+    expect(task.state).toBe("done");
+    expect(seen).toEqual([
+      "POST /api/v1/workspaces/w1/tasks",
+      "GET /api/v1/workspaces/w1/tasks/t1/events",
+      "GET /api/v1/workspaces/w1/tasks/t1",
+    ]);
+  });
+});

--- a/packages/ipollowork-api-sdk/src/sse.ts
+++ b/packages/ipollowork-api-sdk/src/sse.ts
@@ -1,0 +1,111 @@
+/**
+ * SSE parsing.
+ *
+ * Kept separate from the HTTP client and written as a pure incremental parser, because
+ * the failure it has to survive is a network chunk boundary landing in the middle of a
+ * frame — the kind of bug that only shows up under load and is untestable if the parsing
+ * is buried inside a fetch loop.
+ */
+
+export interface SseEvent {
+  event: string;
+  data: string;
+  id?: string;
+}
+
+/**
+ * Feeds raw text in and gets whole frames out.
+ *
+ * Per the SSE spec: fields are separated by newlines, frames by a blank line, a leading
+ * space after the colon is stripped, and a line starting with `:` is a comment (our
+ * keepalive uses one). Multiple `data:` lines in a frame join with newlines.
+ */
+export class SseParser {
+  #buffer = "";
+
+  push(chunk: string): SseEvent[] {
+    this.#buffer += chunk;
+    const events: SseEvent[] = [];
+
+    // Normalize CRLF and lone CR so frame splitting is uniform.
+    this.#buffer = this.#buffer.replace(/\r\n|\r/g, "\n");
+
+    let boundary = this.#buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const raw = this.#buffer.slice(0, boundary);
+      this.#buffer = this.#buffer.slice(boundary + 2);
+      const event = parseFrame(raw);
+      if (event) events.push(event);
+      boundary = this.#buffer.indexOf("\n\n");
+    }
+
+    return events;
+  }
+
+  /** Flushes a trailing frame that was not terminated by a blank line. */
+  flush(): SseEvent[] {
+    const raw = this.#buffer;
+    this.#buffer = "";
+    const event = parseFrame(raw);
+    return event ? [event] : [];
+  }
+}
+
+function parseFrame(raw: string): SseEvent | null {
+  if (!raw.trim()) return null;
+
+  let event = "message";
+  let id: string | undefined;
+  const data: string[] = [];
+
+  for (const line of raw.split("\n")) {
+    if (!line || line.startsWith(":")) continue;
+    const colon = line.indexOf(":");
+    const field = colon === -1 ? line : line.slice(0, colon);
+    let value = colon === -1 ? "" : line.slice(colon + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+
+    if (field === "event") event = value;
+    else if (field === "data") data.push(value);
+    else if (field === "id") id = value;
+  }
+
+  if (data.length === 0 && event === "message") return null;
+  return { event, data: data.join("\n"), ...(id !== undefined ? { id } : {}) };
+}
+
+/** Streams frames from a `Response` body. */
+export async function* readSseStream(
+  response: Response,
+  signal?: AbortSignal,
+): AsyncGenerator<SseEvent, void, unknown> {
+  if (!response.body) return;
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const parser = new SseParser();
+
+  const onAbort = () => {
+    void reader.cancel().catch(() => undefined);
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    while (true) {
+      if (signal?.aborted) break;
+      const { done, value } = await reader.read();
+      if (done) break;
+      for (const event of parser.push(decoder.decode(value, { stream: true }))) {
+        yield event;
+      }
+    }
+    for (const event of parser.flush()) yield event;
+  } finally {
+    signal?.removeEventListener("abort", onAbort);
+    // Releasing matters when the consumer breaks out of the loop early.
+    try {
+      reader.releaseLock();
+    } catch {
+      // Already released by cancel().
+    }
+  }
+}

--- a/packages/ipollowork-api-sdk/src/types.ts
+++ b/packages/ipollowork-api-sdk/src/types.ts
@@ -1,0 +1,237 @@
+/**
+ * Wire types for the iPolloWork public API.
+ *
+ * These mirror the server's `apps/server/src/api/engine/types.ts`. They are duplicated
+ * rather than imported so the SDK stays installable on its own, without pulling the
+ * server workspace in as a dependency.
+ */
+
+export type TokenScope = "owner" | "collaborator" | "viewer";
+
+/** Error body returned by every endpoint, matching the server's `formatError`. */
+export interface ApiErrorBody {
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+export type SessionStatus =
+  | { type: "idle" }
+  | { type: "busy" }
+  | { type: "retry"; attempt: number; message: string; next: number };
+
+export interface Session {
+  id: string;
+  title: string;
+  parentId?: string | null;
+  directory?: string | null;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+  archivedAt?: number | null;
+}
+
+/**
+ * What an engine can do for a workspace.
+ *
+ * Worth checking before assuming a feature works: the engines differ, and the API reports
+ * the difference rather than papering over it.
+ */
+export interface EngineCapabilities {
+  streaming: boolean;
+  /** `?after=` resumption is honoured. */
+  resumableStreaming: boolean;
+  permissions: boolean;
+  questions: boolean;
+  interrupt: boolean;
+  wait: boolean;
+  /** Optional `prompt` fields this engine applies; the rest are rejected with 501. */
+  promptOptions: {
+    system: boolean;
+    reasoningEffort: boolean;
+    variant: boolean;
+  };
+}
+
+/** Session responses carry the engine and its capabilities alongside the session. */
+export interface SessionEnvelope {
+  session: Session;
+  engine: string;
+  capabilities: EngineCapabilities;
+}
+
+export interface Permission {
+  id: string;
+  sessionId: string;
+  kind: string;
+  resources: string[];
+  remember: string[];
+  metadata: Record<string, unknown>;
+  receivedAt: number;
+}
+
+export type PermissionReply = "once" | "always" | "reject";
+
+export interface QuestionOption {
+  label: string;
+  description?: string;
+}
+
+export interface QuestionInfo {
+  header?: string;
+  question: string;
+  options: QuestionOption[];
+  multiple?: boolean;
+  custom?: boolean;
+}
+
+export interface Question {
+  id: string;
+  sessionId: string;
+  questions: QuestionInfo[];
+  receivedAt: number;
+}
+
+export type PromptPart =
+  | { type: "text"; text: string }
+  | { type: "file"; mime: string; url: string; filename?: string }
+  | { type: "agent"; name: string };
+
+export interface ModelRef {
+  providerID: string;
+  modelID: string;
+}
+
+export interface MessagePart {
+  id?: string;
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface Message {
+  id: string;
+  role: "user" | "assistant" | "system";
+  parts: MessagePart[];
+  createdAt?: number | null;
+  completedAt?: number | null;
+}
+
+/**
+ * Normalized event stream, identical across engines.
+ *
+ * `seq` is the durable cursor: pass the last one you processed as `after` to resume a
+ * stream without losing events.
+ */
+export type SessionEvent =
+  | { type: "session.updated"; sessionId: string; session: Session; seq?: string }
+  | { type: "session.deleted"; sessionId: string; seq?: string }
+  | { type: "session.error"; sessionId: string; error: { code?: string; message: string }; seq?: string }
+  | { type: "session.status"; sessionId: string; status: SessionStatus; seq?: string }
+  | { type: "session.idle"; sessionId: string; seq?: string }
+  | { type: "session.compaction"; sessionId: string; running: boolean; seq?: string }
+  | { type: "todo.updated"; sessionId: string; todos: unknown[]; seq?: string }
+  | { type: "permission.asked"; permission: Permission; seq?: string }
+  | { type: "permission.replied"; sessionId: string; requestId: string; seq?: string }
+  | { type: "question.asked"; question: Question; seq?: string }
+  | { type: "question.replied"; sessionId: string; requestId: string; seq?: string }
+  | { type: "message.upsert"; sessionId: string; message: Message; seq?: string }
+  | { type: "message.completed"; sessionId: string; messageId: string; completedAt: number; seq?: string }
+  | { type: "message.removed"; sessionId: string; messageId: string; seq?: string }
+  | { type: "message.part"; sessionId: string; messageId: string; partId: string; part: MessagePart; seq?: string }
+  | {
+      type: "message.delta";
+      sessionId: string;
+      messageId: string;
+      partId: string;
+      kind: "text" | "reasoning";
+      delta: string;
+      seq?: string;
+    }
+  | {
+      type: "tool.called";
+      sessionId: string;
+      messageId: string;
+      callId: string;
+      tool: string;
+      input?: unknown;
+      seq?: string;
+    }
+  | {
+      type: "tool.completed";
+      sessionId: string;
+      messageId: string;
+      callId: string;
+      tool: string;
+      status: "success" | "failed";
+      output?: unknown;
+      error?: string;
+      seq?: string;
+    };
+
+export type TaskState =
+  | "queued"
+  | "running"
+  | "awaiting_approval"
+  | "done"
+  | "failed"
+  | "cancelled";
+
+export interface Task {
+  id: string;
+  workspaceId: string;
+  sessionId?: string | null;
+  goal: string;
+  state: TaskState;
+  createdAt: number;
+  updatedAt: number;
+  summary?: string | null;
+  error?: { code?: string; message: string } | null;
+  pendingPermissions?: Permission[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface Workspace {
+  id: string;
+  name?: string;
+  path?: string;
+  engineId?: string;
+  [key: string]: unknown;
+}
+
+export interface Webhook {
+  id: string;
+  workspaceId: string;
+  url: string;
+  events: string[];
+  /** The secret itself is never returned after creation. */
+  hasSecret: boolean;
+  active: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface Identity {
+  actor: { type: string; clientId: string | null; scope: TokenScope | null };
+  token: { id: string; scope: TokenScope; label: string | null; createdAt: number } | null;
+  policy: Record<string, unknown> | null;
+  server: Record<string, unknown>;
+  workspaces: Array<{ id: string; name?: string }>;
+}
+
+export interface ApiModuleDescriptor {
+  id: string;
+  title: string;
+  description: string;
+  version: string;
+  stability: "stable" | "preview" | "experimental";
+  dependsOn: string[];
+  operations: Array<{
+    operationId: string;
+    method: string;
+    path: string;
+    effect: "read" | "write" | "destructive";
+    scope: TokenScope;
+    summary: string;
+    streaming: "sse" | null;
+    deprecated: boolean;
+  }>;
+}

--- a/packages/ipollowork-api-sdk/tsconfig.json
+++ b/packages/ipollowork-api-sdk/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
> **Opened alongside #353 so the discussion has real code to point at.** It's 61 files, and
> #353 asks whether this is even the shape you want — so please treat the design question
> there as the one that decides this PR's fate, not the diff here. If the answer is "share
> the mapping in `packages/`" or "don't build this," I'll rework or close it, no hard
> feelings. I'd rather land the right thing in four small PRs than this one as-is; see
> "How it's split" below.

Companion to #353. Adds a versioned `/api/v1` surface so callers can drive iPolloWork
without the desktop UI.

## The gap this fills

`routes/sessions.ts` unifies session *reads* across OpenCode and DeepSeek Harness, but there
is no engine-agnostic `create` or `prompt`. The one unified write says so itself —
`DELETE /workspace/:id/sessions/:sessionId` hard-codes `501 session_delete_unsupported` for
Harness (`sessions.ts:234`). Writes today mean either the `/opencode/*` proxy (OpenCode's
private API) or the Harness JSON-RPC allowlist: two dialects, no stable contract.

## Suggested reading order

Don't read this top-to-bottom. In order of what actually matters:

1. **`apps/server/src/api/engine/types.ts`** (~200 lines) — the whole proposal in one file.
   The engine abstraction: normalized event union, connection interface, capability flags.
   If this interface is wrong, everything else is wrong.
2. **`apps/server/src/api/modules/types.ts`** + **`registry.ts`** — how a module declares
   operations once and the registry derives both the route table and the OpenAPI document
   from that single declaration.
3. **`apps/server/src/api/modules/sessions/module.ts`** — the first real module; the pattern
   every other one follows.
4. **`apps/server/src/api/README.md`** — the module contract, written for whoever adds the
   next one.

Everything else is application of those four. `engine/opencode.ts` and `engine/harness.ts`
are the two adapters; `modules/{tasks,webhooks,policy,openapi,compat}/` are modules built on
the same contract.

## What I'd push back on if I were reviewing

- **It duplicates the browser's engine layer.** `opencode-conversation-engine.ts` +
  `deepseek-harness-conversation-engine.ts` and their mappers are ~1,500 lines, and this adds
  a server-side mirror — two copies of the same wire-format knowledge, free to drift. The
  Harness internal-`<system>`-block stripper is literally copied out of
  `deepseek-harness-conversation-mapper.ts`. **Extracting the shared mapping into
  `packages/` is a better end state than this PR**, and I'd rather do that than land two
  copies. It touches browser code, which is why #353 asks first.
- **It increases OpenCode coupling in the server.** `apps/server` currently contains one
  OpenCode event-name string (in `toy-ui.ts`); this adds about thirty, concentrated in
  `engine/opencode.ts`. That's a real move against the boundary `README.md:171` describes,
  even though it's confined to one file.
- **`compat/` is the largest behaviour surface here** — it aliases existing legacy routes
  under `/api/v1`. It deserves its own review pass and is the piece I'd most expect you to
  want changed or dropped.

## Overlap with #355

This branch contains the `serve-node.ts` fix from #355 — byte-identical, since I cut that PR
from these files. If #355 lands first this merges cleanly with no conflict; I'll rebase and
drop the duplicate commit if you'd rather.

The streaming work here is what surfaced that bug: without a working `request.signal`, every
SSE endpoint added below would leak its producer on client disconnect.

## How it's split if you want it in pieces

Note that "OpenAPI generation first" doesn't work — the mount builds the engine registry
unconditionally (`api/index.ts:235`). The order I'd suggest:

1. engine adapter + sessions module (the part worth arguing about)
2. OpenAPI generation + docs
3. tasks / webhooks / policy
4. `compat/` last — most routes, least novel, deserves its own review

Say the word and I'll cut them as separate PRs in that order.

## State

- `tsc --noEmit` clean across the server, not just the new code
- 618 tests for the new code; existing suite unaffected
- TypeScript SDK has no runtime dependencies; Python SDK is standard library only
- `examples/public-api/` has five runnable examples, including a CI review job in `curl` + `jq`

## Known limits, stated plainly

- **Task state is in-memory.** A server restart drops running tasks. Fine for CI, wrong for
  anything durable — the module is structured so a persistent store can replace it, but I
  didn't presume to pick one.
- **The two engines don't have the same capabilities.** Rather than lowest-common-denominator
  the API, unsupported operations return `501 engine_capability_unsupported` and
  `capabilities` advertises what a given engine can do. Harness has no resumable event cursor,
  so `seq` is undefined there and reconnects can miss events.
- **`server-route` is still dormant.** External plugins still cannot register routes. I added
  six *descriptive* `server-route` entries in an example manifest, but nothing mounts from
  them — the signed-publisher gate on executable capabilities looks deliberate and I didn't
  touch it.
