### PR TITLE
Fix translated README WeChat QR links

### DIFF
--- a/docs/translations/README_JA.md
+++ b/docs/translations/README_JA.md
@@ -28,7 +28,7 @@ Codex のようなコーディングは出発点にすぎません。成果物�
 <div align="center">
   <h3>iPolloWork 公式 WeChat コミュニティに参加</h3>
   <p>WeChat で下の QR コードをスキャンすると、製品情報やコミュニティでの交流を目的とした公式グループに参加できます。</p>
-  <img src="../docs/assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 公式 WeChat コミュニティの QR コード" width="220" />
+  <img src="../assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 公式 WeChat コミュニティの QR コード" width="220" />
 </div>
 
 ## iPolloWork の違い

--- a/docs/translations/README_ZH.md
+++ b/docs/translations/README_ZH.md
@@ -28,7 +28,7 @@ Codex 式编码只是起点。当结果变成演示稿、网页、视觉设计�
 <div align="center">
   <h3>加入 iPolloWork 官方微信群</h3>
   <p>使用微信扫描下方二维码，加入官方社区，获取产品动态并交流使用经验。</p>
-  <img src="../docs/assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 官方微信群二维码" width="220" />
+  <img src="../assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 官方微信群二维码" width="220" />
 </div>
 
 ## 它真正解决的三件事

--- a/docs/translations/README_ZH_hk.md
+++ b/docs/translations/README_ZH_hk.md
@@ -30,7 +30,7 @@ Codex 式編碼只是起點。當結果變成演示稿、網頁、視覺設計�
 <div align="center">
   <h3>加入 iPolloWork 官方微信羣</h3>
   <p>使用微信掃描下方二維碼，加入官方社區，獲取產品動態並交流使用經驗。</p>
-  <img src="../docs/assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 官方微信羣二維碼" width="220" />
+  <img src="../assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 官方微信羣二維碼" width="220" />
 </div>
 
 ## 它真正解決的三件事


### PR DESCRIPTION
## Summary
- Fix WeChat QR image paths in translated README files under docs/translations
- Change ../docs/assets/... to ../assets/... so GitHub resolves them to docs/assets instead of docs/docs/assets

## Verification
- Ran a PowerShell link-resolution check for docs/translations/README_*.md and confirmed each WeChat QR image resolves to docs/assets/ipollowork-official-wechat-group.jpg
- Ran rg for ../docs/assets/ipollowork-official-wechat-group.jpg and docs/docs/assets/ipollowork-official-wechat-group.jpg under README/docs translations; no matches remained