### PR TITLE
Add standard MCP Apps workspace surfaces

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -51,6 +51,8 @@
     "@ipollowork/types": "workspace:*",
     "@ipollowork/ui": "workspace:*",
     "@lexical/react": "^0.35.0",
+    "@modelcontextprotocol/ext-apps": "1.7.5",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@opencode-ai/sdk": "^1.18.16",
     "@shikijs/transformers": "^4.0.2",
     "@tanstack/react-query": "^5.90.3",

--- a/apps/app/src/app/lib/ipollowork-server.ts
+++ b/apps/app/src/app/lib/ipollowork-server.ts
@@ -306,6 +306,17 @@ export type iPolloWorkPluginPackageItem = {
   integrity: { sha256: string; status: "verified" | "unsigned" };
 };
 
+export type iPolloWorkPluginUiResource = {
+  pluginId: string;
+  version: string;
+  resource: iPolloWorkExtensionManifest["resources"][number] & {
+    type: "ui";
+    path: string;
+    ui: NonNullable<iPolloWorkExtensionManifest["resources"][number]["ui"]>;
+  };
+  html: string;
+};
+
 export type iPolloWorkPluginPackagePreview = {
   manifest: iPolloWorkExtensionManifest;
   files: Array<{ path: string; sha256: string }>;
@@ -318,7 +329,7 @@ export type iPolloWorkPluginPackageImportSafety =
   | {
       level: "declarative";
       localCode: false;
-      allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp">;
+      allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp" | "ui">;
     }
   | {
       level: "signed";
@@ -1557,6 +1568,12 @@ export function createiPolloWorkServerClient(options: { baseUrl: string; token?:
         hostToken,
         timeoutMs: timeouts.config,
       }),
+    getPluginPackageUiResource: (workspaceId: string, pluginId: string, resourceId: string) =>
+      requestJson<iPolloWorkPluginUiResource>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/plugin-packages/${encodeURIComponent(pluginId)}/ui/${encodeURIComponent(resourceId)}`,
+        { token, hostToken, timeoutMs: timeouts.config },
+      ),
     listBundledPluginPackages: (workspaceId: string) =>
       requestJson<{ items: iPolloWorkBundledPluginPackageItem[] }>(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/plugin-packages/catalog`, {
         token,

--- a/apps/app/src/components/chat/new-conversation-starter.tsx
+++ b/apps/app/src/components/chat/new-conversation-starter.tsx
@@ -67,6 +67,13 @@ type NewConversationStarterProps = {
   selectedCapabilityId?: string | null;
   onSelectMode: (mode: NewConversationMode) => void;
   onSelectPrompt: (prompt: string, capability?: StarterCapability) => void;
+  promptTemplates?: Array<{
+    id: string;
+    label: string;
+    description: string;
+    prompt: string;
+    mode: NewConversationMode;
+  }>;
   templates?: TemplateCatalogItem[];
   templatesLoading?: boolean;
   templateBusyId?: string | null;
@@ -972,6 +979,7 @@ export function NewConversationStarter({
   selectedCapabilityId,
   onSelectMode,
   onSelectPrompt,
+  promptTemplates = [],
   templates = [],
   templatesLoading = false,
   templateBusyId,
@@ -1075,6 +1083,22 @@ export function NewConversationStarter({
   const actions = shortcutIds[selectedMode]
     .map((id) => modeDefinitions.find((action) => action.id === id))
     .filter((action): action is StarterAction => Boolean(action));
+  const visiblePromptTemplates = useMemo(() => [
+    ...(selectedMode === "work" ? savedPromptTemplates.map((template) => ({
+      id: `saved:${template.id}`,
+      label: template.title,
+      description: template.prompt,
+      prompt: template.prompt,
+    })) : []),
+    ...promptTemplates
+      .filter((template) => template.mode === selectedMode)
+      .map((template) => ({
+        id: `plugin:${template.id}`,
+        label: template.label,
+        description: template.description || template.prompt,
+        prompt: template.prompt,
+      })),
+  ], [promptTemplates, savedPromptTemplates, selectedMode]);
 
   const toggleShortcut = (id: string) => {
     const definition = modeDefinitions.find((action) => action.id === id);
@@ -1254,21 +1278,21 @@ export function NewConversationStarter({
             onRequestTemplates={onRequestTemplates}
           />
         ) : null}
-        {selectedMode === "work" && savedPromptTemplates.length > 0 ? (
+        {visiblePromptTemplates.length > 0 ? (
           <div className="mt-4 rounded-xl border border-border/80 bg-muted/25 p-3">
             <div className="mb-2 px-0.5">
               <p className="text-[13px] font-medium text-foreground">{t("new_conversation.saved_templates.title")}</p>
             </div>
             <div className="flex flex-wrap gap-2">
-              {savedPromptTemplates.map((template) => (
+              {visiblePromptTemplates.map((template) => (
                 <button
                   key={template.id}
                   type="button"
                   className="max-w-full rounded-lg border border-border bg-background px-3 py-2 text-left text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   onClick={() => onSelectPrompt(template.prompt)}
                 >
-                  <span className="block truncate font-medium text-foreground">{template.title}</span>
-                  <span className="mt-0.5 block max-w-[220px] truncate">{template.prompt}</span>
+                  <span className="block truncate font-medium text-foreground">{template.label}</span>
+                  <span className="mt-0.5 block max-w-[220px] truncate">{template.description}</span>
                 </button>
               ))}
             </div>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -136,6 +136,8 @@ import { useControlAction, type iPolloWorkControlAction } from "../../../shell/c
 import { getExtensionId, isiPolloWorkExtensionEnabled, IPOLLOWORK_EXTENSION_STATE_CHANGED } from "../../settings/extension-state";
 import { cn } from "@/lib/utils";
 import { useActiveEnterpriseConnection } from "@/react-app/domains/enterprise/use-active-enterprise-connection";
+import { useInstalledPluginContributions } from "@/react-app/plugin-ui/plugin-ui-contributions";
+import type { WorkspaceAppModelContext } from "@/react-app/plugin-ui/workspace-app-frame";
 
 const STARTUP_SKELETON_ROWS = [
   { id: "intro", titleWidth: "42%", bodyWidth: "88%" },
@@ -614,6 +616,10 @@ export function SessionPage(props: SessionPageProps) {
   ));
   const sessionPanelState = useSessionPanelState(props.selectedSessionId ?? "");
   const activePanelTab = useActivePanelTab(props.selectedSessionId ?? "");
+  const { workspaceApps } = useInstalledPluginContributions(
+    props.ipolloworkServerClient,
+    props.runtimeWorkspaceId,
+  );
   const [hiddenTargetRevision, setHiddenTargetRevision] = useState(0);
   const [, setExtensionStateVersion] = useState(0);
   const hiddenAccessibleTargetIds = useMemo(
@@ -2147,6 +2153,37 @@ export function SessionPage(props: SessionPageProps) {
   const openVoiceRailPane = useCallback(() => {
     toggleCurrentSidePanel("voice");
   }, [toggleCurrentSidePanel]);
+  const openWorkspaceApp = useCallback((surface: (typeof workspaceApps)[number]) => {
+    if (!props.selectedSessionId) return;
+    openTab(props.selectedSessionId, {
+      id: `workspace-app:${surface.id}`,
+      type: "workspace-app",
+      label: surface.label,
+      sessionId: props.selectedSessionId,
+      surface,
+    });
+    setCurrentSidePanel("panel");
+  }, [openTab, props.selectedSessionId, setCurrentSidePanel]);
+  const sendWorkspaceAppMessage = useCallback((input: {
+    text: string;
+    modelContext: WorkspaceAppModelContext | null;
+  }) => {
+    if (!props.selectedSessionId || activePanelTab?.type !== "workspace-app") return false;
+    const context = input.modelContext
+      ? `The active Workspace App is ${activePanelTab.label}. Use its available workspace_app tools when the user asks to inspect or edit it. Current app context:\n${JSON.stringify(input.modelContext, null, 2)}`
+      : `The active Workspace App is ${activePanelTab.label}. Use its available workspace_app tools when the user asks to inspect or edit it.`;
+    return props.surface?.onSendDraft({
+      mode: "prompt",
+      parts: [{ type: "text", text: input.text }],
+      attachments: [],
+      text: input.text,
+      resolvedText: input.text,
+      capability: {
+        id: `workspace-app:${activePanelTab.surface.pluginId}:${activePanelTab.surface.resource.id}`,
+        instruction: context,
+      },
+    }, props.selectedSessionId) ?? false;
+  }, [activePanelTab, props.selectedSessionId, props.surface?.onSendDraft]);
   const sidePanelLauncherItems = useMemo<SidePanelLauncherItem[]>(() => [
     {
       id: "web",
@@ -2182,7 +2219,17 @@ export function SessionPage(props: SessionPageProps) {
       onClick: showVideoRailPane,
       disabled: !props.selectedSessionId || props.selectedWorkspaceDisplay.workspaceType === "remote",
     },
-  ], [activePanelTab?.type, addBrowserPanelTab, hasArtifactTargets, locale, panelRailActive, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, showArtifactRailPane, showDesignRailPane, showVideoRailPane, videoRailActive]);
+    ...workspaceApps.map((surface) => ({
+      id: `workspace-app:${surface.id}`,
+      label: surface.label,
+      iconSrc: surface.iconSrc ?? publicAssetUrl("ipollowork-mark.svg"),
+      active: panelRailActive
+        && activePanelTab?.type === "workspace-app"
+        && activePanelTab.surface.id === surface.id,
+      onClick: () => openWorkspaceApp(surface),
+      disabled: !props.selectedSessionId,
+    })),
+  ], [activePanelTab, addBrowserPanelTab, hasArtifactTargets, locale, openWorkspaceApp, panelRailActive, props.selectedSessionId, props.selectedWorkspaceDisplay.workspaceType, showArtifactRailPane, showDesignRailPane, showVideoRailPane, videoRailActive, workspaceApps]);
   const removeAccessibleTarget = useCallback((target: OpenTarget) => {
     const nextHiddenIds = new Set(hiddenAccessibleTargetIds);
     nextHiddenIds.add(target.id);
@@ -3065,6 +3112,7 @@ export function SessionPage(props: SessionPageProps) {
                         launcherItems={sidePanelLauncherItems}
                         aiEditing={isStreamingSessionStatus(props.sidebar.sessionStatusById[props.selectedSessionId])}
                         onAskAi={handleDesignAskAi}
+                        onSendWorkspaceAppMessage={sendWorkspaceAppMessage}
                         onSaveAsTemplate={hasTemplateSession && props.selectedWorkspaceDisplay.workspaceType === "local" ? openTemplateSave : undefined}
                         expanded={rightPanelExpanded}
                         titlebarInset={rightPanelExpanded && (!shellConfig.sidebar || !sidebarOpen)}

--- a/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
+++ b/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
@@ -2,10 +2,11 @@ import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
 import { isCollectibleArtifactTarget, type OpenTarget, type OpenTargetPreview } from "../artifacts/open-target";
+import type { PluginUiSurface } from "@/react-app/plugin-ui/plugin-ui-contributions";
 
 export const PERSISTED_PANEL_TAB_STORE_KEY = "ipollowork:panel-tabs:v1";
 
-export type PanelTabType = "artifact" | "browser" | "design" | "video";
+export type PanelTabType = "artifact" | "browser" | "design" | "video" | "workspace-app";
 
 export type { BrowserPanelTab } from "../../../../app/lib/desktop-types";
 import type { BrowserPanelTab } from "../../../../app/lib/desktop-types";
@@ -33,7 +34,15 @@ export type VideoPanelTab = {
   sessionId: string;
 };
 
-export type PanelTab = BrowserPanelTab | ArtifactPanelTab | DesignPanelTab | VideoPanelTab;
+export type WorkspaceAppPanelTab = {
+  id: string;
+  type: "workspace-app";
+  label: string;
+  sessionId: string;
+  surface: PluginUiSurface;
+};
+
+export type PanelTab = BrowserPanelTab | ArtifactPanelTab | DesignPanelTab | VideoPanelTab | WorkspaceAppPanelTab;
 
 export type SessionPanelState = {
   tabs: PanelTab[];
@@ -173,6 +182,10 @@ function isSameTab(left: PanelTab, right: PanelTab) {
 
   if (left.type === "video" && right.type === "video") {
     return left.label === right.label && left.sessionId === right.sessionId;
+  }
+
+  if (left.type === "workspace-app" && right.type === "workspace-app") {
+    return left.label === right.label && left.sessionId === right.sessionId && left.surface.id === right.surface.id;
   }
 
   return false;
@@ -325,7 +338,7 @@ export const usePanelTabStore = create<PanelTabStore>()(
         const mergedTabs: PanelTab[] = [];
 
         for (const tab of session.tabs) {
-          if (tab.type === "artifact" || tab.type === "design" || tab.type === "video") {
+          if (tab.type === "artifact" || tab.type === "design" || tab.type === "video" || tab.type === "workspace-app") {
             mergedTabs.push(tab);
             continue;
           }

--- a/apps/app/src/react-app/domains/session/panel/side-panel.tsx
+++ b/apps/app/src/react-app/domains/session/panel/side-panel.tsx
@@ -9,6 +9,7 @@ import {
   Loader2,
   Maximize2,
   Minimize2,
+  PanelsTopLeft,
   Plus,
   RotateCw,
   X,
@@ -43,6 +44,7 @@ import { useSidePanelTabs } from "./use-side-panel-tabs";
 import { DesignPanel } from "../design/design-panel";
 import type { DesignAiSelectionContext } from "@ipollowork/design-studio";
 import { VideoPanel } from "../video/video-panel";
+import { WorkspaceAppFrame, type WorkspaceAppModelContext } from "@/react-app/plugin-ui/workspace-app-frame";
 import {
   computeBounds,
   getElectronBrowser,
@@ -60,6 +62,7 @@ type SidePanelProps = {
   launcherItems?: SidePanelLauncherItem[];
   onClose: () => void;
   onAskAi?: (context: DesignAiSelectionContext) => void;
+  onSendWorkspaceAppMessage?: (input: { text: string; modelContext: WorkspaceAppModelContext | null }) => boolean | Promise<boolean>;
   onSaveAsTemplate?: () => void;
   aiEditing?: boolean;
   expanded?: boolean;
@@ -187,7 +190,7 @@ function SidePanelTab({ tab, active, onSelect, onClose }: SidePanelTabProps) {
               <Globe />
             )
           ) : (
-            tab.type === "design" ? <Code2 /> : tab.type === "video" ? <Film /> : <ArtifactIcon type={tab.preview} />
+            tab.type === "design" ? <Code2 /> : tab.type === "video" ? <Film /> : tab.type === "workspace-app" ? <PanelsTopLeft /> : <ArtifactIcon type={tab.preview} />
           )}
           <span className="min-w-0 flex-1 truncate text-left">{tab.label}</span>
         </PanelTab>
@@ -458,6 +461,7 @@ export function SidePanel({
   isRemoteWorkspace = false,
   launcherItems = [],
   onAskAi,
+  onSendWorkspaceAppMessage,
   onSaveAsTemplate,
   aiEditing = false,
   expanded = false,
@@ -741,6 +745,21 @@ export function SidePanel({
           />
         ) : activeTab?.type === "browser" ? (
           <BrowserPanelContent tab={activeTab} onClose={() => closeTab(activeTab)} />
+        ) : activeTab?.type === "workspace-app" && client && workspaceId ? (
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <WorkspaceAppFrame
+              surface={activeTab.surface}
+              client={client}
+              workspaceId={workspaceId}
+              workspaceRoot={workspaceRoot}
+              sessionId={activeTab.sessionId}
+              placement="workspace"
+              displayMode={expanded ? "fullscreen" : "inline"}
+              onDisplayModeChange={(mode) => onExpandedChange?.(mode === "fullscreen")}
+              onSendMessage={onSendWorkspaceAppMessage}
+              onRequestClose={() => closeTab(activeTab)}
+            />
+          </div>
         ) : activeTab?.type === "artifact" ? (
           <div className="min-h-0 flex-1 overflow-hidden">
             <ArtifactPanel

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -115,6 +115,7 @@ import { MessageListProvider, type DispatchAction } from "@/components/chat/mess
 import { OpenTargetProvider, type OpenTargetOptions } from "@/lib/target-provider";
 import type { ThreadStatus } from "@/lib/messages";
 import { collectToolParts, getActiveToolLabel } from "@/lib/tool-activity";
+import { useInstalledPluginContributions } from "@/react-app/plugin-ui/plugin-ui-contributions";
 
 import {
   EnvironmentVariableProvider,
@@ -601,6 +602,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const local = useLocal();
   const { config: shellConfig } = useShellConfig();
   const showThinking = local.prefs.showThinking;
+  const { conversationTemplates } = useInstalledPluginContributions(props.client, props.workspaceId);
   const findOpen = useSessionFindStore((state) => state.open);
   const findSessionId = useSessionFindStore((state) => state.sessionId);
   const findAppliedQuery = useSessionFindStore((state) => state.appliedQuery);
@@ -1944,13 +1946,15 @@ export function SessionSurface(props: SessionSurfaceProps) {
             <NewConversationStarter
               selectedMode={newConversationMode}
               selectedCapabilityId={starterCapability?.id}
+              promptTemplates={conversationTemplates}
               onSelectMode={(mode) => {
                 setNewConversationMode(mode);
                 setStarterCapability(null);
                 if (mode !== "video") setSelectedAnimations([]);
               }}
-              onSelectPrompt={(_prompt, capability) => {
+              onSelectPrompt={(prompt, capability) => {
                 setStarterCapability(capability ?? null);
+                if (prompt) setComposerDraft(props.sessionId, prompt);
                 window.dispatchEvent(new Event("ipollowork:focusPrompt"));
               }}
               templates={props.designTemplates}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -18,6 +18,7 @@ import { readPluginPackageArchive } from "@/react-app/domains/settings/plugin-pa
 import { formatPluginPlatformError } from "@/react-app/domains/settings/plugin-platform-state";
 import { SettingsListEmptyState, SettingsListSearchInput } from "@/react-app/domains/settings/settings-list";
 import { SettingsNotice, SettingsPill } from "@/react-app/domains/settings/settings-section";
+import { notifyPluginUiContributionsChanged } from "@/react-app/plugin-ui/plugin-ui-contributions";
 
 export const MARKETPLACE_CATEGORY_IDS = [
   "ai-agents",
@@ -172,6 +173,7 @@ export function CloudMarketplacesView({
       await client.validatePluginPackageUpload(workspaceId, upload);
       await client.importPluginPackage(workspaceId, upload);
       await refresh();
+      notifyPluginUiContributionsChanged();
       await onInstalled?.(pluginId);
     } catch (cause) {
       setError(formatPluginPlatformError(cause, t("settings.marketplace.install_failed")));

--- a/apps/app/src/react-app/domains/settings/plugin-packages-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/plugin-packages-panel.tsx
@@ -31,6 +31,7 @@ import type {
 import type { iPolloWorkPluginAuthorizationMethod } from "@/app/extensions";
 import type { McpStatus, McpStatusMap } from "@/app/types";
 import { resolveExtensionIconUrl } from "@/react-app/design-system/extension-icon-src";
+import { notifyPluginUiContributionsChanged } from "@/react-app/plugin-ui/plugin-ui-contributions";
 import { AuthorizationFormDialog } from "@/react-app/domains/settings/authorization-form-dialog";
 import { PluginPackageDetail } from "@/react-app/domains/settings/plugin-package-detail";
 import { SettingsListSearchInput } from "@/react-app/domains/settings/settings-list";
@@ -127,6 +128,7 @@ export function PluginPackagesPanel(props: PluginPackagesPanelProps) {
         props.client.listBundledPluginPackages(props.workspaceId),
       ]);
       setItems(response.items);
+      notifyPluginUiContributionsChanged();
       setCatalogItems(catalog.items);
       const states = await Promise.all(response.items.map(async (item) => ({
         pluginId: item.pluginId,

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -11,6 +11,7 @@ import {
   Info,
   Layout,
   Paintbrush,
+  PanelsTopLeft,
   Puzzle,
   RefreshCcw,
   ShieldCheck,
@@ -237,8 +238,12 @@ export function getCloudSettingsTabs(memoryEnabled: boolean): SettingsTab[] {
 type SettingsPageProps = {
   activeTab: SettingsTab;
   onSelectTab: (tab: SettingsTab) => void;
+  pluginPages?: PluginSettingsNavigationItem[];
+  activePluginPageId?: string | null;
+  onSelectPluginPage?: (id: string) => void;
   developerMode: boolean;
   hidePageHeader?: boolean;
+  fullBleed?: boolean;
   showUpdateToolbar?: boolean;
   updateToolbarTone?: string;
   updateToolbarTitle?: string;
@@ -251,7 +256,14 @@ type SettingsPageProps = {
   children: React.ReactNode;
 };
 
-type SettingsSidebarProps = Pick<SettingsPageProps, "activeTab" | "onSelectTab" | "developerMode"> & {
+export type PluginSettingsNavigationItem = {
+  id: string;
+  label: string;
+  description?: string;
+  iconSrc?: string | null;
+};
+
+type SettingsSidebarProps = Pick<SettingsPageProps, "activeTab" | "onSelectTab" | "pluginPages" | "activePluginPageId" | "onSelectPluginPage" | "developerMode"> & {
   onClose: () => void;
 };
 
@@ -285,7 +297,7 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
                   <SidebarMenuItem key={tab}>
                     <SidebarMenuButton
                       type="button"
-                      isActive={props.activeTab === tab}
+                      isActive={!props.activePluginPageId && props.activeTab === tab}
                       onClick={() => props.onSelectTab(tab)}
                     >
                       <Icon />
@@ -294,6 +306,19 @@ export function SettingsSidebar(props: SettingsSidebarProps) {
                   </SidebarMenuItem>
                 );
               })}
+              {props.pluginPages?.map((page) => (
+                <SidebarMenuItem key={page.id}>
+                  <SidebarMenuButton
+                    type="button"
+                    isActive={props.activePluginPageId === page.id}
+                    onClick={() => props.onSelectPluginPage?.(page.id)}
+                    title={page.description}
+                  >
+                    {page.iconSrc ? <img src={page.iconSrc} alt="" className="size-4 rounded-sm object-contain" /> : <PanelsTopLeft />}
+                    <span>{page.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -379,6 +404,9 @@ function DesktopPolicyBanner() {
 }
 
 export function SettingsPage(props: SettingsPageProps) {
+  if (props.fullBleed) {
+    return <div className="flex min-h-0 flex-1 flex-col overflow-hidden">{props.children}</div>;
+  }
   return (
     <SettingsContent>
       {!props.hidePageHeader ? (

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import type * as React from "react";
-import { ChevronDown, X } from "lucide-react";
+import { ChevronDown, PanelsTopLeft, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -48,7 +48,8 @@ export type SettingsShellProps = SettingsPageFrameProps & {
 };
 
 export function SettingsShell(props: SettingsShellProps) {
-  const title = getSettingsTabLabel(props.activeTab);
+  const activePluginPage = props.pluginPages?.find((page) => page.id === props.activePluginPageId);
+  const title = activePluginPage?.label ?? getSettingsTabLabel(props.activeTab);
 
   if (props.compact) {
     return (
@@ -60,6 +61,9 @@ export function SettingsShell(props: SettingsShellProps) {
                 activeTab={props.activeTab}
                 developerMode={props.developerMode}
                 onSelectTab={props.onSelectTab}
+                pluginPages={props.pluginPages}
+                activePluginPageId={props.activePluginPageId}
+                onSelectPluginPage={props.onSelectPluginPage}
               />
             )}
           </div>
@@ -97,6 +101,9 @@ export function SettingsShell(props: SettingsShellProps) {
           activeTab={props.activeTab}
           onSelectTab={props.onSelectTab}
           developerMode={props.developerMode}
+          pluginPages={props.pluginPages}
+          activePluginPageId={props.activePluginPageId}
+          onSelectPluginPage={props.onSelectPluginPage}
           onClose={props.onClose}
         />
         <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-16 [&_header]:pl-16 md:[&_header]:pl-6">
@@ -147,14 +154,15 @@ export function SettingsShell(props: SettingsShellProps) {
   );
 }
 
-function SettingsSectionMenu(props: Pick<SettingsPageFrameProps, "activeTab" | "developerMode" | "onSelectTab">) {
+function SettingsSectionMenu(props: Pick<SettingsPageFrameProps, "activeTab" | "developerMode" | "onSelectTab" | "pluginPages" | "activePluginPageId" | "onSelectPluginPage">) {
   const { memoryEnabled } = useFeatureFlagsPreferences();
   const sections: Array<{ label: string | null; tabs: SettingsTab[] }> = [
     { label: t("settings.group_workspace"), tabs: getWorkspaceSettingsTabs() },
     { label: t("settings.group_global"), tabs: getGlobalSettingsTabs(props.developerMode) },
     { label: t("settings.group_cloud"), tabs: getCloudSettingsTabs(memoryEnabled) },
   ];
-  const ActiveIcon = getSettingsTabIcon(props.activeTab);
+  const activePluginPage = props.pluginPages?.find((page) => page.id === props.activePluginPageId);
+  const ActiveIcon = activePluginPage ? PanelsTopLeft : getSettingsTabIcon(props.activeTab);
 
   return (
     <DropdownMenu>
@@ -162,8 +170,8 @@ function SettingsSectionMenu(props: Pick<SettingsPageFrameProps, "activeTab" | "
         render={(
           <Button variant="outline" size="sm" className="min-w-0 max-w-46 justify-start gap-2">
             <ActiveIcon className="size-4 shrink-0" />
-            <span className="truncate">{getSettingsTabLabel(props.activeTab)}</span>
-            {isSettingsTabBeta(props.activeTab) ? <SettingsBetaBadge /> : null}
+            <span className="truncate">{activePluginPage?.label ?? getSettingsTabLabel(props.activeTab)}</span>
+            {!activePluginPage && isSettingsTabBeta(props.activeTab) ? <SettingsBetaBadge /> : null}
             <ChevronDown className="ml-auto size-4 shrink-0" />
           </Button>
         )}
@@ -187,6 +195,16 @@ function SettingsSectionMenu(props: Pick<SettingsPageFrameProps, "activeTab" | "
                 </DropdownMenuItem>
               );
             })}
+            {index === 0 ? props.pluginPages?.map((page) => (
+              <DropdownMenuItem
+                key={page.id}
+                onClick={() => props.onSelectPluginPage?.(page.id)}
+                className={props.activePluginPageId === page.id ? "bg-foreground/10 text-accent-foreground" : undefined}
+              >
+                {page.iconSrc ? <img src={page.iconSrc} alt="" className="size-4 rounded-sm object-contain" /> : <PanelsTopLeft />}
+                <span>{page.label}</span>
+              </DropdownMenuItem>
+            )) : null}
           </DropdownMenuGroup>
         ))}
       </DropdownMenuContent>

--- a/apps/app/src/react-app/plugin-ui/plugin-ui-contributions.ts
+++ b/apps/app/src/react-app/plugin-ui/plugin-ui-contributions.ts
@@ -1,0 +1,145 @@
+import { useEffect, useState } from "react";
+
+import type {
+  iPolloWorkPluginPackageItem,
+  iPolloWorkServerClient,
+} from "@/app/lib/ipollowork-server";
+import type { PluginContribution, PluginUiResource } from "@ipollowork/types/plugins";
+
+export type PluginUiSurface = {
+  id: string;
+  pluginId: string;
+  pluginName: string;
+  label: string;
+  description: string;
+  iconSrc: string | null;
+  action: string | null;
+  resource: PluginUiResource;
+};
+
+export type PluginConversationTemplate = {
+  id: string;
+  pluginId: string;
+  label: string;
+  description: string;
+  prompt: string;
+  mode: "work" | "code" | "design" | "video";
+};
+
+export type InstalledPluginContributions = {
+  workspaceApps: PluginUiSurface[];
+  settingsPages: PluginUiSurface[];
+  conversationTemplates: PluginConversationTemplate[];
+};
+
+const EMPTY_CONTRIBUTIONS: InstalledPluginContributions = {
+  workspaceApps: [],
+  settingsPages: [],
+  conversationTemplates: [],
+};
+
+export const PLUGIN_UI_CONTRIBUTIONS_CHANGED = "ipollowork:plugin-ui-contributions-changed";
+
+export function notifyPluginUiContributionsChanged() {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(PLUGIN_UI_CONTRIBUTIONS_CHANGED));
+  }
+}
+
+function contributionId(pluginId: string, contribution: PluginContribution, index: number) {
+  return `${pluginId}:${contribution.type}:${contribution.ref ?? contribution.label ?? index}`;
+}
+
+function uiSurface(
+  item: iPolloWorkPluginPackageItem,
+  contribution: PluginContribution,
+  index: number,
+): PluginUiSurface | null {
+  const resource = item.manifest.resources.find((entry) => (
+    entry.type === "ui"
+    && entry.id === contribution.ref
+    && Boolean(entry.path && entry.ui)
+    && !item.disabledResourceIds.includes(entry.id)
+  ));
+  if (!resource?.path || !resource.ui) return null;
+  return {
+    id: contributionId(item.pluginId, contribution, index),
+    pluginId: item.pluginId,
+    pluginName: item.name,
+    label: contribution.label?.trim() || resource.label?.trim() || item.name,
+    description: contribution.description?.trim() || resource.description?.trim() || item.manifest.description,
+    iconSrc: item.manifest.icon?.src?.trim() || null,
+    action: contribution.action?.trim() || null,
+    resource: resource as PluginUiResource,
+  };
+}
+
+export function resolveInstalledPluginContributions(
+  items: iPolloWorkPluginPackageItem[],
+): InstalledPluginContributions {
+  const workspaceApps: PluginUiSurface[] = [];
+  const settingsPages: PluginUiSurface[] = [];
+  const conversationTemplates: PluginConversationTemplate[] = [];
+
+  for (const item of items) {
+    if (!item.enabled) continue;
+    item.manifest.contributions?.forEach((contribution, index) => {
+      if (contribution.type === "workspace-app" || contribution.type === "settings-page") {
+        const surface = uiSurface(item, contribution, index);
+        if (!surface) return;
+        (contribution.type === "workspace-app" ? workspaceApps : settingsPages).push(surface);
+        return;
+      }
+      if (contribution.type !== "conversation-template" || !contribution.prompt?.trim()) return;
+      conversationTemplates.push({
+        id: contributionId(item.pluginId, contribution, index),
+        pluginId: item.pluginId,
+        label: contribution.label?.trim() || item.name,
+        description: contribution.description?.trim() || item.manifest.description,
+        prompt: contribution.prompt.trim(),
+        mode: contribution.mode ?? "work",
+      });
+    });
+  }
+
+  const byLabel = <Value extends { label: string }>(left: Value, right: Value) => left.label.localeCompare(right.label);
+  return {
+    workspaceApps: workspaceApps.sort(byLabel),
+    settingsPages: settingsPages.sort(byLabel),
+    conversationTemplates: conversationTemplates.sort(byLabel),
+  };
+}
+
+export function useInstalledPluginContributions(
+  client: iPolloWorkServerClient | null | undefined,
+  workspaceId: string | null | undefined,
+) {
+  const [contributions, setContributions] = useState(EMPTY_CONTRIBUTIONS);
+
+  useEffect(() => {
+    if (!client || !workspaceId) {
+      setContributions(EMPTY_CONTRIBUTIONS);
+      return;
+    }
+    let active = true;
+    const load = () => {
+      void client.listPluginPackages(workspaceId)
+        .then(({ items }) => {
+          if (active) setContributions(resolveInstalledPluginContributions(items));
+        })
+        .catch(() => {
+          if (active) setContributions(EMPTY_CONTRIBUTIONS);
+        });
+    };
+    load();
+    window.addEventListener(PLUGIN_UI_CONTRIBUTIONS_CHANGED, load);
+    window.addEventListener("focus", load);
+    return () => {
+      active = false;
+      window.removeEventListener(PLUGIN_UI_CONTRIBUTIONS_CHANGED, load);
+      window.removeEventListener("focus", load);
+    };
+  }, [client, workspaceId]);
+
+  return contributions;
+}

--- a/apps/app/src/react-app/plugin-ui/workspace-app-frame.tsx
+++ b/apps/app/src/react-app/plugin-ui/workspace-app-frame.tsx
@@ -1,0 +1,325 @@
+/** @jsxImportSource react */
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  AppBridge,
+  PostMessageTransport,
+  buildAllowAttribute,
+  type McpUiHostContext,
+  type McpUiUpdateModelContextRequest,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { Loader2, RotateCw } from "lucide-react";
+
+import type {
+  iPolloWorkPluginUiResource,
+  iPolloWorkServerClient,
+} from "@/app/lib/ipollowork-server";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { usePlatform } from "@/react-app/kernel/platform";
+import {
+  useControlActions,
+  type iPolloWorkControlAction,
+} from "@/react-app/shell/control/control-provider";
+import {
+  PLUGIN_UI_HOST_CONTEXT_KEY,
+  type PluginUiHostContextV1,
+} from "@ipollowork/types/plugins";
+
+import type { PluginUiSurface } from "./plugin-ui-contributions";
+
+export type WorkspaceAppModelContext = McpUiUpdateModelContextRequest["params"];
+
+type WorkspaceAppFrameProps = {
+  surface: PluginUiSurface;
+  client: iPolloWorkServerClient;
+  workspaceId: string;
+  workspaceRoot: string;
+  sessionId?: string | null;
+  placement: "workspace" | "settings";
+  displayMode?: "inline" | "fullscreen";
+  onDisplayModeChange?: (mode: "inline" | "fullscreen") => void;
+  onSendMessage?: (input: {
+    text: string;
+    modelContext: WorkspaceAppModelContext | null;
+  }) => boolean | Promise<boolean>;
+  onRequestClose?: () => void;
+  className?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cspSourceList(values: string[] | undefined, fallback: string) {
+  return values?.length ? values.join(" ") : fallback;
+}
+
+function withContentSecurityPolicy(resource: iPolloWorkPluginUiResource) {
+  const csp = resource.resource.ui.csp;
+  const policy = [
+    "default-src 'none'",
+    `script-src 'unsafe-inline' ${cspSourceList(csp?.resourceDomains, "")}`.trim(),
+    `style-src 'unsafe-inline' ${cspSourceList(csp?.resourceDomains, "")}`.trim(),
+    `img-src data: blob: ${cspSourceList(csp?.resourceDomains, "")}`.trim(),
+    `font-src data: ${cspSourceList(csp?.resourceDomains, "")}`.trim(),
+    `media-src data: blob: ${cspSourceList(csp?.resourceDomains, "")}`.trim(),
+    `connect-src ${cspSourceList(csp?.connectDomains, "'none'")}`,
+    `frame-src ${cspSourceList(csp?.frameDomains, "'none'")}`,
+    `base-uri ${cspSourceList(csp?.baseUriDomains, "'none'")}`,
+    "form-action 'none'",
+  ].join("; ");
+  const meta = `<meta http-equiv="Content-Security-Policy" content="${policy.replaceAll("&", "&amp;").replaceAll("\"", "&quot;")}">`;
+  if (/<head(?:\s[^>]*)?>/i.test(resource.html)) {
+    return resource.html.replace(/<head(?:\s[^>]*)?>/i, (head) => `${head}${meta}`);
+  }
+  return `${meta}${resource.html}`;
+}
+
+function messageText(content: Array<{ type: string; text?: string }>) {
+  return content.flatMap((block) => block.type === "text" && block.text?.trim() ? [block.text.trim()] : []).join("\n\n");
+}
+
+function toolResult(value: unknown): CallToolResult {
+  return {
+    content: [{ type: "text", text: typeof value === "string" ? value : JSON.stringify(value, null, 2) }],
+    ...(isRecord(value) ? { structuredContent: value } : {}),
+  };
+}
+
+function toolError(error: unknown): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: "text", text: error instanceof Error ? error.message : String(error || "Workspace App tool failed") }],
+  };
+}
+
+function currentTheme(): "light" | "dark" {
+  return document.documentElement.classList.contains("dark") ? "dark" : "light";
+}
+
+export function WorkspaceAppFrame(props: WorkspaceAppFrameProps) {
+  const platform = usePlatform();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const bridgeRef = useRef<AppBridge | null>(null);
+  const modelContextRef = useRef<WorkspaceAppModelContext | null>(null);
+  const onDisplayModeChangeRef = useRef(props.onDisplayModeChange);
+  const onSendMessageRef = useRef(props.onSendMessage);
+  const onRequestCloseRef = useRef(props.onRequestClose);
+  onDisplayModeChangeRef.current = props.onDisplayModeChange;
+  onSendMessageRef.current = props.onSendMessage;
+  onRequestCloseRef.current = props.onRequestClose;
+  const supportsDisplayModeChange = Boolean(props.onDisplayModeChange);
+  const supportsMessage = Boolean(props.onSendMessage);
+  const [resource, setResource] = useState<iPolloWorkPluginUiResource | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    setResource(null);
+    void props.client.getPluginPackageUiResource(
+      props.workspaceId,
+      props.surface.pluginId,
+      props.surface.resource.id,
+    ).then((nextResource) => {
+      if (active) setResource(nextResource);
+    }).catch((nextError) => {
+      if (active) setError(nextError instanceof Error ? nextError.message : "Workspace App could not be loaded");
+    }).finally(() => {
+      if (active) setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+  }, [props.client, props.surface.pluginId, props.surface.resource.id, props.workspaceId, revision]);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!resource || !iframe?.contentWindow) return;
+    let disposed = false;
+    const transport = new PostMessageTransport(iframe.contentWindow, iframe.contentWindow);
+    const pluginContext: PluginUiHostContextV1 = {
+      schemaVersion: 1,
+      pluginId: props.surface.pluginId,
+      resourceId: props.surface.resource.id,
+      surface: props.placement,
+      workspaceId: props.workspaceId,
+      workspaceRoot: props.workspaceRoot,
+      sessionId: props.sessionId ?? null,
+    };
+    const hostContext: McpUiHostContext = {
+      theme: currentTheme(),
+      displayMode: props.displayMode ?? "inline",
+      availableDisplayModes: supportsDisplayModeChange ? ["inline", "fullscreen"] : ["inline"],
+      locale: document.documentElement.lang || navigator.language,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      platform: platform.platform === "desktop" ? "desktop" : "web",
+      userAgent: navigator.userAgent,
+      [PLUGIN_UI_HOST_CONTEXT_KEY]: pluginContext,
+    };
+    const bridge = new AppBridge(
+      null,
+      { name: "iPolloWork", version: "0.21.2" },
+      {
+        experimental: { [PLUGIN_UI_HOST_CONTEXT_KEY]: {} },
+        openLinks: {},
+        serverTools: {},
+        logging: {},
+        updateModelContext: { text: {}, structuredContent: {} },
+        ...(supportsMessage ? { message: { text: {} } } : {}),
+        sandbox: {
+          csp: resource.resource.ui.csp,
+          permissions: resource.resource.ui.permissions,
+        },
+      },
+      { hostContext },
+    );
+    bridgeRef.current = bridge;
+    bridge.oncalltool = async ({ name, arguments: args }) => {
+      try {
+        if (props.surface.action && name !== props.surface.action) {
+          throw new Error(`Workspace App may only call ${props.surface.action}.`);
+        }
+        const result = await props.client.callExtensionAction({
+          extensionId: props.surface.pluginId,
+          action: name,
+          args: isRecord(args) ? args : {},
+          context: {
+            directory: props.workspaceRoot,
+            workspaceId: props.workspaceId,
+            sessionId: props.sessionId ?? undefined,
+          },
+        });
+        return result.ok ? toolResult(result.result) : toolError(result.message);
+      } catch (nextError) {
+        return toolError(nextError);
+      }
+    };
+    bridge.onmessage = async ({ content }) => {
+      const text = messageText(content);
+      const sendMessage = onSendMessageRef.current;
+      if (!text || !sendMessage) return { isError: true };
+      return await sendMessage({ text, modelContext: modelContextRef.current }) ? {} : { isError: true };
+    };
+    bridge.onupdatemodelcontext = async (context) => {
+      modelContextRef.current = context;
+      return {};
+    };
+    bridge.onopenlink = async ({ url }) => {
+      try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return { isError: true };
+        platform.openLink(parsed.toString());
+        return {};
+      } catch {
+        return { isError: true };
+      }
+    };
+    bridge.onrequestdisplaymode = async ({ mode }) => {
+      const changeDisplayMode = onDisplayModeChangeRef.current;
+      const nextMode = mode === "fullscreen" && changeDisplayMode ? "fullscreen" : "inline";
+      changeDisplayMode?.(nextMode);
+      return { mode: nextMode };
+    };
+    bridge.onrequestteardown = () => onRequestCloseRef.current?.();
+    bridge.onloggingmessage = ({ level, logger, data }) => {
+      const log = level === "error" || level === "critical" ? console.error : level === "warning" ? console.warn : console.debug;
+      log(`[workspace-app:${logger ?? props.surface.pluginId}]`, data);
+    };
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (!entry || disposed) return;
+      bridge.setHostContext({
+        containerDimensions: {
+          width: Math.round(entry.contentRect.width),
+          height: Math.round(entry.contentRect.height),
+        },
+      });
+    });
+    resizeObserver.observe(iframe);
+    const themeObserver = new MutationObserver(() => {
+      if (!disposed) bridge.setHostContext({ theme: currentTheme() });
+    });
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+
+    iframe.srcdoc = withContentSecurityPolicy(resource);
+    void bridge.connect(transport).catch((nextError) => {
+      if (!disposed) setError(nextError instanceof Error ? nextError.message : "Workspace App bridge failed");
+    });
+
+    return () => {
+      disposed = true;
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      bridgeRef.current = null;
+      void bridge.teardownResource({}).catch(() => undefined).finally(() => transport.close());
+      iframe.srcdoc = "";
+    };
+  }, [platform, props.client, props.placement, props.sessionId, props.surface.action, props.surface.pluginId, props.surface.resource.id, props.workspaceId, props.workspaceRoot, resource, supportsDisplayModeChange, supportsMessage]);
+
+  useEffect(() => {
+    bridgeRef.current?.setHostContext({ displayMode: props.displayMode ?? "inline" });
+  }, [props.displayMode]);
+
+  const controlActions = useMemo<iPolloWorkControlAction[]>(() => props.placement !== "workspace" ? [] : [
+    {
+      id: "workspace_app.list_tools",
+      label: `List ${props.surface.label} tools`,
+      description: "List standard MCP App tools exposed by the active Workspace App.",
+      sideEffect: "none",
+      execute: async () => bridgeRef.current?.listTools({}) ?? { tools: [] },
+    },
+    {
+      id: "workspace_app.call_tool",
+      label: `Edit ${props.surface.label}`,
+      description: "Call a standard MCP App tool exposed by the active Workspace App.",
+      sideEffect: "mutation",
+      requiresArgs: true,
+      args: [
+        { name: "name", type: "string", required: true, description: "Tool name returned by workspace_app.list_tools." },
+        { name: "arguments", type: "object", description: "Tool arguments." },
+      ],
+      execute: async (args) => {
+        if (!isRecord(args) || typeof args.name !== "string") throw new Error("name is required");
+        const bridge = bridgeRef.current;
+        if (!bridge) throw new Error("Workspace App is not ready");
+        return bridge.callTool({
+          name: args.name,
+          arguments: isRecord(args.arguments) ? args.arguments : {},
+        });
+      },
+    },
+  ], [props.placement, props.surface.label]);
+  useControlActions(controlActions);
+
+  if (loading) {
+    return <div className={cn("flex h-full items-center justify-center text-sm text-muted-foreground", props.className)}><Loader2 className="mr-2 size-4 animate-spin" />Loading {props.surface.label}…</div>;
+  }
+  if (error || !resource) {
+    return (
+      <div className={cn("flex h-full items-center justify-center p-6 text-center", props.className)}>
+        <div>
+          <p className="text-sm font-medium text-foreground">{props.surface.label} could not be displayed.</p>
+          <p className="mt-1 max-w-sm text-xs text-muted-foreground">{error}</p>
+          <Button className="mt-4" size="sm" variant="outline" onClick={() => setRevision((value) => value + 1)}>
+            <RotateCw className="size-3.5" />Retry
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={props.surface.label}
+      className={cn("h-full w-full border-0 bg-background", props.className)}
+      sandbox="allow-scripts"
+      allow={buildAllowAttribute(resource.resource.ui.permissions)}
+    />
+  );
+}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -157,6 +157,8 @@ import {
   OPENAI_IMAGE_MODEL,
 } from "@/react-app/domains/settings/openai-image-extension";
 import type { LocalProviderInstallInput } from "@/react-app/domains/settings/openai-image-extension";
+import { useInstalledPluginContributions } from "@/react-app/plugin-ui/plugin-ui-contributions";
+import { WorkspaceAppFrame } from "@/react-app/plugin-ui/workspace-app-frame";
 
 const ROUTE_IPOLLOWORK_CAPABILITIES: iPolloWorkServerCapabilities = {
   skills: { read: true, write: true, source: "ipollowork" },
@@ -240,6 +242,8 @@ export function parseSettingsPath(pathname: string): {
   redirectPath: string | null;
   extensionsSection?: ExtensionsSection;
   pluginPackageId?: string;
+  pluginPagePluginId?: string;
+  pluginPageResourceId?: string;
 } {
   const trimmed = pathname
     .replace(/^\/workspace\/[^/]+\/settings\/?/, "")
@@ -286,6 +290,16 @@ export function parseSettingsPath(pathname: string): {
       if (tail === "skills") return { tab: "extensions", redirectPath: null, extensionsSection: "skills" };
       if (tail === "plugins") return { tab: "extensions", redirectPath: null, extensionsSection: "plugins" };
       return { tab: "extensions", redirectPath: null, extensionsSection: "all" };
+    case "plugin":
+      if (tail && detailId) {
+        return {
+          tab: "extensions",
+          redirectPath: null,
+          pluginPagePluginId: decodeURIComponent(tail),
+          pluginPageResourceId: decodeURIComponent(detailId),
+        };
+      }
+      return { tab: "extensions", redirectPath: "extensions" };
     default:
       return { tab: "preferences", redirectPath: "preferences" };
   }
@@ -333,6 +347,9 @@ function findSessionWorkspaceId(
 }
 
 function settingsPathForRoute(route: ReturnType<typeof parseSettingsPath>) {
+  if (route.pluginPagePluginId && route.pluginPageResourceId) {
+    return `plugin/${encodeURIComponent(route.pluginPagePluginId)}/${encodeURIComponent(route.pluginPageResourceId)}`;
+  }
   if (route.tab === "extensions" && route.pluginPackageId) {
     return `extensions/plugin/${encodeURIComponent(route.pluginPackageId)}`;
   }
@@ -836,6 +853,18 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   routeStateRef.current.providerRuntimeWorkspaceId = sharedProviderEndpoint?.workspaceId ?? null;
   routeStateRef.current.providerServerClient = sharedProviderEndpoint?.client ?? null;
   const runtimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspace?.id ?? null;
+  const pluginUiClient = selectedWorkspaceEndpoint?.client ?? ipolloworkClient;
+  const { settingsPages } = useInstalledPluginContributions(pluginUiClient, runtimeWorkspaceId);
+  const selectedPluginSettingsPage = settingsPages.find((page) => (
+    page.pluginId === route.pluginPagePluginId
+    && page.resource.id === route.pluginPageResourceId
+  )) ?? null;
+  const pluginSettingsNavigation = useMemo(() => settingsPages.map((page) => ({
+    id: page.id,
+    label: page.label,
+    description: page.description,
+    iconSrc: page.iconSrc,
+  })), [settingsPages]);
   const activeEnginePreferences = getEnginePreferences(local.prefs, activeEngineId);
   routeStateRef.current.runtimeWorkspaceId = runtimeWorkspaceId;
 
@@ -1796,7 +1825,16 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     navigateSettingsPath("cloud-account");
   };
 
-  const settingsView = (() => {
+  const settingsView = selectedPluginSettingsPage && pluginUiClient && runtimeWorkspaceId ? (
+    <WorkspaceAppFrame
+      surface={selectedPluginSettingsPage}
+      client={pluginUiClient}
+      workspaceId={runtimeWorkspaceId}
+      workspaceRoot={selectedWorkspaceRoot}
+      placement="settings"
+      className="min-h-0 flex-1"
+    />
+  ) : (() => {
     switch (route.tab) {
       case "general":
         return (
@@ -2140,12 +2178,18 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       <SettingsShell
         activeTab={route.tab}
         onSelectTab={(tab) => navigateSettingsPath(tab)}
+        pluginPages={pluginSettingsNavigation}
+        activePluginPageId={selectedPluginSettingsPage?.id ?? null}
+        onSelectPluginPage={(id) => {
+          const page = settingsPages.find((candidate) => candidate.id === id);
+          if (page) navigateSettingsPath(`plugin/${encodeURIComponent(page.pluginId)}/${encodeURIComponent(page.resource.id)}`);
+        }}
         developerMode={developerMode}
         headerStatus={routeiPolloWorkStatus}
         busyHint={loading ? t("session.loading_detail") : busyLabel}
         onClose={props.onClose ?? (() => navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId, navigationSessionId) : "/session"))}
         compact={props.embedded}
-        headerTitle={route.tab === "extensions" && !route.pluginPackageId ? (
+        headerTitle={route.tab === "extensions" && !route.pluginPackageId && !selectedPluginSettingsPage ? (
           <SettingsSegmentedTabs
             value={route.extensionsSection === "skills" ? "skills" : "plugins"}
             ariaLabel={t("plugin_library.navigation_label")}
@@ -2156,7 +2200,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             onValueChange={(value) => navigateSettingsPath(value === "skills" ? "extensions/skills" : "extensions")}
           />
         ) : undefined}
-        hidePageHeader={route.tab === "extensions" || Boolean(route.pluginPackageId)}
+        hidePageHeader={route.tab === "extensions" || Boolean(route.pluginPackageId) || Boolean(selectedPluginSettingsPage)}
+        fullBleed={Boolean(selectedPluginSettingsPage)}
         hideShellHeader={Boolean(route.pluginPackageId)}
       >
         {settingsView}

--- a/apps/app/tests/plugin-ui-contributions.test.ts
+++ b/apps/app/tests/plugin-ui-contributions.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import type { iPolloWorkPluginPackageItem } from "../src/app/lib/ipollowork-server";
+import { resolveInstalledPluginContributions } from "../src/react-app/plugin-ui/plugin-ui-contributions";
+import { parsePluginPackageManifest } from "@ipollowork/types/plugins";
+
+describe("plugin UI contributions", () => {
+  test("resolves enabled workspace, settings, and conversation surfaces from one package", async () => {
+    const manifest = parsePluginPackageManifest(await Bun.file(new URL("../../../examples/plugin-packages/workspace-canvas/ipollowork.plugin.json", import.meta.url)).json());
+    const item: iPolloWorkPluginPackageItem = {
+      pluginId: manifest.id,
+      name: manifest.name,
+      version: manifest.package?.version ?? "1.0.0",
+      enabled: true,
+      disabledResourceIds: [],
+      previousVersion: null,
+      manifest,
+      integrity: { sha256: "0".repeat(64), status: "unsigned" },
+    };
+
+    const result = resolveInstalledPluginContributions([item]);
+
+    expect(result.workspaceApps).toHaveLength(1);
+    expect(result.settingsPages).toHaveLength(1);
+    expect(result.conversationTemplates).toMatchObject([{ mode: "work", label: "Plan on a canvas" }]);
+    expect(resolveInstalledPluginContributions([{ ...item, enabled: false }])).toEqual({
+      workspaceApps: [],
+      settingsPages: [],
+      conversationTemplates: [],
+    });
+    expect(resolveInstalledPluginContributions([{ ...item, disabledResourceIds: ["canvas"] }]).workspaceApps).toHaveLength(0);
+  });
+});

--- a/apps/server/src/plugin-package-lifecycle.test.ts
+++ b/apps/server/src/plugin-package-lifecycle.test.ts
@@ -362,6 +362,41 @@ describe("plugin package lifecycle", () => {
     expect(preview.writes.some((entry) => entry.path === ".opencode/mcps/figma.json")).toBe(false);
   });
 
+  test("installs and serves an enabled Workspace App from immutable package artifacts", async () => {
+    const lifecycle = await import("./plugin-package-lifecycle.js");
+    const workspaceRoot = await createRoot("ipollowork-workspace-app-");
+    const packageRoot = fileURLToPath(new URL("../../../examples/plugin-packages/workspace-canvas", import.meta.url));
+    const config = serverConfig(workspaceRoot);
+    process.env.IPOLLOWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+
+    await lifecycle.installPluginPackage({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      packageRoot,
+      workspaceRoot,
+    });
+    const resource = await lifecycle.readInstalledPluginUiResource({
+      serverConfig: config,
+      pluginId: "workspace-canvas",
+      resourceId: "canvas",
+    });
+
+    expect(resource.resource.ui.uri).toBe("ui://workspace-canvas/canvas");
+    expect(resource.html).toContain("Workspace Canvas");
+    await lifecycle.setPluginPackageEnabled({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      pluginId: "workspace-canvas",
+      workspaceRoot,
+      enabled: false,
+    });
+    await expect(lifecycle.readInstalledPluginUiResource({
+      serverConfig: config,
+      pluginId: "workspace-canvas",
+      resourceId: "canvas",
+    })).rejects.toMatchObject({ code: "plugin_package_disabled" });
+  });
+
   test("expands directory resources into owned files without duplicates", async () => {
     const lifecycle = await import("./plugin-package-lifecycle.js");
     const workspaceRoot = await createRoot("ipollowork-plugin-directory-workspace-");

--- a/apps/server/src/plugin-package-lifecycle.ts
+++ b/apps/server/src/plugin-package-lifecycle.ts
@@ -14,7 +14,7 @@ import {
   type PluginEngineVersion,
   type PluginWorkspaceFile,
 } from "./plugin-engine-adapter.js";
-import { parsePluginPackageManifest, type PluginPackageManifest } from "./plugin-package-manifest.js";
+import { parsePluginPackageManifest, type PluginPackageManifest, type PluginResource } from "./plugin-package-manifest.js";
 import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
 import { DEFAULT_ENGINE_ID, type ServerConfig } from "./types.js";
 import serverPackage from "../package.json" with { type: "json" };
@@ -38,6 +38,7 @@ const CURRENT_RESOURCE_KEYS = [
   "requires",
   "provides",
   "required",
+  "ui",
 ] as const;
 const TRUSTED_IMPORT_PUBLISHER_KEYS = new Map([
   [
@@ -105,7 +106,7 @@ export type PluginPackageImportSafety =
   | {
       level: "declarative";
       localCode: false;
-      allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp">;
+      allowedResourceTypes: Array<"skill" | "agent" | "command" | "file" | "mcp" | "ui">;
     }
   | {
       level: "signed";
@@ -134,6 +135,17 @@ export type InstalledPluginService = {
   manifest: PluginPackageManifest;
   version: string;
   modulePath: string;
+};
+
+export type InstalledPluginUiResource = {
+  pluginId: string;
+  version: string;
+  resource: PluginResource & {
+    type: "ui";
+    path: string;
+    ui: NonNullable<PluginResource["ui"]>;
+  };
+  html: string;
 };
 
 function emptyState(): LifecycleState {
@@ -910,7 +922,7 @@ export async function previewPluginPackage(input: { packageRoot: string; workspa
   return { manifest, files, writes, integrity: integrityForManifest(manifest, files, sourceManifest) };
 }
 
-const SAFE_IMPORT_RESOURCE_TYPES = new Set(["skill", "agent", "command", "file", "mcp"]);
+const SAFE_IMPORT_RESOURCE_TYPES = new Set(["skill", "agent", "command", "file", "mcp", "ui"]);
 
 function hasExecutableCapabilities(manifest: PluginPackageManifest): boolean {
   return manifest.resources.some((resource) => resource.type === "local-service" && Boolean(resource.path))
@@ -958,6 +970,7 @@ function safeImportResourcePath(type: string, path: string): boolean {
   if (type === "agent") return path.startsWith("agents/");
   if (type === "command") return path.startsWith("commands/");
   if (type === "mcp") return path.startsWith("mcp/") && path.endsWith(".json");
+  if (type === "ui") return path.startsWith("ui/") && path.endsWith(".html");
   return type === "file" && ["skills/", "agents/", "commands/"]
     .some((prefix) => path.startsWith(prefix));
 }
@@ -1038,7 +1051,7 @@ export async function assertPluginPackageSafeForImport(input: {
   return {
     level: "declarative",
     localCode: false,
-    allowedResourceTypes: ["skill", "agent", "command", "file", "mcp"],
+    allowedResourceTypes: ["skill", "agent", "command", "file", "mcp", "ui"],
   };
 }
 
@@ -1059,6 +1072,40 @@ export async function listInstalledPluginPackages(input: { serverConfig: ServerC
       integrity: integrityForManifest(manifest, version.files, version.manifest),
     };
   }).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export async function readInstalledPluginUiResource(input: {
+  serverConfig: ServerConfig;
+  pluginId: string;
+  resourceId: string;
+}): Promise<InstalledPluginUiResource> {
+  const state = await readState(input.serverConfig);
+  const installed = state.packages[input.pluginId];
+  if (!installed) throw new ApiError(404, "plugin_package_not_installed", "Plugin package is not installed");
+  if (!installed.enabled) throw new ApiError(409, "plugin_package_disabled", "Plugin package is disabled");
+  if (installed.disabledResourceIds.includes(input.resourceId)) {
+    throw new ApiError(409, "plugin_resource_disabled", "Plugin UI resource is disabled");
+  }
+  const version = installed.versions[installed.currentVersion];
+  if (!version) throw new ApiError(500, "plugin_package_state_invalid", "Installed package version is missing");
+  const manifest = manifestFromVersion(version);
+  const resource = manifest.resources.find((entry) => entry.id === input.resourceId && entry.type === "ui");
+  if (!resource?.path || !resource.ui) {
+    throw new ApiError(404, "plugin_ui_resource_not_found", "Plugin UI resource was not found");
+  }
+  if (!version.files.some((file) => file.path === resource.path)) {
+    throw new ApiError(500, "plugin_package_state_invalid", "Plugin UI resource file is missing from the installed package");
+  }
+  const html = await readFile(resolveWithin(artifactRoot(input.serverConfig, input.pluginId, version.version), resource.path), "utf8");
+  if (Buffer.byteLength(html, "utf8") > 5 * 1024 * 1024) {
+    throw new ApiError(413, "plugin_ui_resource_too_large", "Plugin UI resource exceeds the 5MB limit");
+  }
+  return {
+    pluginId: input.pluginId,
+    version: version.version,
+    resource: resource as InstalledPluginUiResource["resource"],
+    html,
+  };
 }
 
 async function reconcilePackageProjection(

--- a/apps/server/src/plugin-package-manifest.test.ts
+++ b/apps/server/src/plugin-package-manifest.test.ts
@@ -465,4 +465,52 @@ describe("plugin package manifest", () => {
       "relatedSkills.1",
     ]));
   });
+
+  test("accepts standard MCP App UI resources and rejects incomplete UI declarations", async () => {
+    const { validatePluginPackageManifest } = await import("./plugin-package-manifest.js");
+    const manifest = await Bun.file(new URL("../../../examples/plugin-packages/workspace-canvas/ipollowork.plugin.json", import.meta.url)).json();
+
+    const result = validatePluginPackageManifest(manifest);
+
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error(JSON.stringify(result.issues));
+    expect(result.manifest.resources[0]).toMatchObject({
+      type: "ui",
+      path: "ui/canvas.html",
+      ui: { uri: "ui://workspace-canvas/canvas", mimeType: "text/html;profile=mcp-app" },
+    });
+    expect(result.manifest.contributions?.map((contribution) => contribution.type)).toEqual([
+      "workspace-app",
+      "settings-page",
+      "conversation-template",
+    ]);
+
+    const invalid = validatePluginPackageManifest({
+      ...manifest,
+      resources: [{ type: "ui", id: "canvas", path: "ui/canvas.js" }],
+    });
+    expect(invalid.success).toBe(false);
+    if (invalid.success) throw new Error("Expected incomplete UI metadata to be rejected");
+    expect(invalid.issues.map((issue) => issue.path)).toEqual(expect.arrayContaining([
+      "resources.0.path",
+      "resources.0.ui",
+    ]));
+
+    const undeclaredNetwork = validatePluginPackageManifest({
+      ...manifest,
+      resources: [{
+        ...manifest.resources[0],
+        ui: {
+          ...manifest.resources[0].ui,
+          csp: { connectDomains: ["https://api.example.com"] },
+        },
+      }],
+    });
+    expect(undeclaredNetwork.success).toBe(false);
+    if (undeclaredNetwork.success) throw new Error("Expected undeclared UI network access to be rejected");
+    expect(undeclaredNetwork.issues).toContainEqual({
+      path: "resources.0.ui.csp",
+      message: "requires the network package permission",
+    });
+  });
 });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -52,6 +52,7 @@ import {
   listInstalledPluginPackages,
   migratePluginPackageLifecycle,
   previewPluginPackage,
+  readInstalledPluginUiResource,
   reconcilePluginPackagesForWorkspace,
   rollbackPluginPackage,
   setPluginPackageEnabled,
@@ -1906,6 +1907,16 @@ function createRoutes(
     await reconcilePluginPackagesForWorkspace({ serverConfig: config, workspaceId: workspace.id, workspaceRoot: workspace.path });
     const items = await listInstalledPluginPackages({ serverConfig: config });
     return jsonResponse({ items });
+  });
+
+  addRoute(routes, "GET", "/workspace/:id/plugin-packages/:pluginId/ui/:resourceId", "client", async (ctx) => {
+    await resolveWorkspace(config, ctx.params.id);
+    const result = await readInstalledPluginUiResource({
+      serverConfig: config,
+      pluginId: ctx.params.pluginId ?? "",
+      resourceId: ctx.params.resourceId ?? "",
+    });
+    return jsonResponse(result);
   });
 
   addRoute(routes, "GET", "/workspace/:id/plugin-packages/catalog", "client", async (ctx) => {

--- a/docs/plugin-packages.md
+++ b/docs/plugin-packages.md
@@ -13,6 +13,7 @@ acme-research/
 ├── ipollowork.plugin.json
 ├── service/acme-research.ts
 ├── skills/acme-research/SKILL.md
+├── ui/canvas.html
 └── engines/opencode/plugins/acme-research.ts
 ```
 
@@ -133,6 +134,41 @@ Package versions use semantic versions. A published version is immutable: changi
 
 Omit `package.engines` for a portable package. Set it when the package requires one of the listed engines. Portable skills, agents, commands, MCP definitions, and services stay under `skills/`, `agents/`, `commands/`, `mcp/`, and `service/`. `engineBindings` contains optional native enhancements under `engines/<engine>/` plus their engine-version ranges. The active adapter projects portable capabilities into its own runtime layout; package authors never write engine runtime paths directly.
 
+## Workspace Apps
+
+Interactive plugin UI uses the [MCP Apps protocol](https://github.com/modelcontextprotocol/ext-apps), not a separate iPolloWork message format. A `ui` resource owns one static HTML entry under `ui/`, declares the standard `ui://` URI and `text/html;profile=mcp-app` MIME type, and can be contributed to the right workspace or Settings:
+
+```json
+{
+  "resources": [{
+    "type": "ui",
+    "id": "canvas",
+    "path": "ui/canvas.html",
+    "ui": {
+      "uri": "ui://workspace-canvas/canvas",
+      "mimeType": "text/html;profile=mcp-app",
+      "prefersBorder": false
+    }
+  }],
+  "contributions": [
+    { "type": "workspace-app", "ref": "canvas", "label": "Canvas" },
+    { "type": "settings-page", "ref": "canvas", "label": "Canvas Settings" },
+    {
+      "type": "conversation-template",
+      "label": "Plan on a canvas",
+      "prompt": "Build a visual plan for this task.",
+      "mode": "work"
+    }
+  ]
+}
+```
+
+The host loads the installed immutable artifact in a script-only sandbox, applies the resource CSP and permission policy, and speaks MCP Apps JSON-RPC over `postMessage`. Standard `ui/message` and `ui/update-model-context` requests connect the surface to the current conversation. A view can expose standard `tools/list` and `tools/call` handlers; iPolloWork publishes those view tools to the active agent as `workspace_app.list_tools` and `workspace_app.call_tool`, so AI and direct manipulation edit the same surface. A view can also call the package's declared local-service actions through standard server `tools/call` requests.
+
+iPolloWork adds only the versioned `ai.ipollo/workspace` host-context field with the current plugin, resource, surface, workspace, root, and session IDs. Apps that ignore this optional field remain standard MCP Apps. Network, frames, camera, microphone, geolocation, and clipboard-write are denied unless the UI resource explicitly declares and the host grants them.
+
+See [`examples/plugin-packages/workspace-canvas`](../examples/plugin-packages/workspace-canvas) for a framework-free example that contributes one editable right-side canvas, one Settings page, one conversation template, and two agent-callable canvas tools. The package is engine-neutral and uses the same install, enable, update, rollback, and uninstall lifecycle as every other capability bundle.
+
 ## Authorization methods
 
 A plugin can declare several choices. The settings UI renders all fields itself; third-party React code is not loaded there.
@@ -199,6 +235,7 @@ POST   /workspace/:id/plugin-packages
 POST   /workspace/:id/plugin-packages/:pluginId/update
 POST   /workspace/:id/plugin-packages/:pluginId/rollback
 PATCH  /workspace/:id/plugin-packages/:pluginId
+GET    /workspace/:id/plugin-packages/:pluginId/ui/:resourceId
 DELETE /workspace/:id/plugin-packages/:pluginId
 ```
 

--- a/examples/plugin-packages/workspace-canvas/README.md
+++ b/examples/plugin-packages/workspace-canvas/README.md
@@ -1,0 +1,10 @@
+# Workspace Canvas
+
+This is the smallest complete iPolloWork Workspace App example. One engine-neutral plugin package contributes:
+
+- an MCP App in the right workspace;
+- the same app as a full Settings page;
+- a Work-mode conversation template;
+- `replace_board` and `append_note` tools that the active agent can call.
+
+The UI is one static HTML file and communicates only through standard MCP Apps JSON-RPC. Install this directory through the local plugin-package developer flow, then open **Canvas** from the right-side launcher.

--- a/examples/plugin-packages/workspace-canvas/ipollowork.plugin.json
+++ b/examples/plugin-packages/workspace-canvas/ipollowork.plugin.json
@@ -1,0 +1,59 @@
+{
+  "schemaVersion": 2,
+  "id": "workspace-canvas",
+  "name": "Workspace Canvas",
+  "description": "A minimal MCP App canvas that can be edited by people and agents.",
+  "category": "Productivity & Collaboration",
+  "source": {
+    "format": "ipollowork-extension-manifest",
+    "origin": "local",
+    "trusted": false
+  },
+  "package": {
+    "version": "1.0.0",
+    "publisher": {
+      "id": "ipollowork",
+      "name": "iPolloWork"
+    },
+    "compatibility": {
+      "ipollowork": ">=0.21.0"
+    },
+    "updateId": "ipollowork/workspace-canvas"
+  },
+  "resources": [
+    {
+      "type": "ui",
+      "id": "canvas",
+      "label": "Workspace Canvas",
+      "description": "An editable shared canvas exposed through standard MCP App tools.",
+      "path": "ui/canvas.html",
+      "required": true,
+      "ui": {
+        "uri": "ui://workspace-canvas/canvas",
+        "mimeType": "text/html;profile=mcp-app",
+        "prefersBorder": false
+      }
+    }
+  ],
+  "contributions": [
+    {
+      "type": "workspace-app",
+      "ref": "canvas",
+      "label": "Canvas",
+      "description": "Open the shared canvas in the right workspace."
+    },
+    {
+      "type": "settings-page",
+      "ref": "canvas",
+      "label": "Canvas Settings",
+      "description": "Configure and inspect the same canvas inside Settings."
+    },
+    {
+      "type": "conversation-template",
+      "label": "Plan on a canvas",
+      "description": "Create a visual plan and keep it synchronized with the conversation.",
+      "prompt": "Open the Canvas workspace app and build a concise visual plan for this task.",
+      "mode": "work"
+    }
+  ]
+}

--- a/examples/plugin-packages/workspace-canvas/ui/canvas.html
+++ b/examples/plugin-packages/workspace-canvas/ui/canvas.html
@@ -1,0 +1,116 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Workspace Canvas</title>
+  <style>
+    :root { color-scheme: light dark; font: 14px/1.5 system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; background: #f7f7f5; color: #191919; }
+    main { display: flex; min-height: 100vh; flex-direction: column; gap: 14px; padding: 18px; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+    h1 { margin: 0; font-size: 16px; }
+    button { border: 1px solid #d9d9d6; border-radius: 8px; background: #fff; color: inherit; padding: 7px 10px; cursor: pointer; }
+    textarea { min-height: 320px; flex: 1; resize: none; border: 1px solid #dfdfdb; border-radius: 12px; background: #fff; color: inherit; padding: 16px; font: inherit; outline: none; box-shadow: 0 10px 30px rgb(0 0 0 / 5%); }
+    textarea:focus { border-color: #7c6df2; box-shadow: 0 0 0 3px rgb(124 109 242 / 14%); }
+    small { color: #777; }
+    @media (prefers-color-scheme: dark) {
+      body { background: #181818; color: #f0f0ee; }
+      textarea, button { border-color: #3a3a38; background: #232323; }
+      small { color: #aaa; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div><h1>Workspace Canvas</h1><small id="status">Connecting…</small></div>
+      <button id="ask" type="button">Ask AI to improve</button>
+    </header>
+    <textarea id="board" aria-label="Canvas content">Goal
+
+• Add a clear objective
+• Break it into the next three actions
+• Let the agent update this canvas</textarea>
+  </main>
+  <script>
+    const board = document.querySelector("#board");
+    const status = document.querySelector("#status");
+    const pending = new Map();
+    let requestId = 0;
+    let contextTimer = 0;
+
+    function post(message) { parent.postMessage(message, "*"); }
+    function respond(id, result) { post({ jsonrpc: "2.0", id, result }); }
+    function request(method, params) {
+      const id = ++requestId;
+      post({ jsonrpc: "2.0", id, method, params });
+      return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+    }
+    function publishContext() {
+      clearTimeout(contextTimer);
+      contextTimer = setTimeout(() => {
+        void request("ui/update-model-context", {
+          content: [{ type: "text", text: `Current canvas:\n${board.value}` }],
+          structuredContent: { canvas: board.value }
+        });
+      }, 120);
+    }
+    function toolResult(text) {
+      publishContext();
+      return { content: [{ type: "text", text }], structuredContent: { canvas: board.value } };
+    }
+
+    addEventListener("message", (event) => {
+      if (event.source !== parent || !event.data || event.data.jsonrpc !== "2.0") return;
+      const message = event.data;
+      if (message.id !== undefined && !message.method) {
+        const handler = pending.get(message.id);
+        if (!handler) return;
+        pending.delete(message.id);
+        message.error ? handler.reject(new Error(message.error.message)) : handler.resolve(message.result);
+        return;
+      }
+      if (message.method === "tools/list") {
+        respond(message.id, { tools: [
+          { name: "replace_board", description: "Replace all canvas text.", inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } },
+          { name: "append_note", description: "Append one note to the canvas.", inputSchema: { type: "object", properties: { text: { type: "string" } }, required: ["text"] } }
+        ] });
+        return;
+      }
+      if (message.method === "tools/call") {
+        const args = message.params?.arguments || {};
+        if (message.params?.name === "replace_board") board.value = String(args.text || "");
+        if (message.params?.name === "append_note") board.value += `${board.value ? "\n" : ""}${String(args.text || "")}`;
+        respond(message.id, toolResult("Canvas updated."));
+        return;
+      }
+      if (message.method === "ui/resource-teardown") respond(message.id, {});
+      if (message.method === "ui/notifications/host-context-changed") {
+        document.documentElement.style.colorScheme = message.params?.theme || "light dark";
+      }
+    });
+
+    board.addEventListener("input", publishContext);
+    document.querySelector("#ask").addEventListener("click", () => {
+      void request("ui/message", {
+        role: "user",
+        content: [{ type: "text", text: "Improve the active canvas while preserving its intent." }]
+      });
+    });
+
+    request("ui/initialize", {
+      protocolVersion: "2025-11-21",
+      appInfo: { name: "Workspace Canvas", version: "1.0.0" },
+      appCapabilities: { tools: {}, availableDisplayModes: ["inline", "fullscreen"] }
+    }).then((host) => {
+      post({ jsonrpc: "2.0", method: "ui/notifications/initialized", params: {} });
+      document.querySelector("#ask").hidden = !host.hostCapabilities?.message;
+      document.documentElement.style.colorScheme = host.hostContext?.theme || "light dark";
+      status.textContent = "Connected";
+      publishContext();
+    }).catch((error) => { status.textContent = error.message; });
+  </script>
+</body>
+</html>

--- a/packages/types/src/plugins.ts
+++ b/packages/types/src/plugins.ts
@@ -8,13 +8,18 @@ const SIMPLE_ID_RE = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/;
 const FIELD_ID_RE = /^[A-Za-z][A-Za-z0-9._-]*$/;
 const ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const RELATION_RE = /^(?:action|authorization|resource|service|workflow):[a-z0-9]+(?:[._/-][a-z0-9]+)*$/;
+const UI_URI_RE = /^ui:\/\/[a-z0-9]+(?:[._/-][a-z0-9]+)*$/;
+const CSP_SOURCE_RE = /^(?:https:\/\/(?:\*\.)?[A-Za-z0-9.-]+(?::\d+)?|http:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d+)?)$/;
 const RESERVED_EXTENSION_IDS = new Set(["google-workspace", "media-center", "openai-image-generation", "storage"]);
+export const PLUGIN_UI_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
+export const PLUGIN_UI_HOST_CONTEXT_KEY = "ai.ipollo/workspace";
 const PORTABLE_RESOURCE_DIRECTORIES: Record<string, string> = {
   skill: "skills/",
   agent: "agents/",
   command: "commands/",
   mcp: "mcp/",
   "local-service": "service/",
+  ui: "ui/",
 };
 
 const sourceFormatSchema = z.enum([
@@ -39,6 +44,7 @@ const resourceTypeSchema = z.enum([
   "file",
   "local-service",
   "native-binary",
+  "ui",
 ]);
 
 const permissionIdSchema = z.enum([
@@ -50,6 +56,7 @@ const permissionIdSchema = z.enum([
   "notifications",
   "camera",
   "microphone",
+  "geolocation",
 ]);
 
 const reloadReasonSchema = z.enum(["plugins", "skills", "mcp", "config", "agents", "commands"]);
@@ -63,6 +70,9 @@ const contributionTypeSchema = z.enum([
   "server-route",
   "native-capability",
   "test-action",
+  "workspace-app",
+  "settings-page",
+  "conversation-template",
 ]);
 const enablementConditionTypeSchema = z.enum([
   "mcp-connected",
@@ -102,6 +112,24 @@ const serviceActionSchema = z.object({
 
 const relationSchema = z.string().regex(RELATION_RE, "must use kind:id syntax");
 
+const uiResourceMetadataSchema = z.object({
+  uri: z.string().regex(UI_URI_RE, "must use a ui:// URI"),
+  mimeType: z.literal(PLUGIN_UI_RESOURCE_MIME_TYPE),
+  csp: z.object({
+    connectDomains: z.array(z.string().regex(CSP_SOURCE_RE)).optional(),
+    resourceDomains: z.array(z.string().regex(CSP_SOURCE_RE)).optional(),
+    frameDomains: z.array(z.string().regex(CSP_SOURCE_RE)).optional(),
+    baseUriDomains: z.array(z.string().regex(CSP_SOURCE_RE)).optional(),
+  }).strict().optional(),
+  permissions: z.object({
+    camera: z.object({}).strict().optional(),
+    microphone: z.object({}).strict().optional(),
+    geolocation: z.object({}).strict().optional(),
+    clipboardWrite: z.object({}).strict().optional(),
+  }).strict().optional(),
+  prefersBorder: z.boolean().optional(),
+}).strict();
+
 const resourceSchema = z.object({
   type: resourceTypeSchema,
   id: z.string().min(1),
@@ -120,6 +148,7 @@ const resourceSchema = z.object({
   requires: z.array(relationSchema).optional(),
   provides: z.array(relationSchema).optional(),
   required: z.boolean().optional(),
+  ui: uiResourceMetadataSchema.optional(),
 }).strict();
 
 const secretFieldSchema = z.object({
@@ -224,6 +253,8 @@ const contributionSchema = z.object({
   description: z.string().optional(),
   prompt: z.string().optional(),
   location: z.enum(["settings-detail", "composer", "session-right-pane", "session-rail", "server", "native"]).optional(),
+  action: z.string().regex(SIMPLE_ID_RE).optional(),
+  mode: z.enum(["work", "code", "design", "video"]).optional(),
 }).strict();
 
 const setupSchema = z.object({
@@ -345,6 +376,7 @@ const manifestSchema = z.object({
     context.addIssue({ code: "custom", path: ["package", "engines"], message: "engine IDs must be unique" });
   }
 
+  const permissionIds = new Set<string>(manifest.permissions?.map((permission) => permission.id) ?? []);
   const resourceIds = new Set<string>();
   manifest.resources.forEach((resource, index) => {
     if (resourceIds.has(resource.id)) {
@@ -357,6 +389,49 @@ const manifestSchema = z.object({
     }
     if (resource.type === "mcp" && resource.path && !resource.path.endsWith(".json")) {
       context.addIssue({ code: "custom", path: ["resources", index, "path"], message: "must be a JSON file" });
+    }
+    if (resource.type === "ui") {
+      if (!resource.path) {
+        context.addIssue({ code: "custom", path: ["resources", index, "path"], message: "is required for UI resources" });
+      } else if (!resource.path.endsWith(".html")) {
+        context.addIssue({ code: "custom", path: ["resources", index, "path"], message: "must be an HTML file" });
+      }
+      if (!resource.ui) {
+        context.addIssue({ code: "custom", path: ["resources", index, "ui"], message: "is required for UI resources" });
+      } else {
+        const csp = resource.ui.csp;
+        const requestsNetwork = [csp?.connectDomains, csp?.resourceDomains, csp?.frameDomains, csp?.baseUriDomains]
+          .some((domains) => Boolean(domains?.length));
+        if (requestsNetwork && !permissionIds.has("network")) {
+          context.addIssue({ code: "custom", path: ["resources", index, "ui", "csp"], message: "requires the network package permission" });
+        }
+        const permissionMap = {
+          camera: "camera",
+          microphone: "microphone",
+          geolocation: "geolocation",
+          clipboardWrite: "clipboard",
+        } as const;
+        Object.entries(permissionMap).forEach(([uiPermission, packagePermission]) => {
+          if (resource.ui?.permissions?.[uiPermission as keyof typeof permissionMap] && !permissionIds.has(packagePermission)) {
+            context.addIssue({ code: "custom", path: ["resources", index, "ui", "permissions", uiPermission], message: `requires the ${packagePermission} package permission` });
+          }
+        });
+      }
+    } else if (resource.ui) {
+      context.addIssue({ code: "custom", path: ["resources", index, "ui"], message: "is only supported by UI resources" });
+    }
+  });
+
+  manifest.contributions?.forEach((contribution, index) => {
+    if (contribution.type === "workspace-app" || contribution.type === "settings-page") {
+      if (!contribution.ref) {
+        context.addIssue({ code: "custom", path: ["contributions", index, "ref"], message: "is required for UI contributions" });
+      } else if (!manifest.resources.some((resource) => resource.id === contribution.ref && resource.type === "ui")) {
+        context.addIssue({ code: "custom", path: ["contributions", index, "ref"], message: "must reference a UI resource" });
+      }
+    }
+    if (contribution.type === "conversation-template" && !contribution.prompt?.trim()) {
+      context.addIssue({ code: "custom", path: ["contributions", index, "prompt"], message: "is required for conversation templates" });
     }
   });
 
@@ -401,7 +476,6 @@ const manifestSchema = z.object({
     methodIds.add(method.id);
   });
 
-  const permissionIds: Set<string> = new Set(manifest.permissions?.map((permission) => permission.id) ?? []);
   const methodsById = new Map(manifest.authorization?.methods.map((method) => [method.id, method]) ?? []);
   Object.entries(manifest.localization?.translations ?? {}).forEach(([locale, translation]) => {
     Object.keys(translation.resources ?? {}).forEach((resourceId) => {
@@ -490,6 +564,20 @@ export type PluginReloadReason = z.infer<typeof reloadReasonSchema>;
 export type PluginSourceFormat = z.infer<typeof sourceFormatSchema>;
 export type PluginSource = PluginManifest["source"];
 export type PluginResource = PluginManifest["resources"][number];
+export type PluginUiResource = PluginResource & {
+  type: "ui";
+  path: string;
+  ui: z.infer<typeof uiResourceMetadataSchema>;
+};
+export type PluginUiHostContextV1 = {
+  schemaVersion: 1;
+  pluginId: string;
+  resourceId: string;
+  surface: "workspace" | "settings";
+  workspaceId: string;
+  workspaceRoot: string;
+  sessionId: string | null;
+};
 export type PluginResourceType = PluginResource["type"];
 export type PluginContribution = NonNullable<PluginManifest["contributions"]>[number];
 export type PluginContributionType = PluginContribution["type"];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,12 @@ importers:
       '@lexical/react':
         specifier: ^0.35.0
         version: 0.35.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(yjs@13.6.30)
+      '@modelcontextprotocol/ext-apps':
+        specifier: 1.7.5
+        version: 1.7.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.4.3)
       '@opencode-ai/sdk':
         specifier: ^1.18.16
         version: 1.18.16
@@ -1885,6 +1891,20 @@ packages:
 
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@modelcontextprotocol/ext-apps@1.7.5':
+    resolution: {integrity: sha512-TjPH2S2y5UEGKhmI6+XGFuqfqOV4ppe1x6DA3txnUaEWkgtA4G5vo14jGKFZmegdkZ1H4QMLyujLvoU1BEdnAg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.29.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -8260,6 +8280,15 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@modelcontextprotocol/ext-apps@1.7.5(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.12)
@@ -8279,6 +8308,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.12)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.12
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -13089,6 +13140,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

- extend the unified plugin manifest with standard MCP App UI resources and contributions for the right workspace, Settings, and conversation templates
- host plugin UI in a script-only sandbox using the official MCP Apps bridge, including model context, messaging, display modes, and app tool calls
- expose active Workspace App tools to the agent through `workspace_app.list_tools` and `workspace_app.call_tool`
- serve enabled UI resources from immutable installed plugin artifacts and keep install, update, rollback, disable, and uninstall behavior unified
- document the contract and add a complete Workspace Canvas example

## User impact

Existing users and plugins keep the same behavior. A plugin can now add a full right-side workspace, a Settings page, and conversation templates without modifying the core application. This PR does not migrate the built-in Design or Video experiences.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @ipollowork/types build`
- `pnpm --filter @ipollowork/app typecheck`
- `pnpm --filter ipollowork-server typecheck`
- `bun test apps/app/tests/plugin-ui-contributions.test.ts apps/server/src/plugin-package-lifecycle.test.ts apps/server/src/plugin-package-manifest.test.ts` (43 passed, 0 failed)
- `pnpm --filter @ipollowork/app build`
- `git diff --check`
- maintainability audit: 0 errors
- Electron app smoke fraimz: passed
- Workspace App fraimz: passed all four frames (conversation template, right-side app, agent tool bridge, Settings page)
