### PR TITLE
feat(provider): add OrcaRouter as a named compatible provider

### DIFF
--- a/apps/app/src/app/utils/index.ts
+++ b/apps/app/src/app/utils/index.ts
@@ -42,6 +42,7 @@ export const FRIENDLY_PROVIDER_LABELS: Record<string, string> = {
   mistral: "Mistral",
   groq: "Groq",
   openrouter: "OpenRouter",
+  orcarouter: "OrcaRouter",
   minimax: "MiniMax",
   tokenstar: "TokenStar",
   together: "Together AI",

--- a/apps/app/src/react-app/design-system/provider-icon.tsx
+++ b/apps/app/src/react-app/design-system/provider-icon.tsx
@@ -29,6 +29,7 @@ export function ProviderIcon(props: ProviderIconProps) {
 
   const fallbackLetters = (() => {
     if (normalizedId === "openrouter") return "OR";
+    if (normalizedId === "orcarouter") return "OC";
     if (normalizedId === "deepseek") return "DS";
     if (normalizedId === "google") return "GO";
     if (normalizedId.length >= 2) return normalizedId.substring(0, 2).toUpperCase();

--- a/apps/app/src/react-app/domains/connections/provider-auth/orcarouter-provider.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/orcarouter-provider.ts
@@ -1,0 +1,74 @@
+export const ORCAROUTER_PROVIDER = {
+  providerId: "orcarouter",
+  name: "OrcaRouter",
+  baseURL: "https://api.orcarouter.ai/v1",
+  signupUrl: "https://www.orcarouter.ai",
+  fallbackModels: [
+    { id: "orcarouter/auto", name: "OrcaRouter Auto" },
+    { id: "openai/gpt-5.5", name: "GPT-5.5" },
+    { id: "anthropic/claude-opus-4.8", name: "Claude Opus 4.8" },
+    { id: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash" },
+    { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro" },
+    { id: "qwen/qwen3.7-max", name: "Qwen3.7 Max" },
+    { id: "minimax/minimax-m2.7", name: "MiniMax M2.7" },
+    { id: "grok/grok-4.3", name: "Grok 4.3" },
+  ],
+};
+
+export type OrcaRouterModel = {
+  id: string;
+  name: string;
+};
+
+const humanizeModelName = (id: string) => {
+  const gatewaySlug = id.split("/").at(-1) ?? id;
+  return gatewaySlug
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(" ")
+    .flatMap((word) => {
+      if (!word) return [];
+      if (/\d/.test(word) || word.length <= 3) return [word.toUpperCase()];
+      const lower = word.toLowerCase();
+      return [lower.charAt(0).toUpperCase() + lower.slice(1)];
+    })
+    .join(" ");
+};
+
+export function orcarouterModelName(id: string) {
+  return (
+    ORCAROUTER_PROVIDER.fallbackModels.find((model) => model.id === id)?.name ??
+    humanizeModelName(id)
+  );
+}
+
+export function orcarouterRuntimeModels(modelIds: string[]) {
+  return Object.fromEntries(
+    modelIds.map((id) => [
+      id,
+      {
+        name: orcarouterModelName(id),
+      },
+    ]),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function parseOrcaRouterModels(value: unknown): OrcaRouterModel[] {
+  const rawModels = isRecord(value) && Array.isArray(value.data) ? value.data : [];
+  const seen = new Set<string>();
+  return rawModels.flatMap((entry) => {
+    if (!isRecord(entry) || typeof entry.id !== "string") return [];
+    const id = entry.id.trim();
+    if (!id || seen.has(id)) return [];
+    seen.add(id);
+    const name = typeof entry.name === "string" && entry.name.trim()
+      ? entry.name.trim()
+      : orcarouterModelName(id);
+    return [{ id, name }];
+  });
+}

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-curation.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-curation.ts
@@ -32,6 +32,7 @@ export const PROVIDER_LABELS: Record<string, string> = {
   anthropic: "Anthropic",
   google: "Google",
   openrouter: "OpenRouter",
+  orcarouter: "OrcaRouter",
   qwen: "Qwen",
   tokenstar: "TokenStar",
   "deepseek-official": "DeepSeek",

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -31,6 +31,7 @@ import {
   parseTokenStarModels,
   TOKENSTAR_PROVIDER,
 } from "./tokenstar-provider";
+import { ORCAROUTER_PROVIDER } from "./orcarouter-provider";
 import {
   buildProviderAuthEntries,
   getProviderAuthEntryGroups,
@@ -112,9 +113,11 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   const isiPolloWorkBuiltInProvider = (id: string) => id.trim().toLowerCase() === "opencode";
   const isTokenStarProvider = (id: string) => id.trim().toLowerCase() === TOKENSTAR_PROVIDER.providerId;
+  const isOrcaRouterProvider = (id: string) => id.trim().toLowerCase() === ORCAROUTER_PROVIDER.providerId;
 
   const OPENCODE_ZEN_KEY_URL = "https://opencode.ai/auth";
   const TOKENSTAR_WEBSITE_URL = "https://tokenstar.io";
+  const ORCAROUTER_WEBSITE_URL = ORCAROUTER_PROVIDER.signupUrl;
 
   const openExternalUrl = async (url: string) => {
     if (!url) return;
@@ -694,6 +697,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     if (isTokenStarProvider(entry.id)) {
       return "Connect TokenStar, check available models, and choose which models to show in iPolloWork.";
     }
+    if (isOrcaRouterProvider(entry.id)) {
+      return "Connect OrcaRouter and use it from every supported agent engine.";
+    }
     return "Paste a secret key that iPolloWork stores locally on this device.";
   };
 
@@ -914,6 +920,8 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                           ? "Paste your iPolloWork built-in models API key."
                           : isTokenStarProvider(selectedEntry.id)
                             ? "Paste your TokenStar API key. iPolloWork verifies it and finds your available models automatically."
+                            : isOrcaRouterProvider(selectedEntry.id)
+                              ? "Paste your OrcaRouter API key to route through the OrcaRouter gateway."
                           : "Paste your API key to connect."}
                       </div>
                     </div>
@@ -947,6 +955,18 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       </button>
                     </div>
                   ) : null}
+                  {isOrcaRouterProvider(selectedEntry.id) ? (
+                    <div className="rounded-lg border border-indigo-5/30 bg-indigo-3/15 px-3 py-2.5 text-xs text-indigo-12 space-y-1.5">
+                      <div>OrcaRouter routes each request to the best model for the task across OpenAI, Anthropic, Google, DeepSeek, and more.</div>
+                      <button
+                        type="button"
+                        className="text-indigo-11 hover:text-indigo-12 underline underline-offset-2 font-medium"
+                        onClick={() => void openExternalUrl(ORCAROUTER_WEBSITE_URL)}
+                      >
+                        No API key? Visit OrcaRouter to get one.
+                      </button>
+                    </div>
+                  ) : null}
                   {selectedTokenStarConnected ? (
                     <div className="rounded-lg border border-gray-6/60 bg-gray-1/60 px-3 py-2.5 text-xs text-gray-10">
                       A TokenStar API key is configured on this device. Delete it before adding a new one.
@@ -955,7 +975,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     <TextInput
                       label="API key"
                       type="password"
-                      placeholder={isTokenStarProvider(selectedEntry.id) ? "vk_..." : isiPolloWorkBuiltInProvider(selectedEntry.id) ? "ock_..." : "sk-..."}
+                      placeholder={isTokenStarProvider(selectedEntry.id) ? "vk_..." : isiPolloWorkBuiltInProvider(selectedEntry.id) ? "ock_..." : isOrcaRouterProvider(selectedEntry.id) ? "sk-orca-..." : "sk-..."}
                       value={apiKeyInput}
                       onChange={(event) => {
                         setApiKeyInput(event.currentTarget.value);

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -78,6 +78,7 @@ import {
   type DesktopAppRestrictionChecker,
 } from "../../../../app/cloud/desktop-app-restrictions";
 import { TOKENSTAR_PROVIDER, tokenStarRuntimeModels } from "./tokenstar-provider";
+import { ORCAROUTER_PROVIDER, orcarouterRuntimeModels } from "./orcarouter-provider";
 import {
   modelRuntimeAdapters,
   type CompatibleProviderProfile,
@@ -271,6 +272,18 @@ const COMPATIBLE_PROVIDER_PRESETS: CompatibleProviderPreset[] = [
     models: (modelIds) => tokenStarRuntimeModels([
       ...new Set(
         (modelIds?.length ? modelIds : TOKENSTAR_PROVIDER.fallbackModels.map((model) => model.id))
+          .map((modelId) => modelId.trim())
+          .filter(Boolean),
+      ),
+    ]),
+  },
+  {
+    providerId: ORCAROUTER_PROVIDER.providerId,
+    name: ORCAROUTER_PROVIDER.name,
+    baseURL: ORCAROUTER_PROVIDER.baseURL,
+    models: (modelIds) => orcarouterRuntimeModels([
+      ...new Set(
+        (modelIds?.length ? modelIds : ORCAROUTER_PROVIDER.fallbackModels.map((model) => model.id))
           .map((modelId) => modelId.trim())
           .filter(Boolean),
       ),
@@ -1242,6 +1255,26 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             type: "api",
             label: t("providers.api_key_label"),
             description: "Connect TokenStar with an API key and choose the models to expose.",
+          },
+        ];
+      }
+    }
+
+    if (
+      getProviderEngineAdapter().capabilities.customProviders &&
+      !isDesktopProviderBlocked({
+        providerId: ORCAROUTER_PROVIDER.providerId,
+        checkRestriction: options.checkDesktopAppRestriction,
+      })
+    ) {
+      const existing = merged[ORCAROUTER_PROVIDER.providerId] ?? [];
+      if (!existing.some((method) => method.type === "api")) {
+        merged[ORCAROUTER_PROVIDER.providerId] = [
+          ...existing,
+          {
+            type: "api",
+            label: t("providers.api_key_label"),
+            description: "Connect OrcaRouter with an API key and use it from every supported agent engine.",
           },
         ];
       }

--- a/apps/app/tests/orcarouter-provider.test.ts
+++ b/apps/app/tests/orcarouter-provider.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ORCAROUTER_PROVIDER,
+  orcarouterModelName,
+  orcarouterRuntimeModels,
+  parseOrcaRouterModels,
+} from "../src/react-app/domains/connections/provider-auth/orcarouter-provider";
+
+describe("OrcaRouter provider preset", () => {
+  test("points at the OrcaRouter OpenAI-compatible gateway", () => {
+    expect(ORCAROUTER_PROVIDER).toMatchObject({
+      providerId: "orcarouter",
+      name: "OrcaRouter",
+      baseURL: "https://api.orcarouter.ai/v1",
+    });
+  });
+
+  test("fallback models cover the adaptive router and the flagship gateway models", () => {
+    expect(ORCAROUTER_PROVIDER.fallbackModels.map((model) => model.id)).toEqual([
+      "orcarouter/auto",
+      "openai/gpt-5.5",
+      "anthropic/claude-opus-4.8",
+      "google/gemini-3.5-flash",
+      "deepseek/deepseek-v4-pro",
+      "qwen/qwen3.7-max",
+      "minimax/minimax-m2.7",
+      "grok/grok-4.3",
+    ]);
+  });
+
+  test("derives a friendly name for unknown gateway models", () => {
+    expect(orcarouterModelName("orcarouter/auto")).toBe("OrcaRouter Auto");
+    expect(orcarouterModelName("openai/gpt-5.5")).toBe("GPT-5.5");
+    expect(orcarouterModelName("anthropic/claude-opus-4.8")).toBe("Claude Opus 4.8");
+    expect(orcarouterModelName("unknown/model")).toBe("Model");
+  });
+
+  test("builds runtime models from a model id list", () => {
+    expect(orcarouterRuntimeModels(["orcarouter/auto", "openai/gpt-5.5"])).toEqual({
+      "orcarouter/auto": { name: "OrcaRouter Auto" },
+      "openai/gpt-5.5": { name: "GPT-5.5" },
+    });
+  });
+
+  test("parses OpenAI-compatible model responses", () => {
+    expect(
+      parseOrcaRouterModels({
+        data: [
+          { id: "orcarouter/auto" },
+          { id: "openai/gpt-5.5", name: "GPT-5.5" },
+          { id: " " },
+          { id: "orcarouter/auto" },
+        ],
+      }),
+    ).toEqual([
+      { id: "orcarouter/auto", name: "OrcaRouter Auto" },
+      { id: "openai/gpt-5.5", name: "GPT-5.5" },
+    ]);
+  });
+
+  test("ignores malformed responses", () => {
+    expect(parseOrcaRouterModels({ data: [{ name: "No ID" }] })).toEqual([]);
+    expect(parseOrcaRouterModels(null)).toEqual([]);
+  });
+});

--- a/apps/app/tests/provider-engine-adapter.test.ts
+++ b/apps/app/tests/provider-engine-adapter.test.ts
@@ -769,6 +769,129 @@ describe("model runtime adapters", () => {
     expect(connectedIds).toContain("deepseek-official");
   });
 
+  test("connects the OrcaRouter compatible provider preset as a callable shared OpenCode provider", async () => {
+    const { calls, client } = createOpenCodeProviderClient();
+    const runtimePatches: unknown[] = [];
+    const mirroredCredentials: Array<{ key: string; value: string }> = [];
+    let providers = [
+      {
+        id: "opencode",
+        name: "OpenCode",
+        source: "api" as const,
+        env: [],
+        models: {},
+      },
+    ];
+    let connectedIds = ["opencode"];
+    const serverClient = {
+      patchConfig: async (_workspaceId: string, patch: unknown) => {
+        calls.push({ name: "patch-config" });
+        runtimePatches.push(patch);
+        return { ok: true };
+      },
+      reloadEngine: async () => {
+        calls.push({ name: "reload-engine" });
+        return { ok: true };
+      },
+      upsertUserEnv: async (entries: Array<{ key: string; value: string }>) => {
+        calls.push({ name: "mirror-shared" });
+        mirroredCredentials.push(...entries);
+        return { updated: entries.map((entry) => entry.key) };
+      },
+    };
+    const store = createProviderAuthStore({
+      client: () => client,
+      providers: () => providers,
+      providerDefaults: () => ({ opencode: "default-model" }),
+      providerConnectedIds: () => connectedIds,
+      disabledProviders: () => [],
+      checkDesktopAppRestriction: () => false,
+      selectedWorkspaceDisplay: () => ({
+        id: "workspace-a",
+        name: "Workspace A",
+        path: "C:\\workspace",
+        preset: "starter",
+        workspaceType: "local",
+        engineId: DEFAULT_ENGINE_ID,
+      }),
+      providerBaseUrl: () => "http://localhost:43121/opencode",
+      selectedWorkspaceRoot: () => "C:\\workspace",
+      runtimeWorkspaceId: () => "workspace-a",
+      ipolloworkServer: {
+        getSnapshot: () => ({
+          ipolloworkServerStatus: "connected",
+          ipolloworkServerClient: serverClient as never,
+          ipolloworkServerCapabilities: { config: { read: true, write: true } },
+        }),
+      },
+      setProviders: (value) => { providers = value; },
+      setProviderDefaults: () => {},
+      setProviderConnectedIds: (value) => { connectedIds = value; },
+      setDisabledProviders: () => {},
+      markEngineConfigReloadRequired: () => {},
+    });
+
+    await store.openProviderAuthModal({ preferredProviderId: "orcarouter" });
+    expect(store.getSnapshot()).toMatchObject({
+      providerAuthModalOpen: true,
+      providerAuthPreferredProviderId: "orcarouter",
+      providerAuthMethods: {
+        orcarouter: [{ type: "api", label: expect.any(String) }],
+      },
+    });
+
+    await store.submitProviderApiKey("orcarouter", "secret");
+
+    expect(runtimePatches).toEqual([{
+      opencode: {
+        provider: {
+          orcarouter: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "OrcaRouter",
+            options: { baseURL: "https://api.orcarouter.ai/v1" },
+            models: {
+              "orcarouter/auto": { name: "OrcaRouter Auto" },
+              "openai/gpt-5.5": { name: "GPT-5.5" },
+              "anthropic/claude-opus-4.8": { name: "Claude Opus 4.8" },
+              "google/gemini-3.5-flash": { name: "Gemini 3.5 Flash" },
+              "deepseek/deepseek-v4-pro": { name: "DeepSeek V4 Pro" },
+              "qwen/qwen3.7-max": { name: "Qwen3.7 Max" },
+              "minimax/minimax-m2.7": { name: "MiniMax M2.7" },
+              "grok/grok-4.3": { name: "Grok 4.3" },
+            },
+          },
+        },
+      },
+    }]);
+    expect(calls).toContainEqual({
+      name: "set",
+      value: {
+        providerID: "orcarouter",
+        auth: { type: "api", key: "secret" },
+      },
+    });
+    expect(calls.findIndex((call) => call.name === "mirror-shared")).toBeLessThan(
+      calls.findIndex((call) => call.name === "patch-config"),
+    );
+    expect(calls.findIndex((call) => call.name === "patch-config")).toBeLessThan(
+      calls.findIndex((call) => call.name === "reload-engine"),
+    );
+    expect(calls.findIndex((call) => call.name === "reload-engine")).toBeLessThan(
+      calls.findIndex((call) => call.name === "set"),
+    );
+    expect(mirroredCredentials[0]).toEqual({
+      key: sharedProviderCredentialEnvKey("orcarouter"),
+      value: "secret",
+    });
+    expect(mirroredCredentials[1]?.key).toBe(sharedProviderProfileEnvKey("orcarouter"));
+    expect(parseSharedProviderProfile(mirroredCredentials[1]?.value ?? "")).toMatchObject({
+      providerId: "orcarouter",
+      api: "openai-completions",
+      baseURL: "https://api.orcarouter.ai/v1",
+    });
+    expect(connectedIds).toContain("orcarouter");
+  });
+
   test("imports a DSH API-key connection into OpenCode", async () => {
     const { calls, client } = createOpenCodeProviderClient();
     const credentialKey = sharedProviderCredentialEnvKey("deepseek-official");


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a named, first-class compatible provider preset in the provider auth flow. Users can connect an OrcaRouter API key and use it from every supported agent engine, exactly like the existing DeepSeek / Qwen / TokenStar presets.

OrcaRouter is an AI gateway that routes each request to the best model for the task across OpenAI, Anthropic, Google, DeepSeek, MiniMax, and more through a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why

iPolloWork already ships named OpenAI-compatible provider presets (DeepSeek, Qwen, TokenStar). Adding OrcaRouter as a named preset makes it a one-click, discoverable provider rather than requiring users to configure a custom OpenAI-compatible endpoint.

## Issue

N/A

## Scope

- New `orcarouter-provider.ts` with the preset definition (base URL, fallback model catalog, runtime model builder, OpenAI-compatible model parser).
- `store.ts`: register the OrcaRouter preset in `COMPATIBLE_PROVIDER_PRESETS` and synthesize its API-key auth method.
- Display name + icon fallback for the `orcarouter` provider id.
- Provider auth modal copy, signup link, and `sk-orca-...` API key placeholder.
- Unit tests for the preset and a store-level connection test.

## Out of scope

- No changes to the OpenCode engine, existing providers, or project config.

## Testing

### Ran

- `pnpm --filter @ipollowork/app typecheck`
- `bun test apps/app/tests/orcarouter-provider.test.ts apps/app/tests/provider-engine-adapter.test.ts apps/app/tests/provider-auth-curation.test.ts apps/app/tests/settings-provider-branding.test.ts`
- `bun test --isolate tests/` (full app suite)
- `node scripts/sync-readme-zh-hant.mjs --check`
- Live test: `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` → HTTP 200, content `ORCA-OK`; all preset gateway models confirmed present in `/v1/models`.

### Result

- Typecheck: pass
- Related tests: 36 pass, 0 fail
- Full app suite: 862 pass, 4 fail — all 4 are pre-existing on clean `main` (composer model menu ×2, sidebar primary actions, managed brand header); none touch provider wiring.
- README sync: synchronized
- L3 live test: pass

## CI status

- Pending (fork first-PR; external auth action likely `action_required` until a maintainer approves CI).

## Manual verification

1. Open provider auth modal → OrcaRouter appears as a named provider.
2. Connect with an API key → provider is materialized into `opencode.json` via `@ai-sdk/openai-compatible` with `baseURL: https://api.orcarouter.ai/v1` and the fallback model catalog.
3. Select an OrcaRouter model in the model picker → chat routes through the OrcaRouter gateway.

## Evidence

Live API test (above) verifies the endpoint and model catalog end-to-end.

## Contributor statement

- [x] I have the right to submit this contribution under `CONTRIBUTING.md`.
- [x] I preserved third-party copyright and license notices, or this change does not add third-party material.

Disclosure: I'm an engineer on the OrcaRouter team.
