### PR TITLE
docs: add verified project badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases/latest"><img src="https://img.shields.io/github/v/release/Devin-AXIS/iPolloWork?display_name=tag&amp;sort=semver" alt="Latest release" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases"><img src="https://img.shields.io/github/downloads/Devin-AXIS/iPolloWork/total" alt="GitHub downloads" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/forks"><img src="https://img.shields.io/github/forks/Devin-AXIS/iPolloWork?style=flat" alt="GitHub forks" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/graphs/contributors"><img src="https://img.shields.io/github/contributors/Devin-AXIS/iPolloWork" alt="GitHub contributors" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
   <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml/badge.svg?branch=main" alt="REUSE Compliance" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL analysis" /></a>
   <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 

--- a/docs/translations/README_JA.md
+++ b/docs/translations/README_JA.md
@@ -8,9 +8,13 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases/latest"><img src="https://img.shields.io/github/v/release/Devin-AXIS/iPolloWork?display_name=tag&amp;sort=semver" alt="Latest release" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases"><img src="https://img.shields.io/github/downloads/Devin-AXIS/iPolloWork/total" alt="GitHub downloads" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/forks"><img src="https://img.shields.io/github/forks/Devin-AXIS/iPolloWork?style=flat" alt="GitHub forks" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/graphs/contributors"><img src="https://img.shields.io/github/contributors/Devin-AXIS/iPolloWork" alt="GitHub contributors" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
   <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml/badge.svg?branch=main" alt="REUSE Compliance" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL analysis" /></a>
   <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 

--- a/docs/translations/README_ZH.md
+++ b/docs/translations/README_ZH.md
@@ -8,9 +8,13 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases/latest"><img src="https://img.shields.io/github/v/release/Devin-AXIS/iPolloWork?display_name=tag&amp;sort=semver" alt="Latest release" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases"><img src="https://img.shields.io/github/downloads/Devin-AXIS/iPolloWork/total" alt="GitHub downloads" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/forks"><img src="https://img.shields.io/github/forks/Devin-AXIS/iPolloWork?style=flat" alt="GitHub forks" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/graphs/contributors"><img src="https://img.shields.io/github/contributors/Devin-AXIS/iPolloWork" alt="GitHub contributors" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
   <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml/badge.svg?branch=main" alt="REUSE Compliance" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL analysis" /></a>
   <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 

--- a/docs/translations/README_ZH_hk.md
+++ b/docs/translations/README_ZH_hk.md
@@ -10,9 +10,13 @@
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases/latest"><img src="https://img.shields.io/github/v/release/Devin-AXIS/iPolloWork?display_name=tag&amp;sort=semver" alt="Latest release" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/releases"><img src="https://img.shields.io/github/downloads/Devin-AXIS/iPolloWork/total" alt="GitHub downloads" /></a>
   <a href="https://github.com/Devin-AXIS/iPolloWork/stargazers"><img src="https://img.shields.io/github/stars/Devin-AXIS/iPolloWork?style=flat" alt="GitHub stars" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/forks"><img src="https://img.shields.io/github/forks/Devin-AXIS/iPolloWork?style=flat" alt="GitHub forks" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/graphs/contributors"><img src="https://img.shields.io/github/contributors/Devin-AXIS/iPolloWork" alt="GitHub contributors" /></a>
   <a href="https://x.com/iPolloWork"><img src="https://img.shields.io/badge/X%20Global-%40iPolloWork%20%C2%B7%207.9K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloWork on X" /></a>
   <a href="https://x.com/iPolloCN"><img src="https://img.shields.io/badge/X%20%E4%B8%AD%E6%96%87-%40iPolloCN%20%C2%B7%203.4K%20followers-000000?logo=x&amp;logoColor=white" alt="Follow iPolloCN on X" /></a>
   <a href="https://www.bestpractices.dev/projects/14127"><img src="https://www.bestpractices.dev/projects/14127/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/reuse.yml/badge.svg?branch=main" alt="REUSE Compliance" /></a>
+  <a href="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml"><img src="https://github.com/Devin-AXIS/iPolloWork/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL analysis" /></a>
   <a href="https://github.com/opea-project"><img src="https://img.shields.io/badge/OPEA-Open%20Platform%20for%20Enterprise%20AI-ff7a00" alt="OPEA: Open Platform for Enterprise AI" /></a>
 </p>
 


### PR DESCRIPTION
## What changed

- add dynamic GitHub forks and contributor badges
- add the passing REUSE Compliance workflow badge
- add the passing CodeQL analysis workflow badge
- keep every existing badge unchanged
- synchronize English, Simplified Chinese, Traditional Chinese, and Japanese READMEs

## Why

These badges add current community and project-health signals that are already backed by public repository data. Coverage, tests, and OpenSSF Scorecard badges are intentionally excluded until their current results are suitable for display.

## Validation

- `pnpm readme:zh-hant:check`
- `git diff --check`
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`
- verified all four new badge image endpoints return HTTP 200
- verified REUSE Compliance and CodeQL badges currently report `passing`

Runtime evidence is not applicable because this is a README-only change.