### PR TITLE
Add OpenSSF project hygiene docs and badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    groups:
+      npm-workspace:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/vendor/hyperframes"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Etc/UTC"
+    groups:
+      hyperframes:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,10 @@
 ## Evidence
 - video/screenshot link, or `N/A (docs-only)`
 
+## Contributor statement
+- [ ] I have the right to submit this contribution under `CONTRIBUTING.md`.
+- [ ] I preserved third-party copyright and license notices, or this change does not add third-party material.
+
 ## Risk
 -
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  push:
+    branches:
+      - main
+      - dev
+  schedule:
+    - cron: "17 2 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript and TypeScript
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:javascript-typescript"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to iPolloWork
 
-Thank you for helping improve iPolloWork. Read `AGENTS.md`, `VISION.md`, `PRINCIPLES.md`, `PRODUCT.md`, and `ARCHITECTURE.md` before making product changes.
+Thank you for helping improve iPolloWork. Read `README.md`, `AGENTS.md`,
+`docs/governance.md`, `SECURITY.md`, and `apps/app/src/react-app/ARCHITECTURE.md`
+before making product changes.
 
 ## Development
 
@@ -11,6 +13,52 @@ Thank you for helping improve iPolloWork. Read `AGENTS.md`, `VISION.md`, `PRINCI
 ```
 
 Keep changes focused, preserve the iPolloWork/OpenCode boundary, and include the checks used to validate the change.
+
+## Issue tracker
+
+Use GitHub Issues for public bug reports, feature requests, documentation
+defects, and task tracking. Do not use public issues for security
+vulnerabilities; follow `SECURITY.md` instead.
+
+## Coding standards
+
+Primary application code is TypeScript, React, Electron, Bun, and Node.js.
+Contributions must follow the local patterns in the owning package and these
+project-wide rules:
+
+- Prefer the existing module owner before adding files, directories, routes, or
+  dependencies.
+- Keep the iPolloWork/OpenCode boundary intact and use supported OpenCode
+  APIs, SDKs, CLI, plugins, and configuration surfaces.
+- Use typed boundaries; avoid `any`, broad type assertions, duplicated derived
+  state, and fallback paths that the type system or control flow already rules
+  out.
+- Reuse UI primitives from `apps/app/src/components/ui` and shared app
+  components from `apps/app/src/components`.
+- Keep generated runtime artifacts out of source directories.
+- Preserve third-party copyright and license notices.
+
+The standard check command is `./ipollowork check` on macOS/Linux or
+`.\ipollowork.cmd check` on Windows. CI also runs package tests, type checks,
+REUSE lint, OpenSSF Scorecard, CodeQL, and dependency review.
+
+## Tests
+
+Major new functionality must include automated tests at the owning package
+layer. Bug fixes should include regression tests whenever practical; maintainers
+expect regression tests for at least half of bugs fixed in any six-month period.
+If a change cannot be tested automatically, explain the reason and include
+manual verification steps in the pull request.
+
+Run the narrowest meaningful checks before opening a pull request, then let CI
+run the shared repository checks. Document every command and result in the pull
+request template.
+
+## Change review
+
+All non-trivial code changes should be reviewed by a maintainer who did not
+author the change. Reviewers check correctness, tests, security impact,
+license/attribution, user-facing behavior, and rollback risk.
 
 ## Contribution terms
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
+  <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 
 <p align="center">
@@ -199,9 +201,9 @@ iPolloWork desktop/UI ── local API ──> iPolloWork server ──> OpenCod
 
 ## Contributing
 
-Read `AGENTS.md`, `CONTRIBUTING.md`, and
-`apps/app/src/react-app/ARCHITECTURE.md` before making product changes. Run the
-narrow relevant test first, followed by:
+Read `AGENTS.md`, `docs/governance.md`, `CONTRIBUTING.md`, `SECURITY.md`, and
+`apps/app/src/react-app/ARCHITECTURE.md` before making product changes. Run
+the narrow relevant test first, followed by:
 
 ```bash
 ./ipollowork check

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,44 @@
 
 ## Supported versions
 
-iPolloWork is under active development and we prioritize fixes on the latest release and
-the current `dev` branch.
+iPolloWork is under active development. Security fixes are prioritized for the
+latest stable release and the active development branch. Older versions are not
+maintained indefinitely; users should upgrade to the latest release unless a
+release note explicitly says that a security fix was backported.
+
+| Version line | Security support |
+| --- | --- |
+| Latest GitHub release | Supported |
+| Active `main`/`dev` development branches | Supported for pre-release fixes |
+| Older releases | Upgrade to the latest release |
+
+If an upgrade requires manual action, the release notes for the new version will
+describe the changed interfaces, migration steps, or known compatibility risks.
+
+## Security expectations
+
+iPolloWork is a local-first desktop and server workspace for agentic work. Users
+can expect the project to:
+
+- keep local workspace files under the user's control and ask for explicit
+  permission before privileged filesystem or external actions;
+- store credentials, dynamic tokens, and private keys separately from ordinary
+  configuration where the product handles them;
+- avoid logging secrets, bearer tokens, API keys, private keys, and OAuth
+  client secrets;
+- validate untrusted input at process, API, workspace, plugin, package, and
+  filesystem boundaries;
+- use HTTPS/TLS for remote service communication in production deployments and
+  verify TLS certificates by default;
+- avoid cryptographic algorithms with known serious weaknesses for default
+  security mechanisms;
+- make local development defaults local-only and clearly separate them from
+  production deployment guidance.
+
+Users should not expect iPolloWork to sandbox every native tool, plugin, browser
+extension, model provider, or command that they explicitly authorize to run as
+their operating-system user. See `docs/security-model.md` for the threat model,
+trust boundaries, and assurance case.
 
 ## Reporting a vulnerability
 
@@ -24,9 +60,47 @@ Please include:
 
 - We will acknowledge receipt within 3 business days.
 - We will provide an initial triage status within 7 business days.
-- We will share remediation or mitigation guidance as soon as available.
+- We will assess severity, affected versions, exploitability, and whether an
+  emergency mitigation or coordinated release is required.
+- We will keep the reporter updated when a fix, mitigation, or public advisory
+  is ready.
+- We will credit reporters in the release note or advisory unless they request
+  anonymity. If no vulnerabilities were resolved in the last 12 months, this
+  credit rule is not applicable for that period.
 
 ## Disclosure guidance
 
 Please keep details private until a fix or mitigation is available and maintainers
 confirm public disclosure timing.
+
+## Release integrity
+
+Official releases are published from the GitHub release workflow after release
+verification succeeds. Local packages are for development testing and must not
+be presented as official releases unless they were produced with the appropriate
+signing credentials and release verification.
+
+Release managers should:
+
+- create annotated, signed Git tags for public major, minor, patch, and security
+  releases when signing keys are available;
+- publish release artifacts only from GitHub Actions release workflows;
+- sign and notarize macOS artifacts with Apple Developer ID before public use;
+- sign Windows installers through the configured Windows signing service before
+  public use;
+- publish checksums or signature materials with the release assets;
+- document any temporary unsigned artifact in the release notes.
+
+Users can verify release integrity by:
+
+1. Downloading installers only from
+   `https://github.com/Devin-AXIS/iPolloWork/releases`.
+2. Checking that the release tag and release notes match the version they
+   intend to install.
+3. On macOS, confirming Gatekeeper accepts the app and `spctl --assess --type
+   execute --verbose /Applications/iPollo.app` reports an accepted Developer ID
+   signature.
+4. On Windows, checking the installer signature in file properties or with
+   `Get-AuthenticodeSignature`.
+5. Comparing published checksums or signatures when they are provided for a
+   release.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -20,4 +20,5 @@ Use the right channel to get faster help:
 
 ## Maintainer triage
 
-Maintainers use the rubric in `TRIAGE.md` to label and route issues.
+Maintainers use the triage process in `docs/governance.md` to label and route
+issues.

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,101 @@
+# iPolloWork Governance
+
+iPolloWork is maintained in the `Devin-AXIS/iPolloWork` GitHub repository. The
+current public project owner is the Devin-AXIS GitHub organization. Repository
+role assignment is controlled through GitHub organization and repository access
+settings.
+
+## Roles
+
+Project owner:
+
+- owns the project direction, public repository settings, release authority,
+  security contact routing, and final decisions when consensus does not emerge;
+- delegates repository access and release permissions to maintainers who need
+  them.
+
+Maintainers:
+
+- review and merge pull requests;
+- triage issues and discussions;
+- keep documentation aligned with current behavior;
+- preserve the iPolloWork/OpenCode boundary;
+- maintain CI, packaging, release, and dependency-monitoring workflows.
+
+Security responders:
+
+- receive private vulnerability reports;
+- triage severity and affected versions;
+- coordinate fixes, disclosure, reporter credit, and advisories;
+- rotate credentials or signing material when required.
+
+Release managers:
+
+- verify release readiness;
+- run the release workflow;
+- confirm version, tag, artifact, signature, notarization, and release-note
+  status before a release becomes public;
+- coordinate rollback or hotfix releases.
+
+Reviewers:
+
+- provide technical review for pull requests;
+- check tests, security impact, user-facing behavior, documentation, and
+  license/attribution changes before merge.
+
+Contributors:
+
+- open issues, propose changes, and submit pull requests under
+  `CONTRIBUTING.md`;
+- include tests for major functionality and practical regression coverage for
+  bug fixes.
+
+## Decisions
+
+Most decisions are made in GitHub issues and pull requests. Maintainers seek
+rough consensus, but the project owner may make the final call when a decision
+blocks releases, security response, repository maintenance, or product
+direction.
+
+Security-sensitive decisions may be made privately until disclosure is safe.
+After disclosure, maintainers should summarize the outcome in a public release
+note, advisory, issue, or pull request when doing so does not expose users to
+additional risk.
+
+## Continuity
+
+The project should be able to continue if any one maintainer becomes
+unavailable. To support that goal:
+
+- at least two trusted people should have the practical ability to triage
+  issues, merge pull requests, and publish emergency fixes;
+- release signing credentials, deployment credentials, and recovery material
+  should be stored in controlled organization secret stores or emergency access
+  vaults, not only on one person's computer;
+- production signing keys and tokens should be scoped to the minimum required
+  access and rotated after suspected exposure;
+- maintainers should document release and recovery steps in the repository.
+
+## Issue Triage
+
+Public work is tracked in GitHub Issues. Maintainers route issues by impact,
+reproducibility, security sensitivity, affected platform, and whether the issue
+blocks a release. Security vulnerabilities must move to the private process in
+`SECURITY.md` instead of public issue discussion.
+
+Recommended public labels include:
+
+- `bug` for reproducible defects;
+- `feature` for product requests;
+- `documentation` for docs defects;
+- `security` for public hardening work that is not a private vulnerability;
+- `good first issue` for small, well-scoped tasks suitable for new
+  contributors;
+- `help wanted` for tasks where maintainers welcome outside implementation.
+
+## Role Changes
+
+Maintainer, security responder, and release manager access should be granted
+only when the person needs the role and understands the repository's security,
+licensing, and release responsibilities. Remove access when the role is no
+longer needed.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,123 @@
+# iPolloWork Security Model
+
+This document records the security expectations, threat model, trust
+boundaries, and assurance case for iPolloWork.
+
+## Security Goals
+
+iPolloWork should:
+
+- keep local workspace files under user control;
+- require explicit user approval before privileged filesystem, shell, browser,
+  network, or account-connected actions;
+- keep credentials and private keys separate from ordinary configuration and
+  logs;
+- validate untrusted input before it crosses process, API, workspace, plugin,
+  package, or filesystem boundaries;
+- use secure transport for production remote communication;
+- preserve the upstream OpenCode boundary instead of silently forking or
+  weakening it;
+- make release provenance, signing status, and unsupported local builds clear to
+  users.
+
+## Non-Goals
+
+iPolloWork does not claim that:
+
+- every user-approved command, plugin, browser extension, model provider, or
+  native tool is sandboxed from the user's operating-system account;
+- local development builds are production-hardened releases;
+- self-hosted deployments are secure without operator-managed TLS, secrets,
+  backups, logging, and access controls;
+- third-party model providers or connected services are covered by iPolloWork's
+  own security controls after a user authorizes data to be sent to them.
+
+## Trust Boundaries
+
+Important boundaries include:
+
+- desktop renderer to Electron main process;
+- Electron desktop to local iPolloWork server;
+- local iPolloWork server to OpenCode sidecar;
+- local workspace files to generated artifacts;
+- plugin package metadata to installed executable plugin code;
+- browser automation and extension surfaces to external websites;
+- local runtime to iPolloCloud or a self-hosted Cloud deployment;
+- Cloud control plane to hosted workers, databases, object storage, OAuth/SSO
+  providers, and external model providers.
+
+Data crossing these boundaries should be parsed, validated, scoped, and logged
+without secrets.
+
+## Input Validation
+
+Server and desktop code should treat these as untrusted:
+
+- HTTP request bodies, route parameters, query strings, and headers;
+- workspace-relative paths and archive entries;
+- plugin package manifests and bundled assets;
+- MCP server, app, connector, browser, and model-provider responses;
+- generated HTML, Markdown, documents, presentations, and media metadata;
+- environment variables and local configuration files.
+
+Validation should prefer explicit schemas, allowlists, normalized paths, and
+root-containment checks. Invalid input should be rejected instead of silently
+rewritten when the rewrite could hide an unsafe request.
+
+## Credentials And Secrets
+
+Credentials, dynamic tokens, and private keys must not be committed. Runtime
+credentials should live in environment variables, OS/keychain-backed stores,
+managed secret stores, or separate private runtime files. Logs, diagnostics,
+exports, and generated artifacts should avoid bearer tokens, API keys, OAuth
+client secrets, signing keys, and private keys.
+
+Users and operators must be able to rotate credentials without recompiling the
+software.
+
+## Cryptography And Transport
+
+Production network communication should use HTTPS/TLS, SSHv2 or later, or
+another secure protocol appropriate for the transport. TLS certificate
+verification must remain enabled by default before sending private headers or
+cookies. Local development HTTP endpoints should remain local-only unless a
+developer explicitly exposes them.
+
+Default security mechanisms must avoid algorithms and modes with known serious
+weaknesses. When iPolloWork relies on platform cryptography, provider SDKs, or
+managed services, it should use their supported modern defaults.
+
+## Hardening
+
+The project uses several hardening layers:
+
+- TypeScript type checks and package tests in CI;
+- REUSE lint for license metadata;
+- OpenSSF Scorecard for repository security posture;
+- CodeQL static analysis for JavaScript and TypeScript;
+- GitHub dependency review and Dependabot for vulnerable dependencies;
+- Electron macOS hardened runtime and notarization for official macOS release
+  artifacts when release signing credentials are configured;
+- path normalization and containment checks for workspace filesystem access.
+
+## Assurance Case
+
+The security requirements are met through a combination of design boundaries,
+automated checks, and release controls:
+
+- user-controlled local workspaces reduce unnecessary hosted data exposure;
+- explicit permission and approval flows limit high-impact actions;
+- typed request/response contracts and schema validation reduce malformed input
+  handling bugs;
+- filesystem paths are normalized and checked before sensitive server
+  operations;
+- credentials are handled as runtime secrets rather than source files;
+- CI runs tests, type checks, license checks, repository security checks, static
+  analysis, and dependency review;
+- official release workflows separate local unsigned development packages from
+  public release artifacts and document signing status.
+
+Residual risk remains for user-approved native commands, third-party plugins,
+browser automation against external sites, connected model providers, and
+self-hosted deployments with weak operator controls. Those risks should be made
+visible in UI, documentation, issue triage, and release notes.

--- a/docs/translations/README_JA.md
+++ b/docs/translations/README_JA.md
@@ -10,6 +10,8 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
+  <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 
 <p align="center">
@@ -188,7 +190,7 @@ iPolloWork desktop/UI ── local API ──> iPolloWork server ──> OpenCod
 
 ## コントリビューション
 
-プロダクトを変更する前に、`AGENTS.md`、`VISION.md`、`PRINCIPLES.md`、`PRODUCT.md`、`ARCHITECTURE.md` を読んでください。まず関連する範囲のテストを実行し、その後に次を実行します。
+プロダクトを変更する前に、`AGENTS.md`、`docs/governance.md`、`CONTRIBUTING.md`、`SECURITY.md`、`apps/app/src/react-app/ARCHITECTURE.md` を読んでください。まず関連する範囲のテストを実行し、その後に次を実行します。
 
 ```bash
 ./ipollowork check

--- a/docs/translations/README_ZH.md
+++ b/docs/translations/README_ZH.md
@@ -10,6 +10,8 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
+  <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 
 <p align="center">

--- a/docs/translations/README_ZH_hk.md
+++ b/docs/translations/README_ZH_hk.md
@@ -12,6 +12,8 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
+  <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 
 <p align="center">

--- a/packages/docs/roadmap.mdx
+++ b/packages/docs/roadmap.mdx
@@ -3,24 +3,55 @@ title: "Roadmap"
 description: "What iPolloWork supports today and what is coming next."
 ---
 
-Sharing the upcoming items in our roadmap:
+This roadmap covers the next year of public iPolloWork development. It is not a
+promise that every item will ship on a specific date; it documents the intended
+direction so contributors can align work and non-goals.
 
-Last updated: 04/16/2026
+Last updated: 2026-08-19
 
 ## Live today
 
 - Desktop app on Windows, Mac, and Linux.
-- Shared agents, skills, Agents, and MCPs.
-- Sign in with OpenAI Auth or other LLM providers.
-- Use any LLM, including LiteLLM and Cloudflare Gateaway.
-- Connect to a remote workspace or a cloud worker for long running tasks.
-- Cloud: Org Hub with provisioned Skills, Agents, and MCPs.
-- Cloud: RBAC, teams within an org, and the ability to deploy cloud workers.
+- Local-first workspace for code, files, browser tasks, documents,
+  presentations, websites, design, and video.
+- Agent workflows backed by OpenCode integration.
+- Skills, plugins, MCP servers, and browser automation.
+- Local providers and cloud-connected providers.
+- GitHub release packaging for desktop installers and portable artifacts.
+- Cloud and self-hosted deployment paths for teams that need shared workers,
+  organization administration, and provider governance.
 
-## Roadmap
+## 2026 Q3-Q4
 
-- Better support for Windows.
-- Claude-compatible plugin marketplace.
-- Git-based provisioning for plugins, skills, and MCPs.
-- Automatic push-based provisioning and sync.
-- Advanced enterprise controls: RBAC, audit trails, SSO/SAML, MDM provisioning...
+- Harden Windows and Linux desktop packaging, installer flows, and update
+  diagnostics.
+- Continue DeepSeek Harness subagent integration while preserving iPolloWork as
+  the primary workspace and keeping DSH optional.
+- Improve plugin package lifecycle checks, package metadata validation, and
+  local installation recovery.
+- Expand design, presentation, website, and video editing flows so generated
+  artifacts remain editable after the first agent pass.
+- Keep release automation aligned with signed macOS builds, Windows signing
+  readiness, REUSE compliance, OpenSSF Scorecard, and security analysis.
+
+## 2027 Q1-Q2
+
+- Strengthen organization controls for shared providers, hosted workers,
+  marketplace assignment, and account recovery.
+- Improve Git-based provisioning and synchronization for plugins, skills, MCP
+  servers, and organization-managed defaults.
+- Add more observable end-to-end validation for high-risk desktop, server,
+  connector, and artifact workflows.
+- Improve documentation for self-hosted deployments, release verification,
+  security boundaries, and operator responsibilities.
+- Continue accessibility and internationalization work across the desktop and
+  browser UI.
+
+## Not Planned In This Window
+
+- Requiring iPolloCloud for local use.
+- Forking or silently rewriting OpenCode internals.
+- Moving user workspace contents into a hosted service by default.
+- Supporting every model provider, plugin marketplace, or enterprise identity
+  system before the stable local workflow is reliable.
+- Treating unsigned local development builds as official public releases.


### PR DESCRIPTION
## Summary
- Add OpenSSF Best Practices and OPEA badges to README files.
- Add OpenSSF-oriented governance, security model, roadmap, dependency review, Dependabot, and CodeQL coverage.
- Update contribution, security, support, and PR template docs with clearer project hygiene policies.

## Why
- Prepare iPolloWork for OpenSSF Best Practices Silver progress.
- Provide public evidence URLs for governance, roles, roadmap, vulnerability response, security expectations, coding standards, test policy, and dependency/security analysis.

## Scope
- Docs and GitHub workflow/config only.
- No application runtime behavior changes.

## Testing
### Ran
- `pnpm readme:zh-hant`
- `pnpm readme:zh-hant:check`
- YAML parse check for new GitHub config/workflows
- `git diff --check`
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`

### Result
- pass

## CI status
- pass: pending GitHub Actions after PR is opened
- code-related failures: none expected
- external/env/auth blockers: CodeQL/dependency review require GitHub Actions permissions on the repository

## Manual verification
1. Verified OpenSSF badge URL returns 200.
2. Verified OPEA badge URL returns 200.
3. Verified translated Traditional Chinese README is synchronized.

## Evidence
- N/A (docs/config-only)

## Contributor statement
- [x] I have the right to submit this contribution under `CONTRIBUTING.md`.
- [x] I preserved third-party copyright and license notices, or this change does not add third-party material.

## Risk
- Low. Changes are documentation and GitHub automation only.
- New workflows may require repository Actions/security permissions to run successfully.
