### PR TITLE
feat(browser): complete semantic action protocol

### DIFF
--- a/apps/desktop/electron/browser-runtime.mjs
+++ b/apps/desktop/electron/browser-runtime.mjs
@@ -9,7 +9,10 @@ const MAX_UPLOAD_FILES = 20;
 const MAX_UPLOAD_FILE_BYTES = 1024 * 1024 * 1024;
 const MAX_INFERRED_CONTROLS = 32;
 const MAX_WAIT_MS = 2_000;
-const MAX_TOTAL_WAIT_MS = 5_000;
+const DEFAULT_WAIT_FOR_MS = 5_000;
+const MAX_WAIT_FOR_MS = 10_000;
+const MAX_TOTAL_WAIT_MS = 10_000;
+const WAIT_POLL_MS = 100;
 const MAX_EXPECTED_NAME = 200;
 const MAX_DEBUGGER_COMMAND_MS = 5_000;
 
@@ -34,7 +37,10 @@ const INTERACTIVE_ROLES = new Set([
 ]);
 const CONTENT_ROLES = new Set(["heading", "listitem", "paragraph", "StaticText"]);
 const WRITABLE_ROLES = new Set(["combobox", "searchbox", "textbox"]);
-const SAFE_KEYS = new Set([
+const CHECKABLE_ROLES = new Set(["checkbox", "menuitemcheckbox", "menuitemradio", "radio", "switch"]);
+const RADIO_ROLES = new Set(["menuitemradio", "radio"]);
+const ACTIVATABLE_ROLES = new Set(["button", "link", "menuitem", "option", "tab", "treeitem"]);
+const NAVIGATION_KEYS = new Set([
   "ArrowDown",
   "ArrowLeft",
   "ArrowRight",
@@ -46,6 +52,8 @@ const SAFE_KEYS = new Set([
   "PageUp",
   "Tab",
 ]);
+const ACTIVATION_KEYS = new Set(["Enter", "Space"]);
+const SCROLL_DISTANCE = { small: 320, page: 800 };
 
 function normalizeText(value) {
   return String(value ?? "").replace(/\s+/g, " ").trim();
@@ -162,7 +170,7 @@ function snapshotLine(node, ref, depth) {
 }
 
 function automationMetadataFunction() {
-  return `function (scrollIntoView) {
+  return `function inspectAutomationTarget(scrollIntoView) {
     if (scrollIntoView) this.scrollIntoView?.({ block: "center", inline: "center", behavior: "instant" });
     const tag = this.tagName?.toUpperCase?.() || "";
     const type = this.getAttribute?.("type")?.toLowerCase?.() || "";
@@ -203,15 +211,19 @@ function automationMetadataFunction() {
         currentWindow = frame.ownerDocument?.defaultView;
       }
     } catch { /* keep local coordinates if a frame boundary refuses access */ }
-    const buttonLike = tag === "BUTTON" || role === "button" || tag === "A"
-      || (tag === "INPUT" && ["button", "submit", "checkbox", "radio"].includes(type))
+    const checkable = ["checkbox", "radio"].includes(type)
+      || ["checkbox", "menuitemcheckbox", "menuitemradio", "radio", "switch"].includes(role);
+    const buttonLike = tag === "BUTTON" || role === "button" || tag === "A" || checkable
+      || (tag === "INPUT" && ["button", "submit"].includes(type))
       || style.cursor === "pointer";
     const writable = tag === "TEXTAREA" || (tag === "INPUT" && !["button", "submit", "checkbox", "radio", "file"].includes(type))
       || this.isContentEditable === true;
     return {
       buttonLike,
+      checkable,
       disabled: Boolean(this.disabled || this.readOnly || this.getAttribute?.("aria-disabled") === "true"),
       fileInput: tag === "INPUT" && type === "file",
+      nativeSelect: tag === "SELECT",
       visible: rect.width > 0 && rect.height > 0 && rect.right > 0 && rect.bottom > 0
         && rect.left < viewportWidth && rect.top < viewportHeight
         && style.display !== "none" && style.visibility !== "hidden" && style.pointerEvents !== "none",
@@ -221,6 +233,29 @@ function automationMetadataFunction() {
       x: (localPoint?.x ?? 0) + offsetX,
       y: (localPoint?.y ?? 0) + offsetY,
     };
+  }`;
+}
+
+function selectExactOptionFunction() {
+  return `function selectExactOption(requestedOption) {
+    if (this.tagName?.toUpperCase?.() !== "SELECT") return { ok: false, reason: "not_select" };
+    const normalize = (value) => String(value ?? "").replace(/\\s+/g, " ").trim();
+    const requested = normalize(requestedOption);
+    const options = Array.from(this.options ?? []);
+    const labelMatches = options.filter((option) => normalize(option.label || option.textContent) === requested);
+    const valueMatches = options.filter((option) => String(option.value) === requestedOption);
+    const matches = labelMatches.length > 0 ? labelMatches : valueMatches;
+    if (matches.length === 0) return { ok: false, reason: "not_found" };
+    if (matches.length > 1) return { ok: false, reason: "ambiguous" };
+    const option = matches[0];
+    const changed = this.value !== option.value;
+    if (changed) {
+      this.value = option.value;
+      option.selected = true;
+      this.dispatchEvent(new Event("input", { bubbles: true }));
+      this.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    return { ok: true, changed, label: normalize(option.label || option.textContent), value: String(option.value) };
   }`;
 }
 
@@ -450,6 +485,7 @@ export function createBrowserRuntime({
     const current = nodes.find((node) => Number(node?.backendDOMNodeId) === entry.backendNodeId) ?? nodes[0];
     if (!current || current.ignored) throw new Error("Browser reference is stale. Take a new snapshot.");
     return {
+      checked: axProperty(current, "checked"),
       name: boundedText(axValue(current.name), MAX_EXPECTED_NAME),
       role: String(axValue(current.role) ?? "unknown"),
     };
@@ -471,6 +507,103 @@ export function createBrowserRuntime({
       awaitPromise: true,
     });
     return inspected?.result?.value ?? null;
+  }
+
+  function requireExpectedName(action, current, actionName) {
+    const rawExpectedName = typeof action.expectedName === "string" ? action.expectedName.trim() : "";
+    if (!rawExpectedName || rawExpectedName.length > MAX_EXPECTED_NAME) {
+      throw new Error(`Browser ${actionName} requires the short exact accessible name from the latest snapshot.`);
+    }
+    const expectedName = boundedText(rawExpectedName, MAX_EXPECTED_NAME);
+    if (normalizeText(current.name) !== normalizeText(expectedName)) {
+      throw new Error("Browser target name changed. Take a new snapshot before acting.");
+    }
+  }
+
+  function focusBrowserTarget(tab) {
+    focusWindow?.();
+    selectTab?.(tab.tabId);
+    tab.view.webContents.focus();
+  }
+
+  function sendPointerClick(tab, metadata) {
+    focusBrowserTarget(tab);
+    const point = { x: Math.round(metadata.x), y: Math.round(metadata.y) };
+    tab.view.webContents.sendInputEvent({ type: "mouseMove", ...point });
+    tab.view.webContents.sendInputEvent({ type: "mouseDown", ...point, button: "left", clickCount: 1 });
+    tab.view.webContents.sendInputEvent({ type: "mouseUp", ...point, button: "left", clickCount: 1 });
+  }
+
+  async function waitUntil(check, timeoutMs, description) {
+    const startedAt = Date.now();
+    while (true) {
+      if (await check()) return Date.now() - startedAt;
+      const elapsedMs = Date.now() - startedAt;
+      if (elapsedMs >= timeoutMs) throw new Error(`Browser waitFor timed out waiting for ${description}.`);
+      await new Promise((resolve) => setTimeout(resolve, Math.min(WAIT_POLL_MS, timeoutMs - elapsedMs)));
+    }
+  }
+
+  async function performStructuredWait({ action, debuggerApi, state, tab }) {
+    const timeoutMs = action.timeoutMs === undefined ? DEFAULT_WAIT_FOR_MS : Number(action.timeoutMs);
+    if (!Number.isInteger(timeoutMs) || timeoutMs < WAIT_POLL_MS || timeoutMs > MAX_WAIT_FOR_MS) {
+      throw new Error(`Browser waitFor timeout must be between ${WAIT_POLL_MS} and ${MAX_WAIT_FOR_MS} ms.`);
+    }
+    const condition = typeof action.condition === "string" ? action.condition : "";
+    let elapsedMs;
+    if (condition === "url") {
+      const value = typeof action.value === "string" ? action.value.trim() : "";
+      const match = action.match === "contains" ? "contains" : "equals";
+      if (!value || value.length > 2_048) throw new Error("Browser waitFor URL requires a bounded non-empty value.");
+      elapsedMs = await waitUntil(() => {
+        const currentUrl = tab.view.webContents.getURL();
+        return match === "contains" ? currentUrl.includes(value) : currentUrl === value;
+      }, timeoutMs, `URL to ${match} ${value}`);
+    } else if (condition === "text") {
+      const value = typeof action.value === "string" ? normalizeText(action.value) : "";
+      if (!value || value.length > 500) throw new Error("Browser waitFor text requires a bounded non-empty value.");
+      const expected = value.toLocaleLowerCase();
+      elapsedMs = await waitUntil(async () => {
+        const trees = await readAccessibilityTrees(debuggerApi).catch(() => []);
+        return trees.some((tree) => tree.nodes.some((node) => {
+          if (node?.ignored) return false;
+          const name = normalizeText(axValue(node.name));
+          const protectedValue = axProperty(node, "protected") === true;
+          const currentValue = protectedValue ? "" : normalizeText(axValue(node.value));
+          return `${name} ${currentValue}`.toLocaleLowerCase().includes(expected);
+        }));
+      }, timeoutMs, `accessible text ${value}`);
+    } else if (condition === "ref") {
+      const { ref, entry } = requireRef(state, action);
+      const requestedState = action.state === "visible" ? "visible" : "attached";
+      elapsedMs = await waitUntil(async () => {
+        try {
+          await currentAccessibleEntry(debuggerApi, entry);
+          if (requestedState === "attached") return true;
+          const objectId = await resolvedNode(debuggerApi, entry);
+          const metadata = await inspectElement(debuggerApi, objectId);
+          return Boolean(metadata?.visible && !metadata.disabled);
+        } catch {
+          return false;
+        }
+      }, timeoutMs, `${ref} to be ${requestedState}`);
+    } else if (condition === "load") {
+      const requestedState = action.state === "interactive" ? "interactive" : "complete";
+      elapsedMs = await waitUntil(async () => {
+        const response = await debuggerCommand(debuggerApi, "Runtime.evaluate", {
+          expression: "document.readyState",
+          returnByValue: true,
+        }).catch(() => null);
+        const readyState = response?.result?.value;
+        return requestedState === "interactive"
+          ? readyState === "interactive" || readyState === "complete"
+          : readyState === "complete";
+      }, timeoutMs, `document readiness ${requestedState}`);
+    } else {
+      throw new Error("Unsupported browser waitFor condition.");
+    }
+    state.latestSnapshotId = null;
+    return { type: "waitFor", condition, elapsedMs };
   }
 
   async function resolveUploadFiles(rawPaths, rawWorkspaceRoot, rawExtensionId) {
@@ -521,15 +654,74 @@ export function createBrowserRuntime({
       await new Promise((resolve) => setTimeout(resolve, durationMs));
       return { type: "wait", durationMs };
     }
+    if (action.type === "waitFor") {
+      return performStructuredWait({ action, debuggerApi, state, tab });
+    }
     if (action.type === "press") {
       const key = typeof action.key === "string" ? action.key.trim() : "";
-      if (!SAFE_KEYS.has(key)) throw new Error("Unsupported browser key. Use fill for text input.");
-      focusWindow?.();
-      selectTab?.(tab.tabId);
-      tab.view.webContents.focus();
-      await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", { type: "keyDown", key });
-      await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", { type: "keyUp", key });
-      return { type: "press", key };
+      if (NAVIGATION_KEYS.has(key)) {
+        focusBrowserTarget(tab);
+        await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", { type: "keyDown", key });
+        await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", { type: "keyUp", key });
+        return { type: "press", key };
+      }
+      if (!ACTIVATION_KEYS.has(key)) throw new Error("Unsupported browser key. Use fill for text input.");
+      if (typeof action.ref !== "string" || !action.ref.trim() || typeof action.expectedName !== "string" || !action.expectedName.trim()) {
+        throw new Error("Browser Enter and Space require a stable ref and exact accessible name.");
+      }
+      const { ref, entry } = requireRef(state, action);
+      const objectId = await resolvedNode(debuggerApi, entry);
+      const metadata = await inspectElement(debuggerApi, objectId, { scrollIntoView: true });
+      const current = entry.inferred
+        ? { name: boundedText(metadata?.text, MAX_EXPECTED_NAME), role: "button" }
+        : await currentAccessibleEntry(debuggerApi, entry);
+      requireExpectedName(action, current, "activation key");
+      if (!metadata?.visible || metadata.disabled || (!metadata.buttonLike && !ACTIVATABLE_ROLES.has(current.role))) {
+        throw new Error("Browser activation-key target is not a visible enabled control.");
+      }
+      focusBrowserTarget(tab);
+      await debuggerCommand(debuggerApi, "DOM.focus", { backendNodeId: entry.backendNodeId });
+      const eventKey = key === "Space" ? " " : key;
+      const code = key === "Space" ? "Space" : "Enter";
+      const windowsVirtualKeyCode = key === "Space" ? 32 : 13;
+      await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", {
+        type: "keyDown",
+        key: eventKey,
+        code,
+        windowsVirtualKeyCode,
+      });
+      await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", {
+        type: "keyUp",
+        key: eventKey,
+        code,
+        windowsVirtualKeyCode,
+      });
+      state.latestSnapshotId = null;
+      return { type: "press", key, ref, name: current.name };
+    }
+    if (action.type === "scroll") {
+      const direction = typeof action.direction === "string" ? action.direction : "";
+      const amount = typeof action.amount === "string" ? action.amount : "";
+      const distance = SCROLL_DISTANCE[amount];
+      if (!distance || !["down", "left", "right", "up"].includes(direction)) {
+        throw new Error("Browser scroll requires a supported direction and amount.");
+      }
+      focusBrowserTarget(tab);
+      const bounds = tab.view.getBounds?.() ?? { width: 800, height: 600 };
+      const point = {
+        x: Math.max(1, Math.round(Number(bounds.width || 800) / 2)),
+        y: Math.max(1, Math.round(Number(bounds.height || 600) / 2)),
+      };
+      const signedDistance = direction === "up" || direction === "left" ? -distance : distance;
+      tab.view.webContents.sendInputEvent({ type: "mouseMove", ...point });
+      tab.view.webContents.sendInputEvent({
+        type: "mouseWheel",
+        ...point,
+        deltaX: direction === "left" || direction === "right" ? signedDistance : 0,
+        deltaY: direction === "up" || direction === "down" ? signedDistance : 0,
+      });
+      state.latestSnapshotId = null;
+      return { type: "scroll", direction, amount };
     }
 
     const { ref, entry } = requireRef(state, action);
@@ -555,24 +747,11 @@ export function createBrowserRuntime({
     }
 
     if (action.type === "click") {
-      const rawExpectedName = typeof action.expectedName === "string" ? action.expectedName.trim() : "";
-      if (!rawExpectedName || rawExpectedName.length > MAX_EXPECTED_NAME) {
-        throw new Error("Browser click requires the short exact accessible name from the latest snapshot.");
-      }
-      const expectedName = boundedText(rawExpectedName, MAX_EXPECTED_NAME);
-      if (!expectedName || normalizeText(current.name) !== normalizeText(expectedName)) {
-        throw new Error("Browser target name changed. Take a new snapshot before clicking.");
-      }
+      requireExpectedName(action, current, "click");
       if (!metadata.buttonLike || !metadata.unobstructed) {
         throw new Error("Browser click target is not an unobstructed interactive control.");
       }
-      focusWindow?.();
-      selectTab?.(tab.tabId);
-      tab.view.webContents.focus();
-      const point = { x: Math.round(metadata.x), y: Math.round(metadata.y) };
-      tab.view.webContents.sendInputEvent({ type: "mouseMove", ...point });
-      tab.view.webContents.sendInputEvent({ type: "mouseDown", ...point, button: "left", clickCount: 1 });
-      tab.view.webContents.sendInputEvent({ type: "mouseUp", ...point, button: "left", clickCount: 1 });
+      sendPointerClick(tab, metadata);
       state.latestSnapshotId = null;
       return { type: "click", ref, name: current.name };
     }
@@ -583,9 +762,7 @@ export function createBrowserRuntime({
       }
       const value = typeof action.value === "string" ? action.value : "";
       if (value.length > MAX_FILL_TEXT) throw new Error("Browser fill text is too long.");
-      focusWindow?.();
-      selectTab?.(tab.tabId);
-      tab.view.webContents.focus();
+      focusBrowserTarget(tab);
       await debuggerCommand(debuggerApi, "DOM.focus", { backendNodeId: entry.backendNodeId });
       const modifiers = platform === "darwin" ? 4 : 2;
       await debuggerCommand(debuggerApi, "Input.dispatchKeyEvent", {
@@ -606,6 +783,68 @@ export function createBrowserRuntime({
       return { type: "fill", ref, characters: Array.from(value).length };
     }
 
+    if (action.type === "hover") {
+      requireExpectedName(action, current, "hover");
+      if (!metadata.unobstructed) throw new Error("Browser hover target is obstructed.");
+      focusBrowserTarget(tab);
+      tab.view.webContents.sendInputEvent({
+        type: "mouseMove",
+        x: Math.round(metadata.x),
+        y: Math.round(metadata.y),
+      });
+      state.latestSnapshotId = null;
+      return { type: "hover", ref, name: current.name };
+    }
+
+    if (action.type === "select") {
+      requireExpectedName(action, current, "select");
+      if (!metadata.nativeSelect || !metadata.unobstructed || !["combobox", "listbox"].includes(current.role)) {
+        throw new Error("Browser select target is not a native select control.");
+      }
+      const option = typeof action.option === "string" ? action.option.trim() : "";
+      if (!option || option.length > 500) throw new Error("Browser select requires one bounded exact option label or value.");
+      const response = await debuggerCommand(debuggerApi, "Runtime.callFunctionOn", {
+        objectId,
+        functionDeclaration: selectExactOptionFunction(),
+        arguments: [{ value: option }],
+        returnByValue: true,
+        awaitPromise: true,
+      });
+      const selected = response?.result?.value;
+      if (!selected?.ok) {
+        const reason = selected?.reason === "ambiguous" ? "is ambiguous" : "was not found";
+        throw new Error(`Browser select option ${reason}. Take a new snapshot and use an exact option label or value.`);
+      }
+      if (selected.changed) state.latestSnapshotId = null;
+      return {
+        type: "select",
+        ref,
+        name: current.name,
+        option: selected.label,
+        value: selected.value,
+        changed: Boolean(selected.changed),
+      };
+    }
+
+    if (action.type === "check") {
+      requireExpectedName(action, current, "check");
+      if (!CHECKABLE_ROLES.has(current.role) || !metadata.checkable) {
+        throw new Error("Browser check target is not a checkbox, radio, or switch.");
+      }
+      const checked = action.checked;
+      if (typeof checked !== "boolean") throw new Error("Browser check requires a boolean checked state.");
+      if (RADIO_ROLES.has(current.role) && checked === false) {
+        throw new Error("Browser radio controls can only be checked; choose another option to change the selection.");
+      }
+      if (current.checked === checked) {
+        return { type: "check", ref, name: current.name, checked, changed: false };
+      }
+      if (!metadata.unobstructed) throw new Error("Browser check target is obstructed.");
+      sendPointerClick(tab, metadata);
+      state.latestSnapshotId = null;
+      return { type: "check", ref, name: current.name, checked, changed: true };
+    }
+
     throw new Error(`Unsupported browser action: ${String(action.type ?? "missing")}`);
   }
 
@@ -615,9 +854,13 @@ export function createBrowserRuntime({
     if (actions.length === 0 || actions.length > MAX_ACTIONS) {
       throw new Error(`Browser act requires 1-${MAX_ACTIONS} actions.`);
     }
-    const totalWait = actions.reduce((sum, action) => (
-      action?.type === "wait" ? sum + Number(action.durationMs || 0) : sum
-    ), 0);
+    const totalWait = actions.reduce((sum, action) => {
+      if (action?.type === "wait") return sum + Number(action.durationMs || 0);
+      if (action?.type === "waitFor") {
+        return sum + (action.timeoutMs === undefined ? DEFAULT_WAIT_FOR_MS : Number(action.timeoutMs));
+      }
+      return sum;
+    }, 0);
     if (!Number.isFinite(totalWait) || totalWait > MAX_TOTAL_WAIT_MS) {
       throw new Error(`Browser action batch may wait at most ${MAX_TOTAL_WAIT_MS} ms in total.`);
     }

--- a/apps/desktop/electron/browser-runtime.test.mjs
+++ b/apps/desktop/electron/browser-runtime.test.mjs
@@ -24,6 +24,7 @@ function createFixture({ workspacePath = null, userDataPath = "/tmp" } = {}) {
   const flattenedNodes = [];
   const frameNodes = [];
   let attached = false;
+  let selectedOption = "writer";
   let url = "https://example.test/form";
   const nodes = [
     axNode({ nodeId: "root", role: "RootWebArea", name: "Fixture", childIds: ["heading", "title", "publish", "password"] }),
@@ -64,12 +65,24 @@ function createFixture({ workspacePath = null, userDataPath = "/tmp" } = {}) {
       if (method === "DOM.resolveNode") return { object: { objectId: `node-${params.backendNodeId}` } };
       if (method === "Runtime.callFunctionOn") {
         const backendNodeId = Number(String(params.objectId).replace("node-", ""));
+        if (String(params.functionDeclaration).includes("selectExactOption")) {
+          const option = params.arguments?.[0]?.value;
+          if (!["Writer", "Reviewer", "writer", "reviewer"].includes(option)) {
+            return { result: { value: { ok: false, reason: "not_found" } } };
+          }
+          const value = String(option).toLowerCase();
+          const changed = selectedOption !== value;
+          selectedOption = value;
+          return { result: { value: { ok: true, changed, label: value === "writer" ? "Writer" : "Reviewer", value } } };
+        }
         return {
           result: {
             value: {
-              buttonLike: backendNodeId === 12 || backendNodeId === 15,
+              buttonLike: [12, 15, 17, 18].includes(backendNodeId),
+              checkable: backendNodeId === 17,
               disabled: false,
               fileInput: backendNodeId === 14,
+              nativeSelect: backendNodeId === 16,
               unobstructed: true,
               text: backendNodeId === 15 ? "发布图文笔记" : "",
               visible: backendNodeId !== 14,
@@ -80,6 +93,7 @@ function createFixture({ workspacePath = null, userDataPath = "/tmp" } = {}) {
           },
         };
       }
+      if (method === "Runtime.evaluate") return { result: { value: "complete" } };
       return {};
     },
   };
@@ -91,7 +105,7 @@ function createFixture({ workspacePath = null, userDataPath = "/tmp" } = {}) {
     isDestroyed() { return false; },
     sendInputEvent(event) { inputEvents.push(event); },
   };
-  const tab = { tabId: "tab-1", view: { webContents } };
+  const tab = { tabId: "tab-1", view: { getBounds: () => ({ width: 640, height: 480 }), webContents } };
   const runtime = createBrowserRuntime({
     getTab: (tabId) => tabId === tab.tabId ? tab : null,
     selectTab() {},
@@ -100,7 +114,18 @@ function createFixture({ workspacePath = null, userDataPath = "/tmp" } = {}) {
     getUserDataPath: () => userDataPath,
     platform: "darwin",
   });
-  return { commands, flattenedNodes, frameNodes, inputEvents, nodes, runtime, setUrl(value) { url = value; } };
+  return { commands, flattenedNodes, frameNodes, inputEvents, nodes, runtime, selectedOption: () => selectedOption, setUrl(value) { url = value; } };
+}
+
+function addSemanticControls(fixture) {
+  fixture.nodes[0].childIds.push("role", "notifications", "hover");
+  fixture.nodes.push(
+    axNode({ nodeId: "role", role: "combobox", name: "Role", backendDOMNodeId: 16, value: "Writer", childIds: ["writer", "reviewer"] }),
+    axNode({ nodeId: "writer", role: "option", name: "Writer", backendDOMNodeId: 19, properties: [{ name: "selected", value: { value: true } }] }),
+    axNode({ nodeId: "reviewer", role: "option", name: "Reviewer", backendDOMNodeId: 20 }),
+    axNode({ nodeId: "notifications", role: "checkbox", name: "Enable notifications", backendDOMNodeId: 17, properties: [{ name: "checked", value: { value: false } }] }),
+    axNode({ nodeId: "hover", role: "button", name: "Open actions", backendDOMNodeId: 18 }),
+  );
 }
 
 it("creates bounded semantic snapshots with stable refs and protected-value redaction", async () => {
@@ -186,6 +211,97 @@ it("executes a bounded batch with real text and pointer input", async () => {
   assert.equal(result.snapshotRequired, true);
 });
 
+it("supports verified hover, native select, check, and bounded scroll actions", async () => {
+  const fixture = createFixture();
+  addSemanticControls(fixture);
+
+  let snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+  const hover = await fixture.runtime.act({
+    tabId: "tab-1",
+    snapshotId: snapshot.snapshotId,
+    actions: [{ type: "hover", ref: "@e8", expectedName: "Open actions" }],
+  });
+  assert.deepEqual(hover.results[0], { type: "hover", ref: "@e8", name: "Open actions" });
+  assert.equal(hover.snapshotRequired, true);
+
+  snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+  const select = await fixture.runtime.act({
+    tabId: "tab-1",
+    snapshotId: snapshot.snapshotId,
+    actions: [{ type: "select", ref: "@e4", expectedName: "Role", option: "Reviewer" }],
+  });
+  assert.deepEqual(select.results[0], {
+    type: "select",
+    ref: "@e4",
+    name: "Role",
+    option: "Reviewer",
+    value: "reviewer",
+    changed: true,
+  });
+  assert.equal(fixture.selectedOption(), "reviewer");
+
+  snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+  const check = await fixture.runtime.act({
+    tabId: "tab-1",
+    snapshotId: snapshot.snapshotId,
+    actions: [{ type: "check", ref: "@e7", expectedName: "Enable notifications", checked: true }],
+  });
+  assert.deepEqual(check.results[0], {
+    type: "check",
+    ref: "@e7",
+    name: "Enable notifications",
+    checked: true,
+    changed: true,
+  });
+
+  snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+  const scroll = await fixture.runtime.act({
+    tabId: "tab-1",
+    snapshotId: snapshot.snapshotId,
+    actions: [{ type: "scroll", direction: "down", amount: "small" }],
+  });
+  assert.deepEqual(scroll.results[0], { type: "scroll", direction: "down", amount: "small" });
+  assert.deepEqual(fixture.inputEvents.at(-1), {
+    type: "mouseWheel",
+    x: 320,
+    y: 240,
+    deltaX: 0,
+    deltaY: 320,
+  });
+});
+
+it("waits for bounded URL, text, ref, and document readiness conditions", async () => {
+  const fixture = createFixture();
+  const cases = [
+    { type: "waitFor", condition: "url", value: "https://example.test/form", match: "equals", timeoutMs: 100 },
+    { type: "waitFor", condition: "text", value: "Create post", timeoutMs: 100 },
+    { type: "waitFor", condition: "ref", ref: "@e2", state: "visible", timeoutMs: 100 },
+    { type: "waitFor", condition: "load", state: "complete", timeoutMs: 100 },
+  ];
+
+  for (const action of cases) {
+    const snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+    const result = await fixture.runtime.act({
+      tabId: "tab-1",
+      snapshotId: snapshot.snapshotId,
+      actions: [action],
+    });
+    assert.equal(result.results[0].type, "waitFor");
+    assert.equal(result.results[0].condition, action.condition);
+    assert.equal(result.snapshotRequired, true);
+  }
+
+  const snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+  await assert.rejects(
+    fixture.runtime.act({
+      tabId: "tab-1",
+      snapshotId: snapshot.snapshotId,
+      actions: [{ type: "waitFor", condition: "text", value: "Never appears", timeoutMs: 100 }],
+    }),
+    /timed out/i,
+  );
+});
+
 it("rejects stale snapshots and changed accessible names before input", async () => {
   const fixture = createFixture();
   const first = await fixture.runtime.snapshot({ tabId: "tab-1" });
@@ -229,9 +345,9 @@ it("invalidates refs when the host reports navigation", async () => {
   );
 });
 
-it("does not allow unscoped activation keys to bypass named clicks", async () => {
+it("requires stable named refs for Enter and Space activation keys", async () => {
   const fixture = createFixture();
-  const snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+  let snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
 
   await assert.rejects(
     fixture.runtime.act({
@@ -239,8 +355,24 @@ it("does not allow unscoped activation keys to bypass named clicks", async () =>
       snapshotId: snapshot.snapshotId,
       actions: [{ type: "press", key: "Enter" }],
     }),
-    /unsupported browser key/i,
+    /require a stable ref/i,
   );
+
+  for (const key of ["Enter", "Space"]) {
+    snapshot = await fixture.runtime.snapshot({ tabId: "tab-1" });
+    const result = await fixture.runtime.act({
+      tabId: "tab-1",
+      snapshotId: snapshot.snapshotId,
+      actions: [{ type: "press", key, ref: "@e2", expectedName: "Publish" }],
+    });
+    assert.deepEqual(result.results[0], { type: "press", key, ref: "@e2", name: "Publish" });
+  }
+  assert.ok(fixture.commands.some((command) => (
+    command.method === "Input.dispatchKeyEvent" && command.params.code === "Enter"
+  )));
+  assert.ok(fixture.commands.some((command) => (
+    command.method === "Input.dispatchKeyEvent" && command.params.code === "Space"
+  )));
 });
 
 it("supplements hidden file inputs and uploads only registered-workspace files", async () => {

--- a/apps/server/src/engine-host-tools.ts
+++ b/apps/server/src/engine-host-tools.ts
@@ -33,7 +33,8 @@ export const ENGINE_BROWSER_INSTRUCTION = `## Built-in Browser
 Use the iPolloWork browser tools only for external websites, never to control the iPolloWork app itself.
 Open a page with ipollowork_browser_open_url, read it with ipollowork_browser_snapshot, then act only through stable refs from that latest snapshot with ipollowork_browser_act.
 Never invent or reuse stale refs. Take a new snapshot after navigation, when snapshotRequired is true, or when a target changed.
-Prefer one bounded action batch when steps are independent. Clicking publish, send, submit, pay, buy, confirm, delete, or similar consequential controls requires user approval and must not be retried after denial.`;
+Prefer one bounded action batch when steps are independent. Use hover, select, check, scroll, or structured wait actions instead of guessing pointer coordinates or timing.
+Activating publish, send, submit, pay, buy, confirm, delete, or similar consequential controls by click, key, or check requires user approval and must not be retried after denial.`;
 
 const CONSEQUENTIAL_BROWSER_CONTROL = /(?:发布|发送|提交|付款|支付|购买|下单|确认|删除|移除|清空数据|授权)|(?:\b(?:publish|send|submit|pay|purchase|buy|checkout|confirm|delete|remove|authorize)\b)|(?:^post(?: now)?$)/i;
 
@@ -43,7 +44,10 @@ export function consequentialBrowserControlNames(value: unknown): string[] {
     .filter((action): action is Record<string, unknown> => (
       typeof action === "object" && action !== null && !Array.isArray(action)
     ))
-    .filter((action) => action.type === "click" && typeof action.expectedName === "string")
+    .filter((action) => (
+      ["check", "click", "press"].includes(String(action.type))
+      && typeof action.expectedName === "string"
+    ))
     .map((action) => String(action.expectedName).trim())
     .filter((name) => name && CONSEQUENTIAL_BROWSER_CONTROL.test(name));
 }
@@ -68,6 +72,34 @@ const browserActionSchema = {
       },
     }, ["type", "key"]),
     objectParameters({
+      type: { const: "press" },
+      key: { type: "string", enum: ["Enter", "Space"] },
+      ref: { type: "string", description: "Stable activatable-control ref from the latest browser snapshot." },
+      expectedName: { type: "string", maxLength: 200, description: "Exact accessible control name shown in the snapshot." },
+    }, ["type", "key", "ref", "expectedName"]),
+    objectParameters({
+      type: { const: "hover" },
+      ref: { type: "string", description: "Stable ref from the latest browser snapshot." },
+      expectedName: { type: "string", maxLength: 200, description: "Exact accessible target name shown in the snapshot." },
+    }, ["type", "ref", "expectedName"]),
+    objectParameters({
+      type: { const: "select" },
+      ref: { type: "string", description: "Stable native-select ref from the latest browser snapshot." },
+      expectedName: { type: "string", maxLength: 200, description: "Exact accessible select name shown in the snapshot." },
+      option: { type: "string", maxLength: 500, description: "Exact visible option label or option value." },
+    }, ["type", "ref", "expectedName", "option"]),
+    objectParameters({
+      type: { const: "check" },
+      ref: { type: "string", description: "Stable checkbox, radio, or switch ref from the latest browser snapshot." },
+      expectedName: { type: "string", maxLength: 200, description: "Exact accessible control name shown in the snapshot." },
+      checked: { type: "boolean", description: "Requested checked state. Radio controls accept true only." },
+    }, ["type", "ref", "expectedName", "checked"]),
+    objectParameters({
+      type: { const: "scroll" },
+      direction: { type: "string", enum: ["down", "left", "right", "up"] },
+      amount: { type: "string", enum: ["small", "page"] },
+    }, ["type", "direction", "amount"]),
+    objectParameters({
       type: { const: "upload" },
       ref: { type: "string", description: "File-input ref from the latest browser snapshot." },
       filePaths: {
@@ -83,6 +115,32 @@ const browserActionSchema = {
       type: { const: "wait" },
       durationMs: { type: "integer", minimum: 0, maximum: 2_000 },
     }, ["type", "durationMs"]),
+    objectParameters({
+      type: { const: "waitFor" },
+      condition: { const: "url" },
+      value: { type: "string", minLength: 1, maxLength: 2_048 },
+      match: { type: "string", enum: ["equals", "contains"] },
+      timeoutMs: { type: "integer", minimum: 100, maximum: 10_000 },
+    }, ["type", "condition", "value", "match"]),
+    objectParameters({
+      type: { const: "waitFor" },
+      condition: { const: "text" },
+      value: { type: "string", minLength: 1, maxLength: 500 },
+      timeoutMs: { type: "integer", minimum: 100, maximum: 10_000 },
+    }, ["type", "condition", "value"]),
+    objectParameters({
+      type: { const: "waitFor" },
+      condition: { const: "ref" },
+      ref: { type: "string", description: "Stable ref from the latest browser snapshot." },
+      state: { type: "string", enum: ["attached", "visible"] },
+      timeoutMs: { type: "integer", minimum: 100, maximum: 10_000 },
+    }, ["type", "condition", "ref", "state"]),
+    objectParameters({
+      type: { const: "waitFor" },
+      condition: { const: "load" },
+      state: { type: "string", enum: ["interactive", "complete"] },
+      timeoutMs: { type: "integer", minimum: 100, maximum: 10_000 },
+    }, ["type", "condition", "state"]),
   ],
 };
 
@@ -155,7 +213,7 @@ export const ENGINE_HOST_TOOLS: readonly EngineHostToolDescriptor[] = [
   },
   {
     name: ENGINE_HOST_TOOL_NAMES.browserAct,
-    description: "Execute one bounded action batch against refs from the latest semantic snapshot. Uses real pointer/keyboard input, validates current name/visibility/obstruction, and rejects stale refs.",
+    description: "Execute one bounded semantic action batch against the latest snapshot: click, fill, scoped key activation, hover, select, check, scroll, upload, or bounded waits. Validates names, state, visibility, obstruction, and stale refs.",
     parameters: objectParameters({
       tabId: { type: "string", description: "Built-in browser tab ID." },
       snapshotId: { type: "string", description: "Latest snapshot ID returned for this tab." },

--- a/apps/server/src/extensions-connect-gating.test.ts
+++ b/apps/server/src/extensions-connect-gating.test.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
-import { consequentialBrowserControlNames } from "./engine-host-tools.js";
+import { consequentialBrowserControlNames, engineHostTool, ENGINE_HOST_TOOL_NAMES } from "./engine-host-tools.js";
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
@@ -14,13 +14,26 @@ import type { ServerConfig } from "./types.js";
 const CLIENT_TOKEN = "owt_connect_client_token";
 const HOST_TOKEN = "owt_connect_host_token";
 
-test("browser host policy identifies only consequential verified clicks", () => {
+test("browser host policy identifies only consequential verified activations", () => {
   expect(consequentialBrowserControlNames([
     { type: "fill", ref: "@e1", value: "Publish" },
     { type: "click", ref: "@e2", expectedName: "Preview" },
     { type: "click", ref: "@e3", expectedName: "确认发布" },
     { type: "click", ref: "@e4", expectedName: "Delete post" },
-  ])).toEqual(["确认发布", "Delete post"]);
+    { type: "press", key: "Enter", ref: "@e5", expectedName: "Submit" },
+    { type: "check", ref: "@e6", expectedName: "Authorize access", checked: true },
+  ])).toEqual(["确认发布", "Delete post", "Submit", "Authorize access"]);
+});
+
+test("browser host action schema exposes one complete semantic action set", () => {
+  const tool = engineHostTool(ENGINE_HOST_TOOL_NAMES.browserAct);
+  const schema = JSON.stringify(tool?.parameters);
+  for (const action of ["check", "click", "fill", "hover", "press", "scroll", "select", "upload", "wait", "waitFor"]) {
+    expect(schema).toContain(`\"${action}\"`);
+  }
+  expect(schema).toContain("Enter");
+  expect(schema).toContain("Space");
+  for (const condition of ["load", "ref", "text", "url"]) expect(schema).toContain(`\"${condition}\"`);
 });
 
 const actionSchema = z.object({

--- a/apps/server/src/opencode-plugins/ipollowork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/ipollowork-extensions-preview.test.ts
@@ -52,7 +52,7 @@ async function transformedSystem(plugin: Awaited<ReturnType<typeof iPolloWorkExt
 }
 
 function startFakeiPolloWorkServer() {
-  const requests: Array<{ pathname: string; search: string; authorization: string | null }> = [];
+  const requests: Array<{ pathname: string; search: string; authorization: string | null; body?: unknown }> = [];
 
   const workspaceOne = { id: "ws_1", name: "Main", path: "/tmp/main" };
   const workspaceTwo = { id: "ws_2", name: "Archive", displayName: "Archive", path: "/tmp/archive" };
@@ -63,16 +63,22 @@ function startFakeiPolloWorkServer() {
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
-    fetch(request) {
+    async fetch(request) {
       const url = new URL(request.url);
+      const body = request.method === "POST" ? await request.json() : undefined;
       requests.push({
         pathname: url.pathname,
         search: url.search,
         authorization: request.headers.get("authorization"),
+        body,
       });
 
       if (request.headers.get("authorization") !== "Bearer test-token") {
         return Response.json({ message: "Unauthorized" }, { status: 401 });
+      }
+
+      if (url.pathname === "/engine-tools/call") {
+        return Response.json({ ok: true, received: body });
       }
 
       if (url.pathname === "/workspaces") {
@@ -256,6 +262,33 @@ describe("iPolloWorkExtensionsPreview UI control tools", () => {
 
     const system = await transformedSystem(plugin);
     expect(system).toContain("ipollowork_ui_execute_action");
+  });
+
+  test("accepts every semantic browser action exposed by the shared host descriptor", async () => {
+    const fake = startFakeiPolloWorkServer();
+    const plugin = await iPolloWorkExtensionsPreview();
+    const actions = [
+      { type: "hover", ref: "r1", expectedName: "Menu" },
+      { type: "select", ref: "r2", expectedName: "Channel", option: "Video" },
+      { type: "check", ref: "r3", expectedName: "Original", checked: true },
+      { type: "scroll", direction: "down", amount: "page" },
+      { type: "press", key: "Enter", ref: "r4", expectedName: "Continue" },
+      { type: "waitFor", condition: "url", value: "/published", match: "contains" },
+      { type: "waitFor", condition: "text", value: "Published" },
+      { type: "waitFor", condition: "load", state: "complete" },
+    ];
+
+    const output = await plugin.tool.ipollowork_browser_act.execute({
+      tabId: "tab-1",
+      snapshotId: "snapshot-1",
+      actions,
+    }, { directory: "/tmp/main" });
+
+    expect(JSON.parse(output)).toMatchObject({ ok: true });
+    expect(fake.requests.find((request) => request.pathname === "/engine-tools/call")?.body).toMatchObject({
+      name: "ipollowork_browser_act",
+      args: { actions },
+    });
   });
 
 });

--- a/apps/server/src/opencode-plugins/ipollowork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/ipollowork-extensions-preview.ts
@@ -68,7 +68,7 @@ const browserSnapshotArgsSchema = z.object({
   tabId: z.string().trim().min(1).describe("Built-in browser tab ID returned by ipollowork_browser_open_url."),
 });
 
-const browserActionSchema = z.discriminatedUnion("type", [
+const browserActionSchema = z.union([
   z.object({
     type: z.literal("click"),
     ref: z.string().trim().min(1),
@@ -80,12 +80,66 @@ const browserActionSchema = z.discriminatedUnion("type", [
     key: z.enum(["ArrowDown", "ArrowLeft", "ArrowRight", "ArrowUp", "End", "Escape", "Home", "PageDown", "PageUp", "Tab"]),
   }),
   z.object({
+    type: z.literal("press"),
+    key: z.enum(["Enter", "Space"]),
+    ref: z.string().trim().min(1),
+    expectedName: z.string().trim().min(1).max(200),
+  }),
+  z.object({
+    type: z.literal("hover"),
+    ref: z.string().trim().min(1),
+    expectedName: z.string().trim().min(1).max(200),
+  }),
+  z.object({
+    type: z.literal("select"),
+    ref: z.string().trim().min(1),
+    expectedName: z.string().trim().min(1).max(200),
+    option: z.string().max(500),
+  }),
+  z.object({
+    type: z.literal("check"),
+    ref: z.string().trim().min(1),
+    expectedName: z.string().trim().min(1).max(200),
+    checked: z.boolean(),
+  }),
+  z.object({
+    type: z.literal("scroll"),
+    direction: z.enum(["down", "left", "right", "up"]),
+    amount: z.enum(["small", "page"]),
+  }),
+  z.object({
     type: z.literal("upload"),
     ref: z.string().trim().min(1),
     filePaths: z.array(z.string().trim().min(1)).min(1).max(20),
     extensionId: z.string().trim().min(1).optional(),
   }),
   z.object({ type: z.literal("wait"), durationMs: z.number().int().min(0).max(2_000) }),
+  z.object({
+    type: z.literal("waitFor"),
+    condition: z.literal("url"),
+    value: z.string().min(1).max(2_048),
+    match: z.enum(["equals", "contains"]),
+    timeoutMs: z.number().int().min(100).max(10_000).optional(),
+  }),
+  z.object({
+    type: z.literal("waitFor"),
+    condition: z.literal("text"),
+    value: z.string().min(1).max(500),
+    timeoutMs: z.number().int().min(100).max(10_000).optional(),
+  }),
+  z.object({
+    type: z.literal("waitFor"),
+    condition: z.literal("ref"),
+    ref: z.string().trim().min(1),
+    state: z.enum(["attached", "visible"]),
+    timeoutMs: z.number().int().min(100).max(10_000).optional(),
+  }),
+  z.object({
+    type: z.literal("waitFor"),
+    condition: z.literal("load"),
+    state: z.enum(["interactive", "complete"]),
+    timeoutMs: z.number().int().min(100).max(10_000).optional(),
+  }),
 ]);
 
 const browserActArgsSchema = z.object({

--- a/evals/flows/unified-agent-browser.flow.mjs
+++ b/evals/flows/unified-agent-browser.flow.mjs
@@ -19,11 +19,13 @@ function startFixtureServer() {
       body { margin: 0; font-family: system-ui, sans-serif; background: #f5f3ef; color: #171717; }
       main { width: min(720px, calc(100% - 48px)); margin: 48px auto; padding: 32px; border-radius: 24px; background: white; box-shadow: 0 18px 60px #17233b1f; }
       label, button { display: block; margin-top: 18px; font-weight: 700; }
-      input { width: 100%; box-sizing: border-box; margin-top: 8px; padding: 13px 14px; border: 1px solid #a3a3a3; border-radius: 12px; font: inherit; }
+      input, select { width: 100%; box-sizing: border-box; margin-top: 8px; padding: 13px 14px; border: 1px solid #a3a3a3; border-radius: 12px; font: inherit; }
+      input[type='checkbox'] { display: inline-block; width: auto; margin-right: 8px; }
       button { padding: 11px 16px; border: 0; border-radius: 12px; background: #171717; color: white; cursor: pointer; }
       #publish { background: #b42318; }
       #result { margin-top: 24px; padding: 16px; border-radius: 12px; background: #eff6ff; }
       iframe { width: 100%; height: 84px; margin-top: 18px; border: 1px solid #d4d4d4; border-radius: 12px; }
+      .scroll-space { height: 900px; }
     </style>
   </head>
   <body>
@@ -33,16 +35,37 @@ function startFixtureServer() {
       <label for="title">Post title</label>
       <input id="title" autocomplete="off">
       <button id="preview" type="button">Preview</button>
+      <button id="actions" type="button">Open actions</button>
+      <label for="role">Role</label>
+      <select id="role"><option value="writer">Writer</option><option value="reviewer">Reviewer</option></select>
+      <label><input id="notifications" type="checkbox">Enable notifications</label>
       <div id="shadow-host"></div>
       <iframe title="Embedded editor" srcdoc="<!doctype html><button type='button'>Frame action</button>"></iframe>
       <input type="file" aria-label="Upload training asset" hidden>
       <button id="publish" type="button">Publish now</button>
       <p id="result">Waiting for an action</p>
+      <p id="hover-result">Hover idle</p>
+      <p id="select-result">Role unchanged</p>
+      <p id="check-result">Notifications unchanged</p>
+      <p id="scroll-result">Scroll idle</p>
+      <div class="scroll-space" aria-hidden="true"></div>
     </main>
     <script>
       const result = document.querySelector('#result');
       document.querySelector('#preview').addEventListener('click', () => {
         result.textContent = 'Preview ready: ' + document.querySelector('#title').value;
+      });
+      document.querySelector('#actions').addEventListener('mouseenter', () => {
+        setTimeout(() => { document.querySelector('#hover-result').textContent = 'Hover menu ready'; }, 120);
+      });
+      document.querySelector('#role').addEventListener('change', (event) => {
+        document.querySelector('#select-result').textContent = 'Selected role: ' + event.target.value;
+      });
+      document.querySelector('#notifications').addEventListener('change', (event) => {
+        document.querySelector('#check-result').textContent = event.target.checked ? 'Notifications enabled' : 'Notifications disabled';
+      });
+      window.addEventListener('scroll', () => {
+        if (window.scrollY > 0) document.querySelector('#scroll-result').textContent = 'Scrolled down';
       });
       document.querySelector('#publish').addEventListener('click', () => {
         result.textContent = 'Published';
@@ -160,23 +183,35 @@ export default {
             const route = await ctx.eval("window.location.hash");
             if (!/\/session\/[^/?#]+/.test(route)) {
               const sessions = await ctx.control("session.list_sessions");
-              ctx.assert(Array.isArray(sessions) && sessions.length > 0, "The browser proof needs one existing conversation.");
-              await ctx.control("session.open", { sessionId: sessions[0].sessionId });
+              if (Array.isArray(sessions) && sessions.length > 0) {
+                await ctx.control("session.open", { sessionId: sessions[0].sessionId });
+              } else {
+                await ctx.waitFor(
+                  `window.__ipolloworkControl.listActions().some((action) => action.id === "session.create_task" && !action.disabled)`,
+                  { timeoutMs: 30_000, label: "new browser proof conversation" },
+                );
+                await ctx.control("session.create_task");
+              }
               await ctx.waitFor("/\/session\/[^/?#]+/.test(window.location.hash)", {
-                timeoutMs: 30_000,
+                timeoutMs: 90_000,
                 label: "existing conversation route",
               });
             }
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
             await ctx.eval("window.__IPOLLOWORK_ELECTRON__.browser.closeAllTabs()", { awaitPromise: true });
             await ctx.waitFor(
               `window.__ipolloworkControl.listActions().some((action) => action.id === "eval.design.seed_html" && !action.disabled)`,
               { timeoutMs: 30_000, label: "Design seed action" },
             );
-            try {
-              await ctx.control("eval.design.seed_html");
-            } catch {
-              await ctx.trustedClick('button[aria-label="Select tab: entry.html"]');
-            }
+            await ctx.control("eval.design.seed_html").catch(() => undefined);
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27, nativeVirtualKeyCode: 27 });
+            await ctx.waitFor(`Boolean(document.querySelector('button[aria-label="Select tab: entry.html"]'))`, {
+              timeoutMs: 30_000,
+              label: "seeded Design tab",
+            });
+            await ctx.trustedClick('button[aria-label="Select tab: entry.html"]');
             await ctx.waitFor(
               `Boolean(document.querySelector('button[aria-label="Select tab: entry.html"][aria-selected="true"]'))`,
               { timeoutMs: 30_000, label: "active Design tab before browser launch" },
@@ -202,6 +237,7 @@ export default {
               return {
                 label: button?.textContent?.trim() ?? "",
                 width: addressRect ? Math.round(addressRect.width) : 0,
+                left: addressRect ? Math.round(addressRect.left) : 0,
                 right: addressRect ? Math.round(addressRect.right) : 0,
                 inputVisible: Boolean(input),
                 profileVisible: Boolean(profileRect?.width),
@@ -233,11 +269,12 @@ export default {
             ctx.assert(tabs.some((tab) => tab.id === ctx.browser.opened.tabId), "The returned host tab is not open.");
             const activeTabId = await ctx.eval(`document.querySelector('button[aria-label^="Select tab:"][aria-selected="true"]')?.closest('[id]')?.id ?? null`);
             ctx.assert(activeTabId === ctx.browser.opened.tabId, "The existing Design surface stole focus from the browser opened by the host.");
-            ctx.assert(ctx.browser.compactAddress.width >= 240, "The resting site address does not use the available toolbar space.");
+            ctx.assert(ctx.browser.compactAddress.width >= 100, "The resting site address is too short to identify the current site.");
             ctx.assert(!ctx.browser.compactAddress.inputVisible, "The full URL input is visible before the user asks for it.");
             ctx.assert(ctx.browser.compactAddress.profileVisible, "The browser profile avatar is not visible.");
             ctx.assert(ctx.browser.compactAddress.profileWidth >= 24 && ctx.browser.compactAddress.profileWidth <= 40, "The browser profile avatar does not keep a compact fixed slot.");
             ctx.assert(ctx.browser.compactAddress.right <= ctx.browser.compactAddress.profileLeft, "The browser profile avatar is not reserved to the right of the address.");
+            ctx.assert(ctx.browser.compactAddress.profileLeft - ctx.browser.compactAddress.right <= 16, "The site address leaves unused toolbar space before the profile avatar.");
             ctx.assert(/Default profile|默认身份/.test(ctx.browser.profileMenuText), "The browser profile menu does not identify the active profile.");
             ctx.assert(/saved|保存/.test(ctx.browser.profileMenuText), "The browser profile menu does not explain sign-in persistence.");
           },
@@ -388,10 +425,79 @@ export default {
       },
     },
     {
+      name: "Modern semantic controls work without selectors or timing guesses",
+      run: async (ctx) => {
+        await ctx.prove("The host can hover, select, check, scroll, and wait for semantic page state", {
+          voiceover: vo[4],
+          action: async () => {
+            const waitForText = async (value) => {
+              const beforeWait = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+              const waited = await ctx.control("browser.act", {
+                tabId: ctx.browser.opened.tabId,
+                snapshotId: beforeWait.snapshotId,
+                actions: [{ type: "waitFor", condition: "text", value, timeoutMs: 2_000 }],
+              });
+              const afterWait = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+              ctx.assert(afterWait.tree.includes(value), `The page did not expose the expected state: ${value}`);
+              return waited.results[0];
+            };
+
+            let snapshot = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+            const hover = await ctx.control("browser.act", {
+              tabId: ctx.browser.opened.tabId,
+              snapshotId: snapshot.snapshotId,
+              actions: [{ type: "hover", ref: refFor(snapshot.tree, "Open actions"), expectedName: "Open actions" }],
+            });
+            const hoverWait = await waitForText("Hover menu ready");
+
+            snapshot = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+            const select = await ctx.control("browser.act", {
+              tabId: ctx.browser.opened.tabId,
+              snapshotId: snapshot.snapshotId,
+              actions: [{ type: "select", ref: refFor(snapshot.tree, "Role"), expectedName: "Role", option: "Reviewer" }],
+            });
+            await waitForText("Selected role: reviewer");
+
+            snapshot = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+            const check = await ctx.control("browser.act", {
+              tabId: ctx.browser.opened.tabId,
+              snapshotId: snapshot.snapshotId,
+              actions: [{ type: "check", ref: refFor(snapshot.tree, "Enable notifications"), expectedName: "Enable notifications", checked: true }],
+            });
+            await waitForText("Notifications enabled");
+
+            snapshot = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+            const scroll = await ctx.control("browser.act", {
+              tabId: ctx.browser.opened.tabId,
+              snapshotId: snapshot.snapshotId,
+              actions: [{ type: "scroll", direction: "down", amount: "page" }],
+            });
+            const scrollWait = await waitForText("Scrolled down");
+            ctx.browser.snapshot = await ctx.control("browser.snapshot", { tabId: ctx.browser.opened.tabId });
+            ctx.browser.semanticActions = { check, hover, hoverWait, scroll, scrollWait, select };
+            await showProofPanel(ctx, "现代语义动作已经统一可用", "悬停、原生下拉、勾选、滚动和条件等待都走同一套 Host 协议，不依赖 selector、坐标脚本或固定延时。", [
+              { label: "Hover + wait", value: `${hover.results[0].type} → ${hoverWait.type}:${hoverWait.condition}` },
+              { label: "Select", value: `${select.results[0].name} → ${select.results[0].option}` },
+              { label: "Check", value: `${check.results[0].name} = ${check.results[0].checked}` },
+              { label: "Scroll + wait", value: `${scroll.results[0].direction}/${scroll.results[0].amount} → ${scrollWait.type}:${scrollWait.condition}` },
+            ]);
+          },
+          assert: async () => {
+            ctx.assert(ctx.browser.semanticActions.hover.results[0].type === "hover", "Hover did not run through the host runtime.");
+            ctx.assert(ctx.browser.semanticActions.select.results[0].value === "reviewer", "Native select did not choose the exact option.");
+            ctx.assert(ctx.browser.semanticActions.check.results[0].checked === true, "Checkbox did not reach the requested state.");
+            ctx.assert(ctx.browser.semanticActions.scroll.results[0].type === "scroll", "Bounded scroll did not run.");
+            ctx.assert(ctx.browser.snapshot.tree.includes("Scrolled down"), "The page did not witness the real scroll input.");
+          },
+          screenshot: { name: "complete-semantic-actions", requireText: ["现代语义动作", "Role → Reviewer", "down/page → waitFor:text"] },
+        });
+      },
+    },
+    {
       name: "Bounded batches reject stale references",
       run: async (ctx) => {
         await ctx.prove("A bounded batch stops after page change and stale refs cannot be replayed", {
-          voiceover: vo[4],
+          voiceover: vo[5],
           action: async () => {
             const before = ctx.browser.snapshot;
             const titleRef = refFor(before.tree, "Post title");
@@ -437,7 +543,7 @@ export default {
       name: "Every engine reaches the same host session",
       run: async (ctx) => {
         await ctx.prove("The engine-facing host tool route returns the same tab and refs", {
-          voiceover: vo[5],
+          voiceover: vo[6],
           action: async () => {
             const serverInfo = await desktopServerInfo(ctx);
             const status = await fetch(`${serverInfo.baseUrl}/status`, { headers: clientHeaders(serverInfo) }).then((response) => response.json());
@@ -478,7 +584,7 @@ export default {
       name: "Consequential clicks require named approval",
       run: async (ctx) => {
         await ctx.prove("Manual approval pauses a publish click and names the requesting session", {
-          voiceover: vo[6],
+          voiceover: vo[7],
           action: async () => {
             const run = await execFile("pnpm", [
               "--filter", "ipollowork-server", "exec", "bun", "test", "src/extensions-connect-gating.test.ts",

--- a/evals/unified-browser-runtime-flows.md
+++ b/evals/unified-browser-runtime-flows.md
@@ -48,7 +48,25 @@ Pass criteria:
 - Fill uses real text input and click uses real pointer events.
 - The final snapshot reflects the page change.
 
-## Flow 3 — stale and unsafe targets fail closed
+## Flow 3 — complete semantic actions and bounded waits
+
+1. Snapshot labelled hover, native select, checkbox, and scrollable controls.
+2. Hover by ref and wait for accessible text instead of sleeping blindly.
+3. Select one exact native option, check the requested state, and scroll by one
+   bounded amount, taking a fresh snapshot whenever requested.
+4. Use Enter or Space only with a stable ref and exact accessible name.
+
+Pass criteria:
+
+- Hover, select, check, scroll, and structured waits all use the same
+  `ipollowork_browser_act` contract for every engine.
+- URL, accessible text, ref visibility, and document readiness waits are
+  bounded to 10 seconds each and 10 seconds per action batch.
+- Select rejects missing or ambiguous options; check is idempotent; radios
+  cannot be unchecked; Enter and Space cannot bypass named-ref validation.
+- No engine-supplied JavaScript, CSS selector, or coordinate is accepted.
+
+## Flow 4 — stale and unsafe targets fail closed
 
 1. Take a snapshot, then navigate or replace the referenced control.
 2. Attempt to act with the old `snapshotId` or ref.
@@ -61,7 +79,7 @@ Pass criteria:
 - No selector fallback, synthetic DOM `.click()`, or arbitrary evaluation is
   used.
 
-## Flow 4 — modern document coverage
+## Flow 5 — modern document coverage
 
 Use a deterministic fixture containing an open/closed shadow tree, a same-origin
 frame, a cross-origin frame, an off-screen control, and a file input.
@@ -75,7 +93,7 @@ Pass criteria:
   data, at most 20 files and 1 GB per file.
 - Unsupported boundaries fail clearly without falling back to page scripts.
 
-## Flow 5 — engine switching keeps one browser session
+## Flow 6 — engine switching keeps one browser session
 
 1. Sign into a test site with one engine and keep the browser tab open.
 2. Switch engines in the same workspace.
@@ -86,7 +104,7 @@ Pass criteria:
 - The same tab, cookies, login state, proxy, and browser permissions remain.
 - A new engine does not start Chrome or create another browser runtime.
 
-## Flow 6 — consequential controls require approval
+## Flow 7 — consequential controls require approval
 
 1. Snapshot a page containing publish, send, submit, pay, buy, confirm, and
    delete controls.
@@ -99,7 +117,7 @@ Pass criteria:
 - The approved attempt performs exactly one verified click.
 - The workspace audit records the actor, tab, and browser action.
 
-## Flow 7 — extension UI remains optional
+## Flow 8 — extension UI remains optional
 
 1. Open the composer Extensions menu and select iPolloWork Browser.
 2. Disable/hide it, verify it disappears from the composer, then restore it.

--- a/evals/voiceovers/unified-agent-browser.md
+++ b/evals/voiceovers/unified-agent-browser.md
@@ -8,8 +8,10 @@
 
 4. I ask it to fill a title and open the preview, and the right-hand page updates through real keyboard and pointer input targeted by those stable references.
 
-5. I ask it to complete several safe steps, and it can fill, wait, and click as one bounded action; if the page changed, it observes again instead of acting on a stale reference.
+5. I ask it to use modern page controls, and the same host runtime can hover, choose an exact option, check a control, scroll, and wait for semantic page state without selector scripts or timing guesses.
 
-6. I switch to another supported engine and give the same instruction, and it uses the same browser session, element references, and permissions rather than a separate engine-specific browser.
+6. I ask it to complete several safe steps, and it can fill, wait, and click as one bounded action; if the page changed, it observes again instead of acting on a stale reference.
 
-7. With manual approval enabled, publishing, payment, deletion, or another consequential action pauses for confirmation and identifies the session or plugin requesting it.
+7. I switch to another supported engine and give the same instruction, and it uses the same browser session, element references, and permissions rather than a separate engine-specific browser.
+
+8. With manual approval enabled, publishing, payment, deletion, or another consequential action pauses for confirmation and identifies the session or plugin requesting it.


### PR DESCRIPTION
## Summary

- complete the shared browser action protocol with hover, native select, check, bounded scroll, and scoped Enter/Space activation
- add structured waits for URL, visible text, semantic refs, and document readiness
- preserve stable-ref validation, exact accessible names, snapshot invalidation, protected-value redaction, and approval gates for consequential controls
- extend Desktop runtime tests, Server schema/policy tests, and the real Fraimz desktop flow

## Architecture

All engines use the same Engine Host schema and Desktop Host executor. This change adds no engine-specific browser adapter, dependency, route, database state, arbitrary JavaScript execution, CSS selector input, or coordinate input.

## Validation

- `node --test electron/browser-runtime.test.mjs` — 10 passed
- `pnpm exec bun test src/extensions-connect-gating.test.ts` — 11 passed
- Desktop full test suite — 133 passed, 3 skipped
- Server full test suite — 537 passed, 3 skipped
- Desktop and Server typechecks passed
- Desktop and Server builds passed
- Fraimz `unified-agent-browser` — 1 passed, 0 failed
- maintainability audit and `git diff --check` passed

<!-- codex-publisher:b7b51a23-caaf-4b38-a47d-34119abdf85e -->