### PR TITLE
Unify iPollo Design and Video plugin skills

### DIFF
--- a/apps/server/src/plugin-package-lifecycle.test.ts
+++ b/apps/server/src/plugin-package-lifecycle.test.ts
@@ -1083,8 +1083,8 @@ describe("plugin package lifecycle", () => {
           { pluginId: "context7", version: "1.0.2", installedVersion: null, updateAvailable: false },
           { pluginId: "github", version: "0.1.2", installedVersion: null, updateAvailable: false },
           { pluginId: "wechat-official", version: "0.1.2", installedVersion: null, updateAvailable: false },
-          { pluginId: "design-agent", version: "0.2.0", installedVersion: "0.2.0", updateAvailable: false },
-          { pluginId: "video-agent", version: "0.2.0", installedVersion: "0.2.0", updateAvailable: false },
+          { pluginId: "design-agent", version: "0.3.0", installedVersion: "0.3.0", updateAvailable: false },
+          { pluginId: "video-agent", version: "0.3.0", installedVersion: "0.3.0", updateAvailable: false },
           { pluginId: "deepseek-harness", version: "0.3.5", installedVersion: null, updateAvailable: false },
         ],
       });
@@ -1253,20 +1253,18 @@ describe("plugin package lifecycle", () => {
     }
   });
 
-  test("installs and removes creative workspace packages without touching projects or related global skills", async () => {
+  test("installs, toggles, removes, and restores complete creative workspace packages", async () => {
     const workspaceRoot = await createRoot("ipollowork-creative-agent-catalog-api-");
     process.env.IPOLLOWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
     const designDirectory = join(workspaceRoot, "design", "existing-session");
     const videoDirectory = join(workspaceRoot, "video", "existing-session");
     const designEntry = join(designDirectory, "entry.html");
     const videoEntry = join(videoDirectory, "index.html");
-    const relatedSkill = join(workspaceRoot, ".opencode", "skills", "hyperframes-cli", "SKILL.md");
+    const videoSupportSkill = join(workspaceRoot, ".opencode", "skills", "hyperframes-cli", "SKILL.md");
     await mkdir(designDirectory, { recursive: true });
     await mkdir(videoDirectory, { recursive: true });
-    await mkdir(dirname(relatedSkill), { recursive: true });
     await writeFile(designEntry, "<main>Existing design</main>\n", "utf8");
     await writeFile(videoEntry, "<div data-composition>Existing video</div>\n", "utf8");
-    await writeFile(relatedSkill, "# Existing HyperFrames CLI\n", "utf8");
 
     const config = serverConfig(workspaceRoot);
     const server = await startServer(config);
@@ -1275,13 +1273,13 @@ describe("plugin package lifecycle", () => {
     const packages = [
       {
         pluginId: "design-agent",
-        version: "0.2.0",
+        version: "0.3.0",
         skillPath: join(workspaceRoot, ".opencode", "skills", "ipollowork-design-studio", "SKILL.md"),
         heading: "# iPolloWork Design Studio",
       },
       {
         pluginId: "video-agent",
-        version: "0.2.0",
+        version: "0.3.0",
         skillPath: join(workspaceRoot, ".opencode", "skills", "ipollowork-video-studio", "SKILL.md"),
         heading: "# iPolloWork Video Studio",
       },
@@ -1300,6 +1298,7 @@ describe("plugin package lifecycle", () => {
       for (const item of packages) {
         expect(await readFile(item.skillPath, "utf8")).toContain(item.heading);
       }
+      expect(await readFile(videoSupportSkill, "utf8")).toContain("# HyperFrames CLI");
 
       const disabled = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/design-agent/resources/ipollowork-design-studio`, {
         method: "PATCH",
@@ -1317,6 +1316,22 @@ describe("plugin package lifecycle", () => {
       expect(enabled.status).toBe(200);
       expect(await readFile(packages[0].skillPath, "utf8")).toContain(packages[0].heading);
 
+      const videoSkillDisabled = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/video-agent/resources/hyperframes-cli`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ enabled: false }),
+      });
+      expect(videoSkillDisabled.status).toBe(200);
+      await expectMissing(videoSupportSkill);
+
+      const videoSkillEnabled = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/video-agent/resources/hyperframes-cli`, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(videoSkillEnabled.status).toBe(200);
+      expect(await readFile(videoSupportSkill, "utf8")).toContain("# HyperFrames CLI");
+
       for (const item of packages) {
         const removal = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages/${item.pluginId}`, {
           method: "DELETE",
@@ -1325,6 +1340,7 @@ describe("plugin package lifecycle", () => {
         expect(removal.status).toBe(200);
         await expectMissing(item.skillPath);
       }
+      await expectMissing(videoSupportSkill);
 
       const afterRemoval = await fetch(`${base}/workspace/${WORKSPACE_ID}/plugin-packages`, { headers });
       expect(afterRemoval.status).toBe(200);
@@ -1342,10 +1358,10 @@ describe("plugin package lifecycle", () => {
         });
         expect(await readFile(item.skillPath, "utf8")).toContain(item.heading);
       }
+      expect(await readFile(videoSupportSkill, "utf8")).toContain("# HyperFrames CLI");
 
       expect(await readFile(designEntry, "utf8")).toBe("<main>Existing design</main>\n");
       expect(await readFile(videoEntry, "utf8")).toBe("<div data-composition>Existing video</div>\n");
-      expect(await readFile(relatedSkill, "utf8")).toBe("# Existing HyperFrames CLI\n");
     } finally {
       await server.stop();
     }

--- a/apps/server/src/plugin-package-manifest.test.ts
+++ b/apps/server/src/plugin-package-manifest.test.ts
@@ -238,7 +238,7 @@ describe("plugin package manifest", () => {
     }]);
   });
 
-  test("accepts the official Design and Video workspace packages without owning related global skills", async () => {
+  test("accepts the official Design and Video workspace packages with managed skills", async () => {
     const { validatePluginPackageManifest } = await import("./plugin-package-manifest.js");
     const designManifest = await Bun.file(new URL("../../../examples/plugin-packages/design-agent/ipollowork.plugin.json", import.meta.url)).json();
     const videoManifest = await Bun.file(new URL("../../../examples/plugin-packages/video-agent/ipollowork.plugin.json", import.meta.url)).json();
@@ -250,11 +250,23 @@ describe("plugin package manifest", () => {
     if (!design.success) throw new Error(JSON.stringify(design.issues));
     expect(video.success).toBe(true);
     if (!video.success) throw new Error(JSON.stringify(video.issues));
+    expect(design.manifest.name).toBe("iPollo Design");
+    expect(video.manifest.name).toBe("iPollo Video");
     expect(design.manifest.resources.map((resource) => resource.type)).toEqual(["skill", "skill"]);
-    expect(video.manifest.resources.map((resource) => resource.type)).toEqual(["skill", "skill"]);
-    expect(video.manifest.relatedSkills).toContain("hyperframes-cli");
-    expect(video.manifest.relatedSkills).toContain("media-use");
-    expect(video.manifest.resources.map((resource) => resource.id)).not.toContain("hyperframes-cli");
+    expect(video.manifest.resources).toHaveLength(11);
+    expect(video.manifest.resources.every((resource) => resource.type === "skill")).toBe(true);
+    expect(video.manifest.relatedSkills).toBeUndefined();
+    expect(video.manifest.resources.map((resource) => resource.id)).toEqual(expect.arrayContaining([
+      "hyperframes",
+      "hyperframes-animation",
+      "hyperframes-cli",
+      "hyperframes-core",
+      "hyperframes-creative",
+      "hyperframes-keyframes",
+      "hyperframes-registry",
+      "media-use",
+      "product-launch-video",
+    ]));
     expect(design.manifest.defaultEnabled).toBe(true);
     expect(video.manifest.defaultEnabled).toBe(true);
     expect(design.manifest.contributions).toMatchObject([{

--- a/examples/plugin-packages/design-agent/ipollowork.plugin.json
+++ b/examples/plugin-packages/design-agent/ipollowork.plugin.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
   "id": "design-agent",
-  "name": "iPolloWork Design Agent",
-  "description": "提供 iPolloWork Design Studio、演示文稿工作台与配套 Agent Skills。",
+  "name": "iPollo Design",
+  "description": "提供 iPollo Design、演示文稿工作台与配套 Agent Skills。",
   "category": "AI Agent 与自动化",
   "defaultEnabled": true,
   "source": {
@@ -15,15 +15,15 @@
     "src": "ipollowork-mark.svg"
   },
   "composer": {
-    "prompt": "使用 iPolloWork Design Agent 在当前会话的设计项目中创建或编辑内容。"
+    "prompt": "使用 iPollo Design 在当前会话的设计项目中创建或编辑内容。"
   },
   "localization": {
     "defaultLocale": "zh",
     "translations": {
       "en": {
-        "description": "iPolloWork Design Studio, presentation workspace, and official Agent Skills.",
+        "description": "iPollo Design workspace, presentation workspace, and official Agent Skills.",
         "category": "AI Agents & Automation",
-        "composer": { "prompt": "Use iPolloWork Design Agent to create or edit content in the current session's design project." },
+        "composer": { "prompt": "Use iPollo Design to create or edit content in the current session's design project." },
         "resources": {
           "ipollowork-design-studio": { "description": "Safely create and edit HTML designs in the current iPolloWork Design session." },
           "ipollowork-presentations": {
@@ -39,7 +39,7 @@
     }
   },
   "package": {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "publisher": {
       "id": "ipollowork",
       "name": "iPolloWork"

--- a/examples/plugin-packages/video-agent/ipollowork.plugin.json
+++ b/examples/plugin-packages/video-agent/ipollowork.plugin.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 2,
   "id": "video-agent",
-  "name": "iPolloWork Video Agent",
-  "description": "提供 iPolloWork Video Studio、HyperFrames、旁白工作流与配套 Agent Skills。",
+  "name": "iPollo Video",
+  "description": "提供 iPollo Video、HyperFrames、旁白工作流与配套 Agent Skills。",
   "category": "AI Agent 与自动化",
   "defaultEnabled": true,
   "source": {
@@ -15,21 +15,30 @@
     "src": "ipollowork-mark.svg"
   },
   "composer": {
-    "prompt": "使用 iPolloWork Video Agent 在当前会话的 Video Studio 项目中创建或编辑视频。"
+    "prompt": "使用 iPollo Video 在当前会话的视频项目中创建或编辑视频。"
   },
   "localization": {
     "defaultLocale": "zh",
     "translations": {
       "en": {
-        "description": "iPolloWork Video Studio, HyperFrames, voiceover workflows, and official Agent Skills.",
+        "description": "iPollo Video, HyperFrames, voiceover workflows, and official Agent Skills.",
         "category": "AI Agents & Automation",
-        "composer": { "prompt": "Use iPolloWork Video Agent to create or edit video in the current session's Video Studio project." },
+        "composer": { "prompt": "Use iPollo Video to create or edit video in the current session's video project." },
         "resources": {
           "ipollowork-video-studio": { "description": "Safely create and edit HyperFrames video in the current iPolloWork Video Studio session." },
           "ipollowork-video-voiceover": {
             "label": "Video Voiceover",
             "description": "Generate and verify scene-by-scene voiceover using the current Video Studio media capabilities."
-          }
+          },
+          "hyperframes": { "label": "HyperFrames", "description": "Route video creation, editing, validation, preview, and rendering through HyperFrames." },
+          "hyperframes-animation": { "label": "HyperFrames Animation", "description": "Create deterministic HyperFrames animation, transitions, and motion choreography." },
+          "hyperframes-cli": { "label": "HyperFrames CLI", "description": "Use the HyperFrames CLI to inspect, validate, preview, render, and publish video projects." },
+          "hyperframes-core": { "label": "HyperFrames Core", "description": "Apply the core HyperFrames composition, timing, media, and determinism contract." },
+          "hyperframes-creative": { "label": "HyperFrames Creative", "description": "Plan visual direction, typography, pacing, audio, and composition for HyperFrames video." },
+          "hyperframes-keyframes": { "label": "HyperFrames Keyframes", "description": "Build and verify seek-safe keyframe animation for HyperFrames projects." },
+          "hyperframes-registry": { "label": "HyperFrames Registry", "description": "Discover, install, and wire reusable HyperFrames blocks and components." },
+          "media-use": { "label": "Media", "description": "Resolve, generate, process, and reuse media assets for video projects." },
+          "product-launch-video": { "label": "Product Launch Video", "description": "Create product launch and promotional videos from product sources and briefs." }
         },
         "permissions": {
           "workspace-read": { "reason": "Read the current session's HyperFrames project, timeline, media, and voiceover settings." },
@@ -40,7 +49,7 @@
     }
   },
   "package": {
-    "version": "0.2.0",
+    "version": "0.3.0",
     "publisher": {
       "id": "ipollowork",
       "name": "iPolloWork"
@@ -73,17 +82,6 @@
       "location": "session-right-pane"
     }
   ],
-  "relatedSkills": [
-    "hyperframes",
-    "hyperframes-animation",
-    "hyperframes-cli",
-    "hyperframes-core",
-    "hyperframes-creative",
-    "hyperframes-keyframes",
-    "hyperframes-registry",
-    "media-use",
-    "product-launch-video"
-  ],
   "resources": [
     {
       "type": "skill",
@@ -105,6 +103,87 @@
       "provides": [
         "workflow:ipollowork-video-voiceover"
       ],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes",
+      "label": "HyperFrames",
+      "description": "统一调度 HyperFrames 视频创建、编辑、检查、预览与渲染。",
+      "path": "skills/hyperframes/SKILL.md",
+      "provides": ["workflow:hyperframes"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes-animation",
+      "label": "HyperFrames 动画",
+      "description": "创建确定性的 HyperFrames 动画、转场和动效编排。",
+      "path": "skills/hyperframes-animation/SKILL.md",
+      "provides": ["workflow:hyperframes-animation"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes-cli",
+      "label": "HyperFrames CLI",
+      "description": "检查、校验、预览、渲染和发布 HyperFrames 视频项目。",
+      "path": "skills/hyperframes-cli/SKILL.md",
+      "provides": ["workflow:hyperframes-cli"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes-core",
+      "label": "HyperFrames 核心",
+      "description": "应用 HyperFrames 的组合、时间、媒体和确定性核心规范。",
+      "path": "skills/hyperframes-core/SKILL.md",
+      "provides": ["workflow:hyperframes-core"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes-creative",
+      "label": "HyperFrames 创作",
+      "description": "规划视频的视觉方向、排版、节奏、音频和构图。",
+      "path": "skills/hyperframes-creative/SKILL.md",
+      "provides": ["workflow:hyperframes-creative"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes-keyframes",
+      "label": "HyperFrames 关键帧",
+      "description": "创建并校验可安全定位的 HyperFrames 关键帧动画。",
+      "path": "skills/hyperframes-keyframes/SKILL.md",
+      "provides": ["workflow:hyperframes-keyframes"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "hyperframes-registry",
+      "label": "HyperFrames 组件库",
+      "description": "发现、安装并接入可复用的 HyperFrames 区块和组件。",
+      "path": "skills/hyperframes-registry/SKILL.md",
+      "provides": ["workflow:hyperframes-registry"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "media-use",
+      "label": "媒体能力",
+      "description": "为视频项目查找、生成、处理并复用媒体素材。",
+      "path": "skills/media-use/SKILL.md",
+      "provides": ["workflow:media-use"],
+      "required": true
+    },
+    {
+      "type": "skill",
+      "id": "product-launch-video",
+      "label": "产品发布视频",
+      "description": "根据产品资料和需求制作产品发布与宣传视频。",
+      "path": "skills/product-launch-video/SKILL.md",
+      "provides": ["workflow:product-launch-video"],
       "required": true
     }
   ]

--- a/examples/plugin-packages/video-agent/skills/hyperframes-animation/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes-animation/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes-animation
+description: Create deterministic animation and transitions for the active iPollo Video project.
+---
+
+# HyperFrames Animation
+
+Use this Skill when the current iPollo Video project needs motion, transitions, or animated emphasis.
+
+1. Follow the active scene timing and visual system.
+2. Keep animation deterministic and derived from the project timeline.
+3. Prefer transform and opacity animation; avoid layout thrashing and uncontrolled timers.
+4. Ensure every frame is correct when seeking directly, not only during linear playback.
+5. Run the session's HyperFrames validation after editing.

--- a/examples/plugin-packages/video-agent/skills/hyperframes-cli/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes-cli/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes-cli
+description: Inspect, validate, preview, and render the active iPollo Video project with its bundled HyperFrames CLI.
+---
+
+# HyperFrames CLI
+
+Use only the CLI command and project path supplied by the active iPollo Video session.
+
+1. Inspect the exact project before changing it.
+2. Use bounded validation, preview, or render commands appropriate to the request.
+3. Do not install global packages, upgrade dependencies, or start an extra persistent server.
+4. Treat command failures as actionable diagnostics and fix the project rather than bypassing checks.
+5. Report the command that verified the final result.

--- a/examples/plugin-packages/video-agent/skills/hyperframes-core/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes-core/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes-core
+description: Apply the core composition, timing, media, and determinism contract used by iPollo Video.
+---
+
+# HyperFrames Core
+
+Use this Skill whenever editing the structure of an active iPollo Video project.
+
+1. Keep one authoritative composition and timeline.
+2. Maintain consistent scene, clip, transition, caption, animation, and audio timing.
+3. Use project-relative media references and preserve existing assets unless replacement is requested.
+4. Keep rendering deterministic for any requested timestamp.
+5. Preserve the session contract and validate before completion.

--- a/examples/plugin-packages/video-agent/skills/hyperframes-creative/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes-creative/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes-creative
+description: Plan visual direction, typography, pacing, audio, and composition for iPollo Video projects.
+---
+
+# HyperFrames Creative
+
+Use this Skill for creative direction inside the current iPollo Video session.
+
+1. Derive the visual system from the confirmed brief and existing project.
+2. Keep typography, spacing, color, composition, and motion coherent across scenes.
+3. Prefer a small number of deliberate visual ideas over generic decorative effects.
+4. Coordinate pacing with narration, music, captions, and transitions.
+5. Apply creative changes through the active project rather than replacing its structure.

--- a/examples/plugin-packages/video-agent/skills/hyperframes-keyframes/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes-keyframes/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes-keyframes
+description: Build seek-safe keyframe animation for the active iPollo Video timeline.
+---
+
+# HyperFrames Keyframes
+
+Use this Skill for timeline-controlled keyframe animation.
+
+1. Express animation from explicit timeline time or progress.
+2. Define stable values before, during, and after each animated interval.
+3. Avoid state that depends on prior frame execution.
+4. Keep easing and overlap intentional and compatible with scene duration.
+5. Verify direct seeking at key boundaries and the final frame.

--- a/examples/plugin-packages/video-agent/skills/hyperframes-registry/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes-registry/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes-registry
+description: Reuse approved HyperFrames blocks and components inside the active iPollo Video project.
+---
+
+# HyperFrames Registry
+
+Use this Skill when a reusable block or component fits the current video brief.
+
+1. Prefer components already available through the bundled HyperFrames runtime.
+2. Add only the minimum component files required by the active project.
+3. Adapt tokens, timing, and content to the project's visual system.
+4. Do not install global Skills or modify unrelated projects.
+5. Validate the integrated component in the exact session project.

--- a/examples/plugin-packages/video-agent/skills/hyperframes/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/hyperframes/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: hyperframes
+description: Route video creation and editing through the active iPollo Video project and its built-in HyperFrames runtime.
+---
+
+# HyperFrames
+
+Use this Skill for end-to-end video work inside an active iPollo Video session.
+
+1. Read the session-provided project path and brief before editing.
+2. Work only in that project; never create a parallel preview server or global Skill install.
+3. Reuse the built-in HyperFrames runtime, timeline, media services, and validation commands exposed by the session.
+4. Preserve duration, scene order, transitions, captions, audio, and seek-safe playback.
+5. Validate the exact project before reporting completion.

--- a/examples/plugin-packages/video-agent/skills/media-use/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/media-use/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: media-use
+description: Find, generate, process, and reuse media through the active iPollo Video session's media services.
+---
+
+# Media
+
+Use this Skill when the current video needs images, footage, audio, narration, captions, or media treatment.
+
+1. Use the media providers and credentials exposed by the active session.
+2. Reuse suitable project assets before generating replacements.
+3. Store results in the session project and reference them with project-relative paths.
+4. Preserve attribution and source metadata where required.
+5. Verify format, duration, dimensions, and timeline placement before completion.

--- a/examples/plugin-packages/video-agent/skills/product-launch-video/SKILL.md
+++ b/examples/plugin-packages/video-agent/skills/product-launch-video/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: product-launch-video
+description: Create product launch and promotional videos through the active iPollo Video workflow.
+---
+
+# Product Launch Video
+
+Use this Skill when the user requests a product launch, feature announcement, or promotional video.
+
+1. Confirm the audience, message, source material, duration, format, and call to action.
+2. Build a concise story from hook to problem, product value, proof, and closing action.
+3. Implement the story in the active iPollo Video project using its existing visual system and media services.
+4. Keep claims grounded in supplied product material.
+5. Validate timing, captions, audio, transitions, and final playback before reporting completion.


### PR DESCRIPTION
## Summary
- rename the built-in creative plugins to `iPollo Design` and `iPollo Video`
- move the nine related Video Skills into the plugin-owned lifecycle as lightweight, self-contained Skill entries
- support per-Skill enable/disable plus plugin install, uninstall, and reinstall without relying on global Skill metadata
- keep existing Design and Video project files untouched by plugin lifecycle operations

## Validation
- `bun test apps/server/src/plugin-package-manifest.test.ts apps/server/src/plugin-package-lifecycle.test.ts`
- `pnpm --dir apps/server typecheck`
- `git diff origin/main --check`
- maintainability audit: no errors

## Scope
- 13 files changed
- 271 insertions, 38 deletions
- no sidebar, project, marketplace UI, or copied global Skill asset library changes
