### PR TITLE
docs: position iPolloWork as an Agent Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**A local-first visual AI workbench that turns one goal into editable code, documents, presentations, websites, designs, and videos—an open alternative to Codex and Claude Code.**
+**An enterprise-grade, local-first Agent Workbench for people and agent teams—plan, collaborate, and create editable code, documents, presentations, websites, designs, and videos in one workspace.**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork gives agents one workspace for repositories, local files, browser tasks, documents, presentations, websites, design, and video. Describe the outcome; the agent plans and executes; you inspect the work, approve actions, and keep editing the result in the same place.
+iPolloWork is the workspace layer for the next agent-native way of working. It brings projects, agents, tasks, schedules, plugins, Skills, MCP tools, and editable outputs into one control surface. Describe the outcome; agents plan and execute; your team reviews progress, approves actions, and keeps editing the result in the same place.
 
-Codex-style coding is only the starting point. When the output is a deck, web page, visual design, or video, iPolloWork keeps it editable instead of handing you a finished file or a chat transcript.
+iPolloWork is not positioned as a replacement for a single coding agent. It is an open workbench that connects [Codex](https://github.com/openai/codex), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), OpenCode, and future agent runtimes while preserving the native strengths of each ecosystem. Coding is only the starting point: when the output is a deck, web page, visual design, or video, it remains editable instead of becoming a finished file or a chat transcript.
 
 <div align="center">
   <h3>Join the official iPolloWork WeChat community</h3>
@@ -36,16 +36,28 @@ Codex-style coding is only the starting point. When the output is a deck, web pa
 
 ## What makes it different
 
-- **Agent-first execution** — plan work, use tools, read and modify files, run commands, and continue from the current state.
-- **Editable results** — move from code to documents, websites, presentations, design, and video; keep changing text, images, layout, and scenes after generation.
-- **Local control** — run on your machine, bring your own model or provider, approve permissions, and extend the workspace with Skills, plugins, MCP servers, and browser automation.
-- **Two agent ecosystems, one workflow** — native [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) subagent collaboration is in active development, designed to let iPolloWork delegate focused work to DSH while both sides keep their own Skills and plugins.
+- **Project-native collaboration** — give people and agents one shared project view for responsibilities, tasks, schedules, execution health, and results instead of scattering work across isolated chats.
+- **Runtime-open, not a replacement** — OpenCode powers the default local runtime, DeepSeek Harness can run as an optional native runtime and delegation target, and Codex or any MCP client can operate iPolloWork through its semantic control surface.
+- **One editable creation loop** — move from code to documents, websites, presentations, design, and video while keeping text, images, layouts, timelines, and scenes editable after generation.
+- **Composable by design** — add Skills, plugins, MCP servers, model providers, browser automation, and engine-native capabilities without binding the whole workspace to one agent framework.
+- **Local and enterprise control** — run locally, bring your own model or provider, review permissions and execution, and connect organization services when a team needs them.
 
-## DeepSeek Harness subagent collaboration
+## Agent runtime compatibility
 
-iPolloWork is integrating [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) as an optional subagent runtime. The integration is in active development and is not included in the latest stable release yet.
+OpenCode is the default local execution runtime today. [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) is integrated as an optional peer runtime and subagent delegation target, while [Codex](https://github.com/openai/codex) and other MCP-compatible clients can connect through the [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) control surface. These paths share the workbench without pretending that every runtime has the same native capabilities.
 
-The collaboration model keeps iPolloWork as the primary workspace: a task can delegate bounded work to DSH subagents when useful, then bring structured results back into the same task. iPolloWork and DSH retain their own Skills and plugin ecosystems, so users can benefit from both without replacing either runtime.
+The collaboration model keeps iPolloWork as the project workspace: a task can delegate bounded work to DSH subagents when useful, then bring structured progress and results back into the same project. Each runtime retains its own agents, Skills, plugins, and execution model.
+
+### Run iPolloWork creative plugins directly in DeepSeek Harness
+
+DeepSeek Harness users can install iPolloWork's native Design, PPT, and Video views into the DSH Web UI and start them from any project directory:
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo
+npx @deepseek-ai/dsh web
+```
+
+Open [http://127.0.0.1:3080](http://127.0.0.1:3080), start a conversation, and choose **Design**, **PPT**, or **Video**. If the `dsh` command is already installed, replace `npx @deepseek-ai/dsh` with `dsh`. DeepSeek Harness is currently a developer preview, so plugin compatibility follows its active release line.
 
 ## Install iPolloWork
 
@@ -174,15 +186,19 @@ This command creates an isolated development profile, points authentication and 
 ## Architecture boundary
 
 ```text
-iPolloWork desktop/UI ── local API ──> iPolloWork server ──> OpenCode
-          │
-          └── optional account/control requests ──> iPolloCloud
+Codex / MCP clients ── ipollowork-ui-mcp ──> iPolloWork desktop/UI
+                                                   │
+                                                   ├── local API ──> Engine Protocol ──> OpenCode (default)
+                                                   │                               └──> DeepSeek Harness (optional)
+                                                   └── optional account/control requests ──> iPolloCloud
 ```
 
-- Agent execution and streaming stay on the Work/Worker path.
+- Agent execution, task state, and streaming are normalized at the shared engine boundary while engine-native behavior remains inside its adapter.
+- Portable Skills, plugins, MCP servers, and project capabilities use one lifecycle; engine-specific enhancements stay optional.
+- Codex compatibility currently uses the MCP control surface rather than claiming a native Codex engine adapter.
 - iPolloCloud handles identity, organizations, entitlements, hosted worker lifecycle, administration, and commercial Apps.
 - The Cloud connection is optional. Local iPolloWork works without an account or commercial service.
-- OpenCode remains its own component and can continue to be upgraded independently.
+- OpenCode and DeepSeek Harness remain independent components and can continue to evolve without turning iPolloWork into a fork of either runtime.
 
 ## Repository layout
 

--- a/docs/translations/README_JA.md
+++ b/docs/translations/README_JA.md
@@ -20,13 +20,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**一つの目的から編集可能なコード・文書・プレゼン・Webサイト・デザイン・動画まで作れる、ローカルファーストのビジュアルAIワークベンチであり、CodexとClaude Codeのソースアベイラブルな代替です。**
+**人とエージェントチームのための、エンタープライズ対応・ローカルファーストの Agent Workbench。コード、文書、プレゼン、Webサイト、デザイン、動画を一つのワークスペースで計画・共同作業・継続編集できます。**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork は、リポジトリ、ローカルファイル、ブラウザ操作、ドキュメント、プレゼンテーション、Web サイト、デザイン、動画を一つのワークスペースで扱える AI エージェント環境です。目的を伝えると、エージェントが計画して実行します。ユーザーは手順を確認し、操作を承認し、同じ場所で成果物を編集し続けられます。
+iPolloWork は、次世代のエージェントネイティブな働き方を支えるワークスペースレイヤーです。プロジェクト、エージェント、タスク、スケジュール、プラグイン、Skills、MCP ツール、編集可能な成果物を一つの操作画面に統合します。目的を伝えるとエージェントが計画して実行し、チームは進捗を確認し、操作を承認し、同じ場所で成果物を編集し続けられます。
 
-Codex のようなコーディングは出発点にすぎません。成果物がスライド、Web ページ、ビジュアルデザイン、動画になっても、完成ファイルやチャットの回答で終わらず、そのまま編集できます。
+iPolloWork は、特定のコーディングエージェントの代替を目指す製品ではありません。[Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode、そして将来のエージェントランタイムを接続しながら、それぞれのエコシステム固有の強みを保つオープンなワークベンチです。コーディングは出発点にすぎず、スライド、Web ページ、ビジュアルデザイン、動画も、完成ファイルやチャット記録で終わらず編集可能なまま残ります。
 
 <div align="center">
   <h3>iPolloWork 公式 WeChat コミュニティに参加</h3>
@@ -36,16 +36,28 @@ Codex のようなコーディングは出発点にすぎません。成果物�
 
 ## iPolloWork の違い
 
-- **エージェント中心の実行** — 作業を計画し、ツールを使い、ファイルを読み書きし、コマンドを実行し、現在の状態から作業を続けます。
-- **編集可能な成果物** — コードからドキュメント、Web サイト、スライド、デザイン、動画まで、生成後もテキスト、画像、レイアウト、シーンを変更できます。
-- **ローカルで管理** — 自分の端末で実行し、任意のモデルやプロバイダーを接続し、権限を承認し、Skills、プラグイン、MCP サーバー、ブラウザ自動化で拡張できます。
-- **2つのエージェントエコシステムを一つのワークフローに** — [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) サブエージェントとのネイティブ連携を開発中です。iPolloWork から DSH に範囲を限定した作業を委任しながら、双方が独自の Skills とプラグインを利用できる形を目指しています。
+- **プロジェクト中心の共同作業** — 人とエージェントが、役割、タスク、スケジュール、実行状態、成果物を同じプロジェクト画面で共有し、孤立したチャットに作業を分散させません。
+- **ランタイムを置き換えずに接続** — OpenCode が標準ローカルランタイムを担い、DeepSeek Harness は任意のネイティブランタイム兼委任先として動作します。Codex や他の MCP クライアントは、セマンティックな制御インターフェースから iPolloWork を操作できます。
+- **一つの編集可能な制作ループ** — コードから文書、Web サイト、プレゼン、デザイン、動画まで、生成後もテキスト、画像、レイアウト、タイムライン、シーンを変更できます。
+- **組み合わせ可能な拡張性** — Skills、プラグイン、MCP サーバー、モデルプロバイダー、ブラウザ自動化、エンジン固有機能を必要に応じて追加できます。
+- **ローカルとエンタープライズの管理** — ローカル実行、モデル選択、権限と実行の確認を保ち、チームで必要なときだけ組織サービスへ接続できます。
 
-## DeepSeek Harness サブエージェント連携
+## エージェントランタイムの互換性
 
-iPolloWork は、[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) をオプションのサブエージェントランタイムとしてネイティブ統合する作業を進めています。この機能は現在開発中で、最新の安定版にはまだ含まれていません。
+OpenCode は現在の標準ローカル実行ランタイムです。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) は任意のピアランタイム兼サブエージェント委任先として統合され、[Codex](https://github.com/openai/codex) と他の MCP 対応クライアントは [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 制御インターフェースから接続できます。すべてが同じワークベンチを利用しますが、各ランタイムのネイティブ機能が同一であるとは扱いません。
 
-連携モデルはシンプルです。iPolloWork を主要なワークスペースとして維持し、必要に応じて範囲を限定した作業を DSH サブエージェントに委任し、その構造化された結果を同じタスクへ戻します。iPolloWork と DSH はそれぞれの Skills とプラグインエコシステムを維持するため、どちらかを置き換えることなく両方の能力を活用できます。
+連携モデルはシンプルです。iPolloWork をプロジェクトワークベンチとして維持し、必要に応じて範囲を限定した作業を DSH サブエージェントに委任し、構造化された進捗と結果を同じプロジェクトへ戻します。各ランタイムは独自のエージェント、Skills、プラグイン、実行モデルを維持します。
+
+### DeepSeek Harness で iPolloWork の制作プラグインを直接起動する
+
+DeepSeek Harness の Web UI に、iPolloWork のネイティブ Design、PPT、Video ビューをインストールし、任意のプロジェクトディレクトリから起動できます。
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo
+npx @deepseek-ai/dsh web
+```
+
+[http://127.0.0.1:3080](http://127.0.0.1:3080) を開き、会話を開始して **Design**、**PPT**、**Video** のいずれかを選択します。`dsh` コマンドをインストール済みの場合は、`npx @deepseek-ai/dsh` を `dsh` に置き換えられます。DeepSeek Harness は現在デベロッパープレビューのため、プラグイン互換性はその最新リリース系列に追従します。
 
 ## iPolloWork のインストール
 
@@ -171,15 +183,19 @@ Windows の開発ビルドでは、本番用の `ipollowork://` ハンドラー�
 ## アーキテクチャの境界
 
 ```text
-iPolloWork desktop/UI ── local API ──> iPolloWork server ──> OpenCode
-          │
-          └── optional account/control requests ──> iPolloCloud
+Codex / MCP clients ── ipollowork-ui-mcp ──> iPolloWork desktop/UI
+                                                   │
+                                                   ├── local API ──> Engine Protocol ──> OpenCode (default)
+                                                   │                               └──> DeepSeek Harness (optional)
+                                                   └── optional account/control requests ──> iPolloCloud
 ```
 
-- エージェントの実行とストリーミングは、Work/Worker パス上で行われます。
+- エージェント実行、タスク状態、ストリーミングは共通エンジン境界で正規化し、エンジン固有の挙動は各アダプター内に保持します。
+- ポータブルな Skills、プラグイン、MCP サーバー、プロジェクト機能は一つのライフサイクルを使い、エンジン固有の拡張は任意です。
+- Codex 互換性は現在 MCP 制御インターフェース経由であり、ネイティブ Codex エンジンアダプターが存在すると誤認させません。
 - iPolloCloud は、ID、組織、権限、ホスト型 Worker のライフサイクル、管理機能、商用アプリを担当します。
+- OpenCode と DeepSeek Harness は独立コンポーネントのまま進化でき、iPolloWork がどちらかのフォークになることはありません。
 - Cloud 接続は任意です。ローカルの iPolloWork は、アカウントや商用サービスなしで動作します。
-- OpenCode は独立したコンポーネントのままであり、独立してアップグレードを続けられます。
 
 ## リポジトリ構成
 

--- a/docs/translations/README_ZH.md
+++ b/docs/translations/README_ZH.md
@@ -20,13 +20,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**一个本地优先的可视化 AI 工作台：从一个目标出发，直接产出可继续编辑的代码、文档、演示稿、网站、设计和视频，也是 Codex 与 Claude Code 的源码可用替代方案。**
+**面向人与智能体团队的企业级、本地优先 Agent Workbench：在一个工作空间里规划、协作，并持续编辑代码、文档、演示稿、网站、设计和视频。**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork 让 AI 智能体在一个工作空间里处理代码仓库、本地文件、浏览器任务、文档、演示稿、网站、设计和视频。你描述目标，智能体负责规划和执行；你可以检查过程、批准操作，并在同一个地方继续编辑结果。
+iPolloWork 是面向下一代 Agent 原生工作方式的工作台层。它把项目、智能体、任务、日程、插件、Skills、MCP 工具和可编辑成果放进同一个控制界面。你描述目标，智能体负责规划和执行；团队可以检查进度、批准操作，并在同一个地方继续编辑结果。
 
-Codex 式编码只是起点。当结果变成演示稿、网页、视觉设计或视频时，iPolloWork 仍然让它保持可编辑，而不是只交付一个成品文件或一段聊天记录。
+iPolloWork 不再把自己定义成某一个编程智能体的“平替”。它是连接 [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode 和未来智能体运行时的开放工作台，同时保留各个生态自身的原生优势。编程只是起点：当结果变成演示稿、网页、视觉设计或视频时，它仍然可以继续编辑，而不是只留下一个成品文件或一段聊天记录。
 
 <div align="center">
   <h3>加入 iPolloWork 官方微信群</h3>
@@ -34,18 +34,30 @@ Codex 式编码只是起点。当结果变成演示稿、网页、视觉设计�
   <img src="../assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 官方微信群二维码" width="220" />
 </div>
 
-## 它真正解决的三件事
+## 它真正解决的核心问题
 
-- **智能体执行** — 规划工作、调用工具、读写文件、运行命令，并从当前状态继续推进。
-- **结果可编辑** — 从代码延伸到文档、网站、演示稿、设计和视频；生成之后，文字、图片、布局和画面仍能继续修改。
-- **本地可控** — 在自己的设备上运行，接入自己的模型或服务商，逐项批准权限，并通过 Skills、插件、MCP 服务和浏览器自动化扩展能力。
-- **双智能体生态协作** — 正在原生接入 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 子代理，让 iPolloWork 可以把边界明确的任务交给 DSH，同时两边继续使用各自的 Skills 和插件生态。
+- **项目原生协作** — 人与智能体围绕同一个项目查看职责、任务、日程、执行健康和成果，不再把工作拆散在彼此孤立的对话里。
+- **兼容运行时，而不是替代运行时** — OpenCode 提供默认本地执行，DeepSeek Harness 可作为可选原生运行时和委派目标，Codex 或其他 MCP 客户端可以通过语义控制接口操作 iPolloWork。
+- **一体化可编辑创作** — 从代码延伸到文档、网站、演示稿、设计和视频；生成之后，文字、图片、布局、时间线和画面仍能继续修改。
+- **可组合扩展** — Skills、插件、MCP 服务、模型渠道、浏览器自动化和引擎原生能力可以按需加入，不把整个工作台绑定到某一个智能体框架。
+- **本地与企业可控** — 可以完全在本地运行、自选模型或服务商、逐项审核权限和执行；团队需要时再连接组织服务。
 
-## DeepSeek Harness 子代理协作
+## 智能体运行时兼容
 
-iPolloWork 正在将 [DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 作为可选子代理运行时原生接入。该功能目前仍在积极开发，尚未包含在最新稳定版中。
+OpenCode 是目前默认的本地执行运行时。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 已作为可选同级运行时和子代理委派目标接入；[Codex](https://github.com/openai/codex) 与其他支持 MCP 的客户端则可以通过 [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 控制界面接入。它们共享同一个工作台，但不会假装所有运行时都拥有完全相同的原生能力。
 
-协作方式保持简单：iPolloWork 仍然是主工作空间；需要时，一个任务可以把边界明确的工作交给 DSH 子代理，再把结构化结果带回同一个任务。iPolloWork 与 DSH 保留各自的 Skills 和插件生态，让用户同时获得两边的能力，而不需要替换任何一方。
+协作方式保持简单：iPolloWork 是项目工作台；需要时，一个任务可以把边界明确的工作交给 DSH 子代理，再把结构化进度和结果带回同一个项目。各运行时继续保留自己的智能体、Skills、插件和执行机制。
+
+### 在 DeepSeek Harness 中直接启动 iPolloWork 创作插件
+
+DeepSeek Harness 用户可以把 iPolloWork 的 Design、PPT 和 Video 原生视图安装到 DSH Web 界面，并从任意项目目录启动：
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo
+npx @deepseek-ai/dsh web
+```
+
+打开 [http://127.0.0.1:3080](http://127.0.0.1:3080)，新建对话后选择 **Design**、**PPT** 或 **Video**。如果已经安装 `dsh` 命令，可以把 `npx @deepseek-ai/dsh` 直接替换成 `dsh`。DeepSeek Harness 目前仍处于开发者预览阶段，插件兼容性会跟随其活跃版本线。
 
 ## 安装 iPolloWork
 
@@ -163,15 +175,19 @@ corepack enable
 ## 架构边界
 
 ```text
-iPolloWork 桌面/UI ──> iPolloWork Server ──> OpenCode
-        │
-        └── 可选账号与控制请求 ──> iPolloCloud
+Codex / MCP 客户端 ── ipollowork-ui-mcp ──> iPolloWork 桌面/UI
+                                                 │
+                                                 ├── 本地 API ──> Engine Protocol ──> OpenCode（默认）
+                                                 │                                  └──> DeepSeek Harness（可选）
+                                                 └── 可选账号与控制请求 ──> iPolloCloud
 ```
 
-- 智能体执行和流式数据保持在 Work/Worker 路径。
+- 智能体执行、任务状态和流式数据在统一引擎边界规范化，引擎原生行为仍留在各自适配器中。
+- 可移植的 Skills、插件、MCP 服务和项目能力使用同一生命周期，引擎专属增强保持可选。
+- Codex 当前通过 MCP 控制界面兼容接入，不会被误写成已经存在的 Codex 原生引擎适配器。
 - Cloud 负责账号、组织、权益、托管 Worker 生命周期、管理后台和商业 App。
 - 不连接 Cloud 时，iPolloWork 仍可完整本地运行。
-- iPolloWork 不修改 OpenCode，OpenCode 可以继续独立升级。
+- iPolloWork 不会 fork OpenCode 或 DeepSeek Harness，两者都可以继续独立演进。
 
 ## Star 增长趋势
 

--- a/docs/translations/README_ZH_hk.md
+++ b/docs/translations/README_ZH_hk.md
@@ -22,13 +22,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**一個本地優先的可視化 AI 工作台：從一個目標出發，直接產出可繼續編輯的代碼、文檔、演示稿、網站、設計和視頻，也是 Codex 與 Claude Code 的源碼可用替代方案。**
+**面向人與智能體團隊的企業級、本地優先 Agent Workbench：在一個工作空間裏規劃、協作，並持續編輯代碼、文檔、演示稿、網站、設計和視頻。**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork 讓 AI 智能體在一個工作空間裏處理代碼倉庫、本地文件、瀏覽器任務、文檔、演示稿、網站、設計和視頻。你描述目標，智能體負責規劃和執行；你可以檢查過程、批准操作，並在同一個地方繼續編輯結果。
+iPolloWork 是面向下一代 Agent 原生工作方式的工作台層。它把項目、智能體、任務、日程、插件、Skills、MCP 工具和可編輯成果放進同一個控制界面。你描述目標，智能體負責規劃和執行；團隊可以檢查進度、批准操作，並在同一個地方繼續編輯結果。
 
-Codex 式編碼只是起點。當結果變成演示稿、網頁、視覺設計或視頻時，iPolloWork 仍然讓它保持可編輯，而不是隻交付一個成品文件或一段聊天記錄。
+iPolloWork 不再把自己定義成某一個編程智能體的“平替”。它是連接 [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode 和未來智能體運行時的開放工作台，同時保留各個生態自身的原生優勢。編程只是起點：當結果變成演示稿、網頁、視覺設計或視頻時，它仍然可以繼續編輯，而不是隻留下一個成品文件或一段聊天記錄。
 
 <div align="center">
   <h3>加入 iPolloWork 官方微信羣</h3>
@@ -36,18 +36,30 @@ Codex 式編碼只是起點。當結果變成演示稿、網頁、視覺設計�
   <img src="../assets/ipollowork-official-wechat-group.jpg" alt="iPolloWork 官方微信羣二維碼" width="220" />
 </div>
 
-## 它真正解決的三件事
+## 它真正解決的核心問題
 
-- **智能體執行** — 規劃工作、調用工具、讀寫文件、運行命令，並從當前狀態繼續推進。
-- **結果可編輯** — 從代碼延伸到文檔、網站、演示稿、設計和視頻；生成之後，文字、圖片、佈局和畫面仍能繼續修改。
-- **本地可控** — 在自己的設備上運行，接入自己的模型或服務商，逐項批准權限，並通過 Skills、插件、MCP 服務和瀏覽器自動化擴展能力。
-- **雙智能體生態協作** — 正在原生接入 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 子代理，讓 iPolloWork 可以把邊界明確的任務交給 DSH，同時兩邊繼續使用各自的 Skills 和插件生態。
+- **項目原生協作** — 人與智能體圍繞同一個項目查看職責、任務、日程、執行健康和成果，不再把工作拆散在彼此孤立的對話裏。
+- **兼容運行時，而不是替代運行時** — OpenCode 提供默認本地執行，DeepSeek Harness 可作為可選原生運行時和委派目標，Codex 或其他 MCP 客户端可以通過語義控制接口操作 iPolloWork。
+- **一體化可編輯創作** — 從代碼延伸到文檔、網站、演示稿、設計和視頻；生成之後，文字、圖片、佈局、時間線和畫面仍能繼續修改。
+- **可組合擴展** — Skills、插件、MCP 服務、模型渠道、瀏覽器自動化和引擎原生能力可以按需加入，不把整個工作台綁定到某一個智能體框架。
+- **本地與企業可控** — 可以完全在本地運行、自選模型或服務商、逐項審核權限和執行；團隊需要時再連接組織服務。
 
-## DeepSeek Harness 子代理協作
+## 智能體運行時兼容
 
-iPolloWork 正在將 [DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 作為可選子代理運行時原生接入。該功能目前仍在積極開發，尚未包含在最新穩定版中。
+OpenCode 是目前默認的本地執行運行時。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 已作為可選同級運行時和子代理委派目標接入；[Codex](https://github.com/openai/codex) 與其他支持 MCP 的客户端則可以通過 [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 控制界面接入。它們共享同一個工作台，但不會假裝所有運行時都擁有完全相同的原生能力。
 
-協作方式保持簡單：iPolloWork 仍然是主工作空間；需要時，一個任務可以把邊界明確的工作交給 DSH 子代理，再把結構化結果帶回同一個任務。iPolloWork 與 DSH 保留各自的 Skills 和插件生態，讓用户同時獲得兩邊的能力，而不需要替換任何一方。
+協作方式保持簡單：iPolloWork 是項目工作台；需要時，一個任務可以把邊界明確的工作交給 DSH 子代理，再把結構化進度和結果帶回同一個項目。各運行時繼續保留自己的智能體、Skills、插件和執行機制。
+
+### 在 DeepSeek Harness 中直接啓動 iPolloWork 創作插件
+
+DeepSeek Harness 用户可以把 iPolloWork 的 Design、PPT 和 Video 原生視圖安裝到 DSH Web 界面，並從任意項目目錄啓動：
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo
+npx @deepseek-ai/dsh web
+```
+
+打開 [http://127.0.0.1:3080](http://127.0.0.1:3080)，新建對話後選擇 **Design**、**PPT** 或 **Video**。如果已經安裝 `dsh` 命令，可以把 `npx @deepseek-ai/dsh` 直接替換成 `dsh`。DeepSeek Harness 目前仍處於開發者預覽階段，插件兼容性會跟隨其活躍版本線。
 
 ## 安裝 iPolloWork
 
@@ -165,15 +177,19 @@ corepack enable
 ## 架構邊界
 
 ```text
-iPolloWork 桌面/UI ──> iPolloWork Server ──> OpenCode
-        │
-        └── 可選賬號與控制請求 ──> iPolloCloud
+Codex / MCP 客户端 ── ipollowork-ui-mcp ──> iPolloWork 桌面/UI
+                                                 │
+                                                 ├── 本地 API ──> Engine Protocol ──> OpenCode（默認）
+                                                 │                                  └──> DeepSeek Harness（可選）
+                                                 └── 可選賬號與控制請求 ──> iPolloCloud
 ```
 
-- 智能體執行和流式數據保持在 Work/Worker 路徑。
+- 智能體執行、任務狀態和流式數據在統一引擎邊界規範化，引擎原生行為仍留在各自適配器中。
+- 可移植的 Skills、插件、MCP 服務和項目能力使用同一生命週期，引擎專屬增強保持可選。
+- Codex 當前通過 MCP 控制界面兼容接入，不會被誤寫成已經存在的 Codex 原生引擎適配器。
 - Cloud 負責賬號、組織、權益、託管 Worker 生命週期、管理後台和商業 App。
 - 不連接 Cloud 時，iPolloWork 仍可完整本地運行。
-- iPolloWork 不修改 OpenCode，OpenCode 可以繼續獨立升級。
+- iPolloWork 不會 fork OpenCode 或 DeepSeek Harness，兩者都可以繼續獨立演進。
 
 ## Star 增長趨勢
 


### PR DESCRIPTION
## Summary\n\n- Reposition iPolloWork as an enterprise-grade, local-first Agent Workbench rather than a Codex replacement.\n- Describe the distinct OpenCode, DeepSeek Harness, and Codex/MCP integration paths.\n- Add direct DeepSeek Harness commands for the iPolloWork Design, PPT, and Video plugins.\n- Keep English, Simplified Chinese, generated Traditional Chinese, and Japanese README introductions aligned.\n\n## Validation\n\n- pnpm readme:zh-hant --check\n- git diff --check\n- Maintainable-code audit: 4 files checked, no errors or warnings.\n\nRepository metadata was updated separately: removed the openclaw topic; added codex-plugin, deepseek-harness-npm, and multi-agent-workspace; refreshed the short description.