### PR TITLE
docs: emphasize the unified Agent Workbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**An enterprise-grade, local-first Agent Workbench for people and agent teams—plan, collaborate, and create editable code, documents, presentations, websites, designs, and videos in one workspace.**
+**The enterprise-grade, local-first Agent Workbench for people and agent teams—one workspace for multiple agent engines, one unified system for plugins and Skills, multi-agent projects and tasks, and editable creation across code, documents, presentations, websites, design, and video.**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork is the workspace layer for the next agent-native way of working. It brings projects, agents, tasks, schedules, plugins, Skills, MCP tools, and editable outputs into one control surface. Describe the outcome; agents plan and execute; your team reviews progress, approves actions, and keeps editing the result in the same place.
+iPolloWork is the unified workspace layer for the next agent-native way of working. It does not split projects or extensions by runtime: teams coordinate agents, tasks, schedules, plugins, Skills, tools, execution, and editable outputs from one control surface. Describe the outcome; agents plan and execute; your team reviews progress, approves actions, and keeps editing the result in the same place.
 
-iPolloWork is not positioned as a replacement for a single coding agent. It is an open workbench that connects [Codex](https://github.com/openai/codex), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), OpenCode, and future agent runtimes while preserving the native strengths of each ecosystem. Coding is only the starting point: when the output is a deck, web page, visual design, or video, it remains editable instead of becoming a finished file or a chat transcript.
+iPolloWork is not positioned as a replacement for a single coding agent. It connects [Codex](https://github.com/openai/codex), [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness), OpenCode, and future agent runtimes through explicit compatibility boundaries while preserving the native strengths of each ecosystem. Coding is only the starting point: when the output is a deck, web page, visual design, or video, it remains editable instead of becoming a finished file or a chat transcript.
 
 <div align="center">
   <h3>Join the official iPolloWork WeChat community</h3>
@@ -36,21 +36,26 @@ iPolloWork is not positioned as a replacement for a single coding agent. It is a
 
 ## What makes it different
 
-- **Project-native collaboration** — give people and agents one shared project view for responsibilities, tasks, schedules, execution health, and results instead of scattering work across isolated chats.
-- **Runtime-open, not a replacement** — OpenCode powers the default local runtime, DeepSeek Harness can run as an optional native runtime and delegation target, and Codex or any MCP client can operate iPolloWork through its semantic control surface.
-- **One editable creation loop** — move from code to documents, websites, presentations, design, and video while keeping text, images, layouts, timelines, and scenes editable after generation.
-- **Composable by design** — add Skills, plugins, MCP servers, model providers, browser automation, and engine-native capabilities without binding the whole workspace to one agent framework.
-- **Local and enterprise control** — run locally, bring your own model or provider, review permissions and execution, and connect organization services when a team needs them.
+- **One workbench across agent engines** — use Codex, DeepSeek Harness, OpenCode, and future runtimes without rebuilding the project experience around each engine.
+- **One global extension system** — install, enable, update, and uninstall portable plugins, Skills, agents, commands, services, and authorization once; optional engine-native bindings stay behind the same lifecycle.
+- **Project-native human-agent collaboration** — give people and agents one shared project view for responsibilities, tasks, schedules, execution health, and results instead of scattering work across isolated chats.
+- **One editable production loop** — move from code to documents, websites, presentations, design, and video while keeping text, images, layouts, timelines, and scenes editable after generation.
+- **Local and enterprise control** — run locally, bring your own model or provider, review permissions and execution, and connect organization services only when a team needs them.
 
 ## Agent runtime compatibility
 
-OpenCode is the default local execution runtime today. [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) is integrated as an optional peer runtime and subagent delegation target, while [Codex](https://github.com/openai/codex) and other MCP-compatible clients can connect through the [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) control surface. These paths share the workbench without pretending that every runtime has the same native capabilities.
+OpenCode is the default local execution runtime today. [DeepSeek Harness (DSH)](https://github.com/deepseek-ai/deepseek-harness) is integrated as an optional peer runtime and subagent delegation target, while [Codex](https://github.com/openai/codex) connects through the [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) control surface. MCP is the integration protocol for that path, not another agent engine alongside Codex, DSH, and OpenCode. These paths share the workbench without pretending that every runtime has the same native capabilities.
 
 The collaboration model keeps iPolloWork as the project workspace: a task can delegate bounded work to DSH subagents when useful, then bring structured progress and results back into the same project. Each runtime retains its own agents, Skills, plugins, and execution model.
 
 ### Run iPolloWork creative plugins directly in DeepSeek Harness
 
 DeepSeek Harness users can install iPolloWork's native Design, PPT, and Video views into the DSH Web UI and start them from any project directory:
+
+<p>
+  <a href="https://www.npmjs.com/package/deepseek-idesign"><img src="https://img.shields.io/npm/v/deepseek-idesign?label=DeepSeek%20Design&amp;logo=npm&amp;color=CB3837" alt="deepseek-idesign npm version" /></a>
+  <a href="https://www.npmjs.com/package/deepseek-ivideo"><img src="https://img.shields.io/npm/v/deepseek-ivideo?label=DeepSeek%20Video&amp;logo=npm&amp;color=CB3837" alt="deepseek-ivideo npm version" /></a>
+</p>
 
 ```bash
 npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo

--- a/docs/translations/README_JA.md
+++ b/docs/translations/README_JA.md
@@ -20,13 +20,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**人とエージェントチームのための、エンタープライズ対応・ローカルファーストの Agent Workbench。コード、文書、プレゼン、Webサイト、デザイン、動画を一つのワークスペースで計画・共同作業・継続編集できます。**
+**人とエージェントチームのための、エンタープライズ対応・ローカルファーストの Agent Workbench。複数エンジンと統一されたプラグイン／Skill システム、マルチエージェントのプロジェクトとタスク、コード・文書・プレゼン・Webサイト・デザイン・動画の編集可能な制作を一つのワークスペースに統合します。**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork は、次世代のエージェントネイティブな働き方を支えるワークスペースレイヤーです。プロジェクト、エージェント、タスク、スケジュール、プラグイン、Skills、MCP ツール、編集可能な成果物を一つの操作画面に統合します。目的を伝えるとエージェントが計画して実行し、チームは進捗を確認し、操作を承認し、同じ場所で成果物を編集し続けられます。
+iPolloWork は、次世代のエージェントネイティブな働き方を支える統一ワークスペースレイヤーです。ランタイムごとにプロジェクトや拡張機能を分断せず、エージェント、タスク、スケジュール、プラグイン、Skills、ツール、実行状況、編集可能な成果物を一つの操作画面に統合します。目的を伝えるとエージェントが計画して実行し、チームは進捗を確認し、操作を承認し、同じ場所で成果物を編集し続けられます。
 
-iPolloWork は、特定のコーディングエージェントの代替を目指す製品ではありません。[Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode、そして将来のエージェントランタイムを接続しながら、それぞれのエコシステム固有の強みを保つオープンなワークベンチです。コーディングは出発点にすぎず、スライド、Web ページ、ビジュアルデザイン、動画も、完成ファイルやチャット記録で終わらず編集可能なまま残ります。
+iPolloWork は、特定のコーディングエージェントの代替を目指す製品ではありません。明確な互換境界を通じて [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode、そして将来のエージェントランタイムを接続しながら、それぞれのエコシステム固有の強みを保ちます。コーディングは出発点にすぎず、スライド、Web ページ、ビジュアルデザイン、動画も、完成ファイルやチャット記録で終わらず編集可能なまま残ります。
 
 <div align="center">
   <h3>iPolloWork 公式 WeChat コミュニティに参加</h3>
@@ -36,21 +36,26 @@ iPolloWork は、特定のコーディングエージェントの代替を目指
 
 ## iPolloWork の違い
 
-- **プロジェクト中心の共同作業** — 人とエージェントが、役割、タスク、スケジュール、実行状態、成果物を同じプロジェクト画面で共有し、孤立したチャットに作業を分散させません。
-- **ランタイムを置き換えずに接続** — OpenCode が標準ローカルランタイムを担い、DeepSeek Harness は任意のネイティブランタイム兼委任先として動作します。Codex や他の MCP クライアントは、セマンティックな制御インターフェースから iPolloWork を操作できます。
+- **複数エンジン、一つのワークベンチ** — Codex、DeepSeek Harness、OpenCode、将来のランタイムに対応し、エンジンごとにプロジェクト体験を作り直す必要がありません。
+- **統一されたグローバル拡張システム** — ポータブルなプラグイン、Skills、エージェント、コマンド、サービス、認証を一度だけインストール・有効化・更新・削除し、任意のエンジン固有バインディングも同じライフサイクルで管理します。
+- **プロジェクト中心の人とエージェントの共同作業** — 役割、タスク、スケジュール、実行状態、成果物を同じプロジェクト画面で共有し、孤立したチャットに作業を分散させません。
 - **一つの編集可能な制作ループ** — コードから文書、Web サイト、プレゼン、デザイン、動画まで、生成後もテキスト、画像、レイアウト、タイムライン、シーンを変更できます。
-- **組み合わせ可能な拡張性** — Skills、プラグイン、MCP サーバー、モデルプロバイダー、ブラウザ自動化、エンジン固有機能を必要に応じて追加できます。
-- **ローカルとエンタープライズの管理** — ローカル実行、モデル選択、権限と実行の確認を保ち、チームで必要なときだけ組織サービスへ接続できます。
+- **ローカルとエンタープライズの管理** — ローカル実行、モデル選択、権限と実行の確認を保ち、チームで本当に必要なときだけ組織サービスへ接続できます。
 
 ## エージェントランタイムの互換性
 
-OpenCode は現在の標準ローカル実行ランタイムです。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) は任意のピアランタイム兼サブエージェント委任先として統合され、[Codex](https://github.com/openai/codex) と他の MCP 対応クライアントは [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 制御インターフェースから接続できます。すべてが同じワークベンチを利用しますが、各ランタイムのネイティブ機能が同一であるとは扱いません。
+OpenCode は現在の標準ローカル実行ランタイムです。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) は任意のピアランタイム兼サブエージェント委任先として統合され、[Codex](https://github.com/openai/codex) は [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 制御インターフェースから接続します。MCP はこの接続経路で使うプロトコルであり、Codex、DSH、OpenCode と並ぶ別のエージェントエンジンではありません。すべてが同じワークベンチを利用しますが、各ランタイムのネイティブ機能が同一であるとは扱いません。
 
 連携モデルはシンプルです。iPolloWork をプロジェクトワークベンチとして維持し、必要に応じて範囲を限定した作業を DSH サブエージェントに委任し、構造化された進捗と結果を同じプロジェクトへ戻します。各ランタイムは独自のエージェント、Skills、プラグイン、実行モデルを維持します。
 
 ### DeepSeek Harness で iPolloWork の制作プラグインを直接起動する
 
 DeepSeek Harness の Web UI に、iPolloWork のネイティブ Design、PPT、Video ビューをインストールし、任意のプロジェクトディレクトリから起動できます。
+
+<p>
+  <a href="https://www.npmjs.com/package/deepseek-idesign"><img src="https://img.shields.io/npm/v/deepseek-idesign?label=DeepSeek%20Design&amp;logo=npm&amp;color=CB3837" alt="deepseek-idesign npm version" /></a>
+  <a href="https://www.npmjs.com/package/deepseek-ivideo"><img src="https://img.shields.io/npm/v/deepseek-ivideo?label=DeepSeek%20Video&amp;logo=npm&amp;color=CB3837" alt="deepseek-ivideo npm version" /></a>
+</p>
 
 ```bash
 npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo

--- a/docs/translations/README_ZH.md
+++ b/docs/translations/README_ZH.md
@@ -20,13 +20,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**面向人与智能体团队的企业级、本地优先 Agent Workbench：在一个工作空间里规划、协作，并持续编辑代码、文档、演示稿、网站、设计和视频。**
+**面向人与智能体团队的企业级、本地优先 Agent Workbench：在一个工作空间内统一多引擎、统一插件与 Skills，管理多智能体项目和任务，并持续编辑代码、文档、演示稿、网站、设计和视频。**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork 是面向下一代 Agent 原生工作方式的工作台层。它把项目、智能体、任务、日程、插件、Skills、MCP 工具和可编辑成果放进同一个控制界面。你描述目标，智能体负责规划和执行；团队可以检查进度、批准操作，并在同一个地方继续编辑结果。
+iPolloWork 是面向下一代 Agent 原生工作方式的统一工作台层。它不会按运行时割裂项目和扩展，而是把智能体、任务、日程、插件、Skills、工具、执行过程和可编辑成果放进同一个控制界面。你描述目标，智能体负责规划和执行；团队可以检查进度、批准操作，并在同一个地方继续编辑结果。
 
-iPolloWork 不再把自己定义成某一个编程智能体的“平替”。它是连接 [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode 和未来智能体运行时的开放工作台，同时保留各个生态自身的原生优势。编程只是起点：当结果变成演示稿、网页、视觉设计或视频时，它仍然可以继续编辑，而不是只留下一个成品文件或一段聊天记录。
+iPolloWork 不再把自己定义成某一个编程智能体的“平替”。它通过明确的兼容边界连接 [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode 和未来智能体运行时，同时保留各个生态自身的原生优势。编程只是起点：当结果变成演示稿、网页、视觉设计或视频时，它仍然可以继续编辑，而不是只留下一个成品文件或一段聊天记录。
 
 <div align="center">
   <h3>加入 iPolloWork 官方微信群</h3>
@@ -36,21 +36,26 @@ iPolloWork 不再把自己定义成某一个编程智能体的“平替”。它
 
 ## 它真正解决的核心问题
 
-- **项目原生协作** — 人与智能体围绕同一个项目查看职责、任务、日程、执行健康和成果，不再把工作拆散在彼此孤立的对话里。
-- **兼容运行时，而不是替代运行时** — OpenCode 提供默认本地执行，DeepSeek Harness 可作为可选原生运行时和委派目标，Codex 或其他 MCP 客户端可以通过语义控制接口操作 iPolloWork。
-- **一体化可编辑创作** — 从代码延伸到文档、网站、演示稿、设计和视频；生成之后，文字、图片、布局、时间线和画面仍能继续修改。
-- **可组合扩展** — Skills、插件、MCP 服务、模型渠道、浏览器自动化和引擎原生能力可以按需加入，不把整个工作台绑定到某一个智能体框架。
-- **本地与企业可控** — 可以完全在本地运行、自选模型或服务商、逐项审核权限和执行；团队需要时再连接组织服务。
+- **多引擎，一个工作台** — 兼容 Codex、DeepSeek Harness、OpenCode 和未来运行时，不需要围绕每个引擎重新搭建项目体验。
+- **统一的全局扩展系统** — 插件、Skills、智能体、命令、服务和授权只需安装、启用、更新或卸载一次；可选的引擎原生绑定仍归同一生命周期管理。
+- **项目原生的人机协作** — 人与智能体围绕同一个项目查看职责、任务、日程、执行健康和成果，不再把工作拆散在彼此孤立的对话里。
+- **一体化可编辑生产** — 从代码延伸到文档、网站、演示稿、设计和视频；生成之后，文字、图片、布局、时间线和画面仍能继续修改。
+- **本地与企业可控** — 可以完全在本地运行、自选模型或服务商、逐项审核权限和执行；团队真正需要时再连接组织服务。
 
 ## 智能体运行时兼容
 
-OpenCode 是目前默认的本地执行运行时。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 已作为可选同级运行时和子代理委派目标接入；[Codex](https://github.com/openai/codex) 与其他支持 MCP 的客户端则可以通过 [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 控制界面接入。它们共享同一个工作台，但不会假装所有运行时都拥有完全相同的原生能力。
+OpenCode 是目前默认的本地执行运行时。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 已作为可选同级运行时和子代理委派目标接入；[Codex](https://github.com/openai/codex) 则通过 [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 控制界面接入。MCP 是这条接入路径使用的协议，不是与 Codex、DSH、OpenCode 并列的另一个智能体引擎。它们共享同一个工作台，但不会假装所有运行时都拥有完全相同的原生能力。
 
 协作方式保持简单：iPolloWork 是项目工作台；需要时，一个任务可以把边界明确的工作交给 DSH 子代理，再把结构化进度和结果带回同一个项目。各运行时继续保留自己的智能体、Skills、插件和执行机制。
 
 ### 在 DeepSeek Harness 中直接启动 iPolloWork 创作插件
 
 DeepSeek Harness 用户可以把 iPolloWork 的 Design、PPT 和 Video 原生视图安装到 DSH Web 界面，并从任意项目目录启动：
+
+<p>
+  <a href="https://www.npmjs.com/package/deepseek-idesign"><img src="https://img.shields.io/npm/v/deepseek-idesign?label=DeepSeek%20Design&amp;logo=npm&amp;color=CB3837" alt="deepseek-idesign npm 版本" /></a>
+  <a href="https://www.npmjs.com/package/deepseek-ivideo"><img src="https://img.shields.io/npm/v/deepseek-ivideo?label=DeepSeek%20Video&amp;logo=npm&amp;color=CB3837" alt="deepseek-ivideo npm 版本" /></a>
+</p>
 
 ```bash
 npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo

--- a/docs/translations/README_ZH_hk.md
+++ b/docs/translations/README_ZH_hk.md
@@ -22,13 +22,13 @@
   <a href="https://trendshift.io/repositories/88012?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-88012"><img src="https://trendshift.io/api/badge/trendshift/repositories/88012/weekly?language=TypeScript" alt="#24 TypeScript Repository Of The Week | Trendshift" width="250" height="55" /></a>
 </p>
 
-**面向人與智能體團隊的企業級、本地優先 Agent Workbench：在一個工作空間裏規劃、協作，並持續編輯代碼、文檔、演示稿、網站、設計和視頻。**
+**面向人與智能體團隊的企業級、本地優先 Agent Workbench：在一個工作空間內統一多引擎、統一插件與 Skills，管理多智能體項目和任務，並持續編輯代碼、文檔、演示稿、網站、設計和視頻。**
 
 https://github.com/user-attachments/assets/201b561a-22ec-4c8e-a4e8-f34172cf0aa3
 
-iPolloWork 是面向下一代 Agent 原生工作方式的工作台層。它把項目、智能體、任務、日程、插件、Skills、MCP 工具和可編輯成果放進同一個控制界面。你描述目標，智能體負責規劃和執行；團隊可以檢查進度、批准操作，並在同一個地方繼續編輯結果。
+iPolloWork 是面向下一代 Agent 原生工作方式的統一工作台層。它不會按運行時割裂項目和擴展，而是把智能體、任務、日程、插件、Skills、工具、執行過程和可編輯成果放進同一個控制界面。你描述目標，智能體負責規劃和執行；團隊可以檢查進度、批准操作，並在同一個地方繼續編輯結果。
 
-iPolloWork 不再把自己定義成某一個編程智能體的“平替”。它是連接 [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode 和未來智能體運行時的開放工作台，同時保留各個生態自身的原生優勢。編程只是起點：當結果變成演示稿、網頁、視覺設計或視頻時，它仍然可以繼續編輯，而不是隻留下一個成品文件或一段聊天記錄。
+iPolloWork 不再把自己定義成某一個編程智能體的“平替”。它通過明確的兼容邊界連接 [Codex](https://github.com/openai/codex)、[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)、OpenCode 和未來智能體運行時，同時保留各個生態自身的原生優勢。編程只是起點：當結果變成演示稿、網頁、視覺設計或視頻時，它仍然可以繼續編輯，而不是隻留下一個成品文件或一段聊天記錄。
 
 <div align="center">
   <h3>加入 iPolloWork 官方微信羣</h3>
@@ -38,21 +38,26 @@ iPolloWork 不再把自己定義成某一個編程智能體的“平替”。它
 
 ## 它真正解決的核心問題
 
-- **項目原生協作** — 人與智能體圍繞同一個項目查看職責、任務、日程、執行健康和成果，不再把工作拆散在彼此孤立的對話裏。
-- **兼容運行時，而不是替代運行時** — OpenCode 提供默認本地執行，DeepSeek Harness 可作為可選原生運行時和委派目標，Codex 或其他 MCP 客户端可以通過語義控制接口操作 iPolloWork。
-- **一體化可編輯創作** — 從代碼延伸到文檔、網站、演示稿、設計和視頻；生成之後，文字、圖片、佈局、時間線和畫面仍能繼續修改。
-- **可組合擴展** — Skills、插件、MCP 服務、模型渠道、瀏覽器自動化和引擎原生能力可以按需加入，不把整個工作台綁定到某一個智能體框架。
-- **本地與企業可控** — 可以完全在本地運行、自選模型或服務商、逐項審核權限和執行；團隊需要時再連接組織服務。
+- **多引擎，一個工作台** — 兼容 Codex、DeepSeek Harness、OpenCode 和未來運行時，不需要圍繞每個引擎重新搭建項目體驗。
+- **統一的全局擴展系統** — 插件、Skills、智能體、命令、服務和授權只需安裝、啓用、更新或卸載一次；可選的引擎原生綁定仍歸同一生命週期管理。
+- **項目原生的人機協作** — 人與智能體圍繞同一個項目查看職責、任務、日程、執行健康和成果，不再把工作拆散在彼此孤立的對話裏。
+- **一體化可編輯生產** — 從代碼延伸到文檔、網站、演示稿、設計和視頻；生成之後，文字、圖片、佈局、時間線和畫面仍能繼續修改。
+- **本地與企業可控** — 可以完全在本地運行、自選模型或服務商、逐項審核權限和執行；團隊真正需要時再連接組織服務。
 
 ## 智能體運行時兼容
 
-OpenCode 是目前默認的本地執行運行時。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 已作為可選同級運行時和子代理委派目標接入；[Codex](https://github.com/openai/codex) 與其他支持 MCP 的客户端則可以通過 [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 控制界面接入。它們共享同一個工作台，但不會假裝所有運行時都擁有完全相同的原生能力。
+OpenCode 是目前默認的本地執行運行時。[DeepSeek Harness（DSH）](https://github.com/deepseek-ai/deepseek-harness) 已作為可選同級運行時和子代理委派目標接入；[Codex](https://github.com/openai/codex) 則通過 [`ipollowork-ui-mcp`](https://www.npmjs.com/package/ipollowork-ui-mcp) 控制界面接入。MCP 是這條接入路徑使用的協議，不是與 Codex、DSH、OpenCode 並列的另一個智能體引擎。它們共享同一個工作台，但不會假裝所有運行時都擁有完全相同的原生能力。
 
 協作方式保持簡單：iPolloWork 是項目工作台；需要時，一個任務可以把邊界明確的工作交給 DSH 子代理，再把結構化進度和結果帶回同一個項目。各運行時繼續保留自己的智能體、Skills、插件和執行機制。
 
 ### 在 DeepSeek Harness 中直接啓動 iPolloWork 創作插件
 
 DeepSeek Harness 用户可以把 iPolloWork 的 Design、PPT 和 Video 原生視圖安裝到 DSH Web 界面，並從任意項目目錄啓動：
+
+<p>
+  <a href="https://www.npmjs.com/package/deepseek-idesign"><img src="https://img.shields.io/npm/v/deepseek-idesign?label=DeepSeek%20Design&amp;logo=npm&amp;color=CB3837" alt="deepseek-idesign npm 版本" /></a>
+  <a href="https://www.npmjs.com/package/deepseek-ivideo"><img src="https://img.shields.io/npm/v/deepseek-ivideo?label=DeepSeek%20Video&amp;logo=npm&amp;color=CB3837" alt="deepseek-ivideo npm 版本" /></a>
+</p>
 
 ```bash
 npx @deepseek-ai/dsh plugin --profile web add deepseek-idesign deepseek-ippt deepseek-ivideo


### PR DESCRIPTION
## Summary\n\n- Make the core positioning explicit: multiple agent engines, one unified plugin and Skills system, project-native human-agent collaboration, and editable production across code, documents, presentations, design, and video.\n- Keep MCP in the lower technical explanation as an integration protocol instead of listing it as a peer engine.\n- Add dynamic npm version badges for DeepSeek Design and DeepSeek Video below the DeepSeek Harness section, without changing the top badge group.\n- Keep English, Simplified Chinese, generated Traditional Chinese, and Japanese positioning aligned.\n\n## Validation\n\n- pnpm readme:zh-hant --check\n- git diff --check\n- Maintainable-code audit: 4 files checked, no errors or warnings.\n- Both npm version badge endpoints return HTTP 200.\n\nRepository metadata was updated separately: the short description now emphasizes multiple engines and unified plugins and Skills; the mistaken deepseek-harness-npm topic was removed.