### PR TITLE
docs: add license compliance materials

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,11 @@
 - code-related failures:
 - external/env/auth blockers:
 
+## License compliance
+- dependency/license/asset changes: yes/no
+- if yes, reviewed against `docs/compliance/open-source-policy.md`: yes/no/N/A
+- `THIRD_PARTY_NOTICES.md` updated if needed: yes/no/N/A
+
 ## Manual verification
 1.
 2.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,17 +5,20 @@ on:
     branches:
       - main
       - dev
+    paths:
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "apps/**/package.json"
+      - "packages/**/package.json"
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -24,3 +27,12 @@ jobs:
         uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
+          comment-summary-in-pr: always
+          deny-licenses: >
+            AGPL-1.0, AGPL-1.0-only, AGPL-1.0-or-later,
+            AGPL-3.0, AGPL-3.0-only, AGPL-3.0-or-later,
+            GPL-2.0, GPL-2.0-only, GPL-2.0-or-later,
+            GPL-3.0, GPL-3.0-only, GPL-3.0-or-later,
+            LGPL-2.0, LGPL-2.0-only, LGPL-2.0-or-later,
+            LGPL-2.1, LGPL-2.1-only, LGPL-2.1-or-later,
+            LGPL-3.0, LGPL-3.0-only, LGPL-3.0-or-later

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
       - dev
-    paths:
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "apps/**/package.json"
-      - "packages/**/package.json"
 
 permissions:
   contents: read

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,15 @@
+iPolloWork Notices
+
+Copyright (c) 2026 Different AI, Inc. All rights reserved.
+
+iPolloWork is distributed under the iPolloWork Source Available License 1.0.
+See LICENSE for the controlling terms.
+
+This repository also contains separately licensed third-party components,
+templates, dependencies, vendored source, generated artifacts, and portions
+previously released under other licenses. Those materials remain governed by
+their own license terms. See THIRD_PARTY_NOTICES.md and LICENSES/ for
+additional notice material.
+
+The iPolloWork name, logo, product attribution, and related marks are not
+licensed except as expressly stated in LICENSE.

--- a/README.md
+++ b/README.md
@@ -212,6 +212,24 @@ git diff --check
 
 See `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md` for contribution, community, and security policies.
 
+## Compliance
+
+iPolloWork keeps repository-level license compliance materials for GitHub
+review and release preparation:
+
+- `NOTICE` records repository-level copyright, attribution, and trademark
+  notices.
+- [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) summarizes the current third-party dependency
+  license posture and review-required items.
+- [docs/compliance/](docs/compliance/) documents the open source policy, license compliance
+  process, SBOM process, and self-certification record.
+- `.github/workflows/dependency-review.yml` runs GitHub Dependency Review on
+  pull requests that change workspace dependencies.
+
+These materials are process and evidence records. They do not replace the
+controlling license text in `LICENSE`, third-party license terms, or legal
+review for release decisions.
+
 ## License
 
 iPolloWork uses the **iPolloWork Source Available License 1.0**:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,88 @@
+# Third Party Notices
+
+This file records the third-party license compliance posture for the
+iPolloWork repository. It is intended to make the GitHub repository easier to
+review and to provide a maintained starting point for release checks.
+
+This repository is source-available under the iPolloWork Source Available
+License 1.0. Third-party components remain governed by their own license
+terms.
+
+## Current Dependency License Snapshot
+
+Snapshot source: `pnpm licenses list --json --long` from the repository root.
+
+Snapshot date: 2026-08-19.
+
+Snapshot environment: Windows development checkout with installed workspace
+dependencies. Release builds should regenerate this snapshot on the relevant
+release platform because optional native packages can vary by operating system
+and CPU architecture.
+
+| License expression | Package entries |
+| --- | ---: |
+| MIT | 866 |
+| ISC | 68 |
+| Apache-2.0 | 38 |
+| BSD-3-Clause | 14 |
+| BSD-2-Clause | 13 |
+| BlueOak-1.0.0 | 10 |
+| MPL-2.0 | 3 |
+| LGPL-2.1 | 2 |
+| Apache-2.0 AND LGPL-3.0-or-later | 2 |
+| OFL-1.1 | 2 |
+| MIT-0 | 2 |
+| GPLv3 | 1 |
+| GPL-3.0 | 1 |
+| Python-2.0 | 1 |
+| CC-BY-4.0 | 1 |
+| (MPL-2.0 OR Apache-2.0) | 1 |
+| (MIT OR WTFPL) | 1 |
+| Unlicense | 1 |
+| (AFL-2.1 OR BSD-3-Clause) | 1 |
+| (MIT OR GPL-3.0-or-later) | 1 |
+| CC0-1.0 | 1 |
+| MIT AND Apache-2.0 | 1 |
+| (MIT AND Zlib) | 1 |
+| (BSD-2-Clause OR MIT OR Apache-2.0) | 1 |
+| WTFPL OR ISC | 1 |
+| WTFPL | 1 |
+| 0BSD | 1 |
+| (MIT OR CC0-1.0) | 1 |
+| (WTFPL OR MIT) | 1 |
+
+## Items Requiring Maintainer Review
+
+The following dependency license expressions should be reviewed before public
+release packaging or redistribution. Listing them here does not grant
+additional rights and does not represent legal approval.
+
+| Component | Version | License expression | Source |
+| --- | --- | --- | --- |
+| `@ffmpeg-installer/ffmpeg` | 1.1.0 | LGPL-2.1 | https://github.com/kribblo/node-ffmpeg-installer |
+| `@ffprobe-installer/ffprobe` | 2.1.2 | LGPL-2.1 | https://github.com/SavageCore/node-ffprobe-installer |
+| `@ffmpeg-installer/win32-x64` | 4.1.0 | GPLv3 | https://ffmpeg.zeranoe.com/builds/win64/static/ |
+| `@ffprobe-installer/win32-x64` | 5.1.0 | GPL-3.0 | https://www.gyan.dev/ffmpeg/builds/ |
+| `@img/sharp-win32-arm64` | 0.34.5 | Apache-2.0 AND LGPL-3.0-or-later | https://sharp.pixelplumbing.com |
+| `@img/sharp-win32-x64` | 0.34.5 | Apache-2.0 AND LGPL-3.0-or-later | https://sharp.pixelplumbing.com |
+| `jszip` | 3.10.1 | MIT OR GPL-3.0-or-later | https://github.com/Stuk/jszip |
+
+## Regeneration
+
+To refresh the dependency license snapshot:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm licenses list --json --long
+```
+
+For a release, store the generated output or an SPDX/CycloneDX SBOM under the
+release artifacts and update this file if the license families or review
+items changed.
+
+## Vendored And Template Materials
+
+The repository includes vendored source and bundled templates under paths such
+as `vendor/` and `apps/server/bundled-templates/`. Keep their included
+`LICENSE` and `NOTICE` files with the relevant source or template, and include
+material license changes in release review.

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,15 @@
+# Compliance Materials
+
+This directory collects the repository's open source license compliance
+process and self-assessment materials.
+
+Important documents:
+
+- [Open source policy](open-source-policy.md)
+- [License compliance process](license-compliance-process.md)
+- [Self-certification record](self-certification.md)
+- [SBOM process](sbom.md)
+
+These materials are process and evidence records for this repository. They do
+not replace the license text in `LICENSE`, third-party license terms, or legal
+review for commercial release decisions.

--- a/docs/compliance/license-compliance-process.md
+++ b/docs/compliance/license-compliance-process.md
@@ -1,0 +1,65 @@
+# License Compliance Process
+
+## Purpose
+
+This process describes how maintainers identify, review, document, and
+preserve license information for iPolloWork.
+
+## Responsibilities
+
+Maintainers are responsible for checking license information before adding or
+shipping third-party material. When a license is unclear or review-required,
+maintainers should escalate the dependency to the repository owner or the
+appropriate business/legal reviewer before release.
+
+## Pull Request Review
+
+For every pull request that adds or updates dependencies, vendored code,
+templates, generated assets, model files, fonts, or datasets:
+
+1. Identify the new or changed third-party material.
+2. Confirm the license and source URL.
+3. Check whether the license is allowed or review-required under
+   `docs/compliance/open-source-policy.md`.
+4. Keep upstream `LICENSE`, `NOTICE`, attribution, and copyright files.
+5. Update `THIRD_PARTY_NOTICES.md` when the dependency materially changes the
+   license profile or release notices.
+6. Record any review decision in the pull request.
+
+## Release Review
+
+Before publishing release artifacts:
+
+1. Install dependencies from the lockfile.
+2. Generate the dependency license report:
+
+   ```bash
+   pnpm licenses list --json --long
+   ```
+
+3. Generate or refresh an SBOM as described in `docs/compliance/sbom.md`.
+4. Compare the new report with `THIRD_PARTY_NOTICES.md`.
+5. Review GPL, AGPL, LGPL, MPL, unknown, custom, and commercial license
+   expressions before redistribution.
+6. Confirm that vendored and bundled materials still carry their upstream
+   license and notice files.
+7. Attach the relevant license report, SBOM, or review evidence to the release
+   record when applicable.
+
+## Exception Handling
+
+If a dependency cannot be approved:
+
+1. Remove or replace the dependency.
+2. Disable the affected release artifact until review is complete.
+3. Document the decision in the pull request or release record.
+
+## Evidence
+
+Evidence for this process includes:
+
+- Pull request dependency review results
+- `pnpm licenses list --json --long` output
+- SBOM artifacts
+- `THIRD_PARTY_NOTICES.md`
+- Maintainer comments approving review-required dependencies

--- a/docs/compliance/open-source-policy.md
+++ b/docs/compliance/open-source-policy.md
@@ -1,0 +1,59 @@
+# Open Source And Source-Available Policy
+
+## Scope
+
+This policy applies to this repository, including application code, packages,
+vendored source, bundled templates, build tooling, release artifacts, and
+third-party dependencies.
+
+## Project License
+
+iPolloWork is distributed under the iPolloWork Source Available License 1.0.
+See `LICENSE` for the controlling terms.
+
+This repository is source-available and is not licensed under an OSI-approved
+open source license unless a specific file or component states otherwise.
+Separately licensed third-party components remain under their own terms.
+
+## Allowed Dependency Categories
+
+Maintainers may generally use dependencies under permissive licenses such as:
+
+- MIT
+- BSD-2-Clause
+- BSD-3-Clause
+- ISC
+- Apache-2.0
+- 0BSD
+- CC0-1.0 for data or metadata where appropriate
+
+## Review-Required Dependency Categories
+
+Maintainer review is required before adding, updating, bundling, or shipping
+dependencies with any of the following:
+
+- GPL, AGPL, LGPL, MPL, EPL, CDDL, SSPL, BUSL, or other copyleft or
+  source-available terms
+- Custom, unknown, missing, deprecated, or ambiguous license expressions
+- Commercial, trial, non-commercial-only, research-only, or field-of-use
+  restrictions
+- Media, model weights, fonts, datasets, or templates with attribution,
+  redistribution, or usage restrictions
+
+## Prohibited Without Written Approval
+
+Do not add or ship code, assets, models, datasets, fonts, or templates when
+the license is unknown or when redistribution rights cannot be confirmed.
+
+Do not remove third-party copyright, license, attribution, or NOTICE files.
+
+## Records
+
+Compliance records are maintained in:
+
+- `LICENSE`
+- `NOTICE`
+- `LICENSES/`
+- `THIRD_PARTY_NOTICES.md`
+- `docs/compliance/`
+- GitHub pull request history and dependency review results

--- a/docs/compliance/sbom.md
+++ b/docs/compliance/sbom.md
@@ -1,0 +1,45 @@
+# SBOM Process
+
+## Purpose
+
+An SBOM records the software components included in a build or release. For
+iPolloWork, the SBOM should be generated from the locked dependency graph and
+stored with release evidence.
+
+## Recommended Formats
+
+Use one of the standard SBOM formats:
+
+- SPDX
+- CycloneDX
+
+## Generation
+
+For dependency license review, run:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm licenses list --json --long
+```
+
+For a formal release SBOM, generate an SPDX or CycloneDX artifact from the
+same checkout, lockfile, operating system, and architecture used for the
+release build. Store the generated artifact with release evidence and update
+`THIRD_PARTY_NOTICES.md` when it changes the public notice posture.
+
+## Review
+
+Before publishing release artifacts, review the SBOM for:
+
+- Unknown or missing licenses
+- GPL, AGPL, LGPL, MPL, or other review-required licenses
+- Native packages that vary by platform
+- Vendored source under `vendor/`
+- Bundled templates and assets under `apps/server/bundled-templates/`
+- Fonts, images, media, datasets, and model files
+
+## Retention
+
+Keep the SBOM or license report for each release together with the release
+record. If the artifact is not committed to the repository, attach it to the
+release notes or internal release evidence.

--- a/docs/compliance/self-certification.md
+++ b/docs/compliance/self-certification.md
@@ -1,0 +1,42 @@
+# Open Source License Compliance Self-Certification
+
+## Statement
+
+This repository maintains open source license compliance materials and performs
+self-assessment against the documented compliance process.
+
+This record is a repository-level self-certification and evidence checklist. It
+does not represent third-party certification, legal advice, or an OpenChain
+conformance claim unless the repository owner separately completes and approves
+that process.
+
+## Self-Assessment
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| Project license is declared | Complete | `LICENSE` |
+| Source-available status is disclosed | Complete | `README.md`, `LICENSE` |
+| Notices are preserved at the repository root | Complete | `NOTICE` |
+| Historical or separately licensed material is identified | Complete | `LICENSES/MIT.txt`, `LICENSE` section 6 |
+| Third-party license posture is documented | Complete | `THIRD_PARTY_NOTICES.md` |
+| Compliance policy is documented | Complete | `docs/compliance/open-source-policy.md` |
+| Review process is documented | Complete | `docs/compliance/license-compliance-process.md` |
+| SBOM process is documented | Complete | `docs/compliance/sbom.md` |
+| Pull requests can run dependency review | Complete | `.github/workflows/dependency-review.yml` |
+| Review-required license categories are identified | Complete | `docs/compliance/open-source-policy.md` |
+| Current review-required dependency items are listed | Needs review before release | `THIRD_PARTY_NOTICES.md` |
+| Release license report is attached to each release | Process defined | `docs/compliance/license-compliance-process.md` |
+| SBOM artifact is attached to each release | Process defined | `docs/compliance/sbom.md` |
+
+## Current Result
+
+Self-assessment status: process materials added; final release approval is
+pending maintainer review of review-required dependency items.
+
+## Maintainer Review Record
+
+Use this section for release or compliance review sign-off.
+
+| Date | Reviewer | Scope | Result | Notes |
+| --- | --- | --- | --- | --- |
+| 2026-08-19 | Pending | Repository baseline | Pending | Initial compliance materials added. |


### PR DESCRIPTION
## Summary
- Add repository-level license compliance materials for GitHub review and release preparation.
- Add NOTICE, THIRD_PARTY_NOTICES, compliance policy, compliance process, SBOM process, and self-certification record.
- Extend the PR template with license compliance checks.
- Strengthen Dependency Review with dependency-file path filters, PR summaries, and GPL/LGPL deny-list coverage.

## Testing
- Ran \pnpm licenses list --json --long\ against the latest origin/main worktree and updated the dependency license snapshot.
- Ran \git diff --check\.

## Notes
- This is a self-assessment/evidence record and does not claim third-party certification or OpenChain conformance.
- Review-required dependency items remain listed for maintainer/legal review before release.