### PR TITLE
Improve OpenSSF issue reporting controls

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -4,6 +4,10 @@ title: "[Bug]: "
 labels:
   - bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please do not report security vulnerabilities in public issues. Follow the private reporting process in [SECURITY.md](https://github.com/Devin-AXIS/iPolloWork/security/policy).
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/Devin-AXIS/iPolloWork/security/policy
+    about: Please report suspected vulnerabilities privately instead of opening a public issue.
+  - name: Community support
+    url: https://github.com/Devin-AXIS/iPolloWork/blob/main/SUPPORT.md
+    about: Read the support and maintainer triage policy before opening a public issue.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,7 @@
 name: Coverage
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- add a GitHub issue-template contact link for private security reports
- warn bug reporters not to disclose vulnerabilities in public issues
- allow maintainers to manually dispatch the Coverage workflow for OpenSSF evidence collection

## OpenSSF evidence
- Reporting security issues: `.github/ISSUE_TEMPLATE/config.yml` and `.github/ISSUE_TEMPLATE/bug.yml`
- Coverage evidence collection: `.github/workflows/coverage.yml`

## Verification
- Passed: GitHub issue template/workflow YAML parse check
- Passed: `git diff --check`
- Passed: `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`

## Notes
This is repository metadata only. No runtime fraimz proof is needed because the change does not alter the app/server/desktop user flow.