### PR TITLE
style(app): refine task controls and scheduling

### DIFF
--- a/apps/app/src/components/ui/menu-styles.ts
+++ b/apps/app/src/components/ui/menu-styles.ts
@@ -1,4 +1,4 @@
-export const menuSurfaceClassName = "dark relative isolate rounded-[8px]! bg-popover/70 text-popover-foreground shadow-lg ring-1 ring-foreground/5 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 dark:ring-foreground/10";
+export const menuSurfaceClassName = "dark relative isolate rounded-[8px]! bg-popover/70 text-popover-foreground shadow-lg ring-1 ring-foreground/5 backdrop-blur-2xl backdrop-saturate-150 dark:ring-foreground/10";
 
 export const menuInteractionClassName = "**:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!";
 

--- a/apps/app/src/components/ui/select.tsx
+++ b/apps/app/src/components/ui/select.tsx
@@ -85,11 +85,12 @@ function SelectContent({
   align = "center",
   alignOffset = 0,
   alignItemWithTrigger = false,
+  collisionAvoidance,
   ...props
 }: SelectPrimitive.Popup.Props &
   Pick<
     SelectPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger" | "collisionAvoidance"
   >) {
   const styleScope = React.useContext(SelectStyleScopeContext)
   return (
@@ -100,6 +101,7 @@ function SelectContent({
         align={align}
         alignOffset={alignOffset}
         alignItemWithTrigger={alignItemWithTrigger}
+        collisionAvoidance={collisionAvoidance}
         className="isolate z-[70]"
       >
         <SelectPrimitive.Popup

--- a/apps/app/src/components/ui/switch.tsx
+++ b/apps/app/src/components/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border-2 transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-5 data-[size=default]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-unchecked:border-transparent data-unchecked:bg-input/90 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border-2 transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-5 data-[size=default]:w-11 data-[size=sm]:h-4 data-[size=sm]:w-7 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-[#1FBAC0] data-checked:bg-[#1FBAC0] data-unchecked:border-transparent data-unchecked:bg-input/90 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className
       )}
       {...props}

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -846,7 +846,6 @@ export default {
   "work.time.date_picker": "Date",
   "work.time.time_picker": "Time",
   "work.automation.title": "Run automatically",
-  "work.automation.description": "At the start time, the project's entry Agent runs the task title and description.",
   "work.automation.enabled": "Automatic execution enabled",
   "work.automation.recurrence": "Repeat",
   "work.automation.model": "Execution model",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -848,7 +848,6 @@ export default {
   "work.time.date_picker": "日期",
   "work.time.time_picker": "时间",
   "work.automation.title": "自动执行",
-  "work.automation.description": "到开始时间后，由项目入口智能体执行标题和说明中的任务。",
   "work.automation.enabled": "已启用自动执行",
   "work.automation.recurrence": "重复方式",
   "work.automation.model": "执行模型",

--- a/apps/app/src/react-app/domains/session/design/design-panel.tsx
+++ b/apps/app/src/react-app/domains/session/design/design-panel.tsx
@@ -2010,7 +2010,7 @@ export function DesignPanel({
     <Label className={cn("flex shrink-0 items-center gap-2 text-xs", !branding && "order-1")}>
       <Switch
         size="sm"
-        className="border-[#AEB2B9] bg-transparent shadow-none data-checked:!border-[#0A84FF] data-checked:!bg-[#0A84FF] data-unchecked:!border-[#AEB2B9] data-unchecked:!bg-transparent [&_[data-slot=switch-thumb]]:!shadow-none [&_[data-slot=switch-thumb][data-checked]]:!bg-white [&_[data-slot=switch-thumb][data-unchecked]]:!bg-[#62666D]"
+        className="border-[#AEB2B9] bg-transparent shadow-none data-unchecked:!border-[#AEB2B9] data-unchecked:!bg-transparent [&_[data-slot=switch-thumb]]:!shadow-none [&_[data-slot=switch-thumb][data-checked]]:!bg-white [&_[data-slot=switch-thumb][data-unchecked]]:!bg-[#62666D]"
         checked={editing}
         onCheckedChange={(checked) => {
           setEditing(checked);

--- a/apps/app/src/react-app/domains/work/work-item-sheet.tsx
+++ b/apps/app/src/react-app/domains/work/work-item-sheet.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource react */
 import * as React from "react";
-import { CalendarClock, ChevronDown, LockKeyhole, Timer, Trash2 } from "lucide-react";
+import { CalendarClock, CalendarDays, ChevronDown, LockKeyhole, Timer, Trash2 } from "lucide-react";
 import {
   WORK_ITEM_TITLE_MAX_LENGTH,
   type WorkBoardConfig,
@@ -23,7 +23,9 @@ import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
@@ -79,10 +81,21 @@ const filledValueClassName = "font-medium text-dls-accent dark:text-dls-text";
 const placeholderClassName = "placeholder:font-normal placeholder:text-dls-secondary/60";
 const compactInputClassName = `h-[34px] rounded-lg px-2 text-[13px] ${filledValueClassName} ${placeholderClassName}`;
 const compactSelectTriggerClassName = `h-[34px] w-full rounded-lg border-border bg-background px-2 py-2 text-[13px] shadow-none data-[size=default]:h-[34px] ${filledValueClassName}`;
+const UNASSIGNED_ASSIGNEE_VALUE = "__unassigned__";
+const FOLLOW_PROJECT_MODEL_VALUE = "__follow_project_model__";
 const UNSET_CUSTOM_FIELD_VALUE = "__unset__";
 const SCHEDULE_SLOT_MS = 30 * 60 * 1_000;
 const DEFAULT_SCHEDULE_DURATION_MS = 60 * 60 * 1_000;
-const nativeSelectClassName = `h-[34px] w-full rounded-lg border border-border bg-background px-2 text-[13px] outline-none transition focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 ${filledValueClassName}`;
+const TIME_PICKER_INTERVAL_MINUTES = 15;
+const TIME_OPTIONS_15_MINUTES = Array.from(
+  { length: (24 * 60) / TIME_PICKER_INTERVAL_MINUTES },
+  (_, index) => {
+    const totalMinutes = index * TIME_PICKER_INTERVAL_MINUTES;
+    const hour = String(Math.floor(totalMinutes / 60)).padStart(2, "0");
+    const minute = String(totalMinutes % 60).padStart(2, "0");
+    return `${hour}:${minute}`;
+  },
+);
 
 function toDateInput(timestamp: number | null): string {
   if (timestamp === null) return "";
@@ -117,6 +130,11 @@ function updateTimePart(timestamp: number | null, timeValue: string): number | n
   return fromDateAndTime(toDateInput(timestamp) || toDateInput(Date.now()), timeValue);
 }
 
+function timePickerOptions(selectedTime: string): string[] {
+  if (!selectedTime || TIME_OPTIONS_15_MINUTES.includes(selectedTime)) return TIME_OPTIONS_15_MINUTES;
+  return [...TIME_OPTIONS_15_MINUTES, selectedTime].sort();
+}
+
 type DateTimePickerFieldProps = {
   id: string;
   label: string;
@@ -133,6 +151,65 @@ function openNativePicker(event: React.MouseEvent<HTMLInputElement>) {
   event.currentTarget.showPicker();
 }
 
+type TimePicker24HourProps = {
+  id: string;
+  label: string;
+  timestamp: number | null;
+  minimumTime?: string;
+  required?: boolean;
+  invalid?: boolean;
+  describedBy?: string;
+  onChange: (timestamp: number | null) => void;
+};
+
+function TimePicker24Hour(props: TimePicker24HourProps) {
+  const time = toTimeInput(props.timestamp);
+
+  return (
+    <div data-testid={`${props.id}-time-picker-24h`}>
+      <Select
+        value={time || undefined}
+        onValueChange={(nextTime) => {
+          if (!nextTime) return;
+          props.onChange(updateTimePart(props.timestamp, nextTime));
+        }}
+      >
+        <SelectTrigger
+          id={`${props.id}-time`}
+          className={cn(
+            compactSelectTriggerClassName,
+            "rounded-[8px] border-[#EBEBEB] pe-4 leading-[18px] dark:border-border [&_svg]:text-[#858A94] [&_svg]:[stroke-width:1.333]",
+            !time && "font-normal text-dls-secondary",
+          )}
+          aria-label={`${props.label} · ${t("work.time.time_picker")}`}
+          aria-required={props.required || undefined}
+          aria-invalid={props.invalid || undefined}
+          aria-describedby={props.describedBy}
+        >
+          <SelectValue>{time || "--:--"}</SelectValue>
+        </SelectTrigger>
+        <SelectContent
+          side="bottom"
+          align="end"
+          collisionAvoidance={{ side: "none", align: "shift", fallbackAxisSide: "none" }}
+          className="max-h-64 w-(--anchor-width) min-w-(--anchor-width) p-1"
+        >
+          {timePickerOptions(time).map((option) => (
+            <SelectItem
+              key={option}
+              value={option}
+              disabled={Boolean(props.minimumTime && option < props.minimumTime)}
+              className="h-8 px-2 py-0 text-[13px] font-normal"
+            >
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 function DateTimePickerField(props: DateTimePickerFieldProps) {
   const minimumDate = toDateInput(props.min ?? null);
   const minimumTime = minimumDate && minimumDate === toDateInput(props.timestamp)
@@ -143,33 +220,40 @@ function DateTimePickerField(props: DateTimePickerFieldProps) {
       <legend className="text-sm font-semibold leading-5 text-foreground">
         {props.label}{props.required ? <RequiredMark /> : null}
       </legend>
-      <div className="grid grid-cols-[minmax(0,1fr)_7rem] gap-2">
-        <Input
-          ref={props.inputRef}
-          id={`${props.id}-date`}
-          type="date"
+      <div className="grid grid-cols-2 gap-2">
+        <div className="relative min-w-0">
+          <Input
+            ref={props.inputRef}
+            id={`${props.id}-date`}
+            type="date"
+            required={props.required}
+            min={minimumDate || undefined}
+            value={toDateInput(props.timestamp)}
+            className={cn(
+              compactInputClassName,
+              "rounded-[8px] border-[#EBEBEB] pe-10 leading-[18px] dark:border-border [&::-webkit-calendar-picker-indicator]:opacity-0",
+            )}
+            aria-label={`${props.label} · ${t("work.time.date_picker")}`}
+            aria-invalid={props.invalid || undefined}
+            aria-describedby={props.describedBy}
+            onClick={openNativePicker}
+            onChange={(event) => props.onChange(updateDatePart(props.timestamp, event.currentTarget.value))}
+          />
+          <CalendarDays
+            aria-hidden="true"
+            strokeWidth={1}
+            className="pointer-events-none absolute end-4 top-1/2 size-3.5 -translate-y-1/2 text-black dark:text-dls-text"
+          />
+        </div>
+        <TimePicker24Hour
+          id={props.id}
+          label={props.label}
+          timestamp={props.timestamp}
+          minimumTime={minimumTime}
           required={props.required}
-          min={minimumDate || undefined}
-          value={toDateInput(props.timestamp)}
-          className={compactInputClassName}
-          aria-label={`${props.label} · ${t("work.time.date_picker")}`}
-          aria-invalid={props.invalid || undefined}
-          aria-describedby={props.describedBy}
-          onClick={openNativePicker}
-          onChange={(event) => props.onChange(updateDatePart(props.timestamp, event.currentTarget.value))}
-        />
-        <Input
-          id={`${props.id}-time`}
-          type="time"
-          required={props.required}
-          min={minimumTime}
-          value={toTimeInput(props.timestamp)}
-          className={compactInputClassName}
-          aria-label={`${props.label} · ${t("work.time.time_picker")}`}
-          aria-invalid={props.invalid || undefined}
-          aria-describedby={props.describedBy}
-          onClick={openNativePicker}
-          onChange={(event) => props.onChange(updateTimePart(props.timestamp, event.currentTarget.value))}
+          invalid={props.invalid}
+          describedBy={props.describedBy}
+          onChange={props.onChange}
         />
       </div>
     </fieldset>
@@ -186,12 +270,12 @@ function automationRecurrenceFromValue(value: string): WorkItemAutomationRecurre
   return "once";
 }
 
-function automationModelValue(model: ProjectAgentModel | null | undefined): string {
-  return model ? JSON.stringify([model.providerId, model.modelId]) : "";
+function automationModelValue(model: ProjectAgentModel): string {
+  return JSON.stringify([model.providerId, model.modelId]);
 }
 
 function automationModelFromValue(value: string): ProjectAgentModel | null {
-  if (!value) return null;
+  if (value === FOLLOW_PROJECT_MODEL_VALUE) return null;
   try {
     const parsed: unknown = JSON.parse(value);
     if (
@@ -247,13 +331,21 @@ function editorValuesEqual(left: WorkItemEditorValue, right: WorkItemEditorValue
     && JSON.stringify(left.customFields) === JSON.stringify(right.customFields);
 }
 
+function shouldInitiallyOpenTimePanel(item: WorkItem | null, scheduleMode: boolean): boolean {
+  return item === null
+    || scheduleMode
+    || item.startAt !== null
+    || item.dueAt !== null
+    || item.automation !== null;
+}
+
 function RequiredMark() {
   return <span className="text-destructive" aria-hidden="true"> *</span>;
 }
 
 export function WorkItemSheet(props: WorkItemSheetProps) {
   const [value, setValue] = React.useState<WorkItemEditorValue>(() => emptyEditorValue(props.defaultStatus, props.scheduleMode, props.initialSchedule));
-  const [timeOpen, setTimeOpen] = React.useState(false);
+  const [timeOpen, setTimeOpen] = React.useState(() => shouldInitiallyOpenTimePanel(props.item, props.scheduleMode));
   const [validationAttempted, setValidationAttempted] = React.useState(false);
   const [discardConfirmOpen, setDiscardConfirmOpen] = React.useState(false);
   const initialValueRef = React.useRef(value);
@@ -276,11 +368,7 @@ export function WorkItemSheet(props: WorkItemSheetProps) {
     } : emptyEditorValue(props.defaultStatus, props.scheduleMode, props.initialSchedule);
     initialValueRef.current = nextValue;
     setValue(nextValue);
-    setTimeOpen(props.scheduleMode || Boolean(props.item && (
-      props.item.startAt !== null
-      || props.item.dueAt !== null
-      || props.item.automation !== null
-    )));
+    setTimeOpen(shouldInitiallyOpenTimePanel(props.item, props.scheduleMode));
     setValidationAttempted(false);
     setDiscardConfirmOpen(false);
   }, [props.defaultStatus, props.initialSchedule, props.item, props.open, props.scheduleMode]);
@@ -299,7 +387,16 @@ export function WorkItemSheet(props: WorkItemSheetProps) {
   const selectedAutomationModelAvailable = !selectedAutomationModel || modelProviders.some((provider) => (
     provider.id === selectedAutomationModel.providerId && selectedAutomationModel.modelId in provider.models
   ));
-  const selectedAssigneeAvailable = !value.assignee || props.agents.some((agent) => agent.id === value.assignee);
+  const selectedAutomationProvider = selectedAutomationModel
+    ? modelProviders.find((provider) => provider.id === selectedAutomationModel.providerId)
+    : undefined;
+  const selectedAutomationModelName = selectedAutomationModel
+    ? selectedAutomationProvider?.models[selectedAutomationModel.modelId]?.name || selectedAutomationModel.modelId
+    : t("work.automation.follow_project_model");
+  const selectedAssignee = value.assignee
+    ? props.agents.find((agent) => agent.id === value.assignee)
+    : undefined;
+  const selectedAssigneeAvailable = !value.assignee || Boolean(selectedAssignee);
   const isDirty = !editorValuesEqual(value, initialValueRef.current);
   const requestClose = () => {
     if (props.saving || props.deleting) return;
@@ -455,30 +552,32 @@ export function WorkItemSheet(props: WorkItemSheetProps) {
 
           {!props.item?.execution ? <div className="space-y-3">
             <Label htmlFor="work-item-assignee" className="text-sm font-semibold leading-5">{t("work.field.assignee")}</Label>
-            <select
-              id="work-item-assignee"
-              value={value.assignee ?? ""}
-              className={nativeSelectClassName}
-              onChange={(event) => {
-                const assignee = event.currentTarget.value || null;
+            <Select
+              value={value.assignee ?? UNASSIGNED_ASSIGNEE_VALUE}
+              onValueChange={(nextAssignee) => {
+                if (!nextAssignee) return;
+                const assignee = nextAssignee === UNASSIGNED_ASSIGNEE_VALUE ? null : nextAssignee;
                 setValue((current) => ({ ...current, assignee }));
               }}
             >
-              <option value="">{t("project_overview.unassigned")}</option>
-              {!selectedAssigneeAvailable && value.assignee ? (
-                <option value={value.assignee}>{value.assignee}</option>
-              ) : null}
-              {props.agents.map((agent) => (
-                <option key={agent.id} value={agent.id}>{agent.name}</option>
-              ))}
-            </select>
+              <SelectTrigger id="work-item-assignee" className={compactSelectTriggerClassName}>
+                <SelectValue>{value.assignee ? selectedAssignee?.name ?? value.assignee : t("project_overview.unassigned")}</SelectValue>
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectItem value={UNASSIGNED_ASSIGNEE_VALUE}>{t("project_overview.unassigned")}</SelectItem>
+                {!selectedAssigneeAvailable && value.assignee ? (
+                  <SelectItem value={value.assignee}>{value.assignee}</SelectItem>
+                ) : null}
+                {props.agents.map((agent) => (
+                  <SelectItem key={agent.id} value={agent.id}>{agent.name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div> : null}
 
           <Collapsible
-            open={scheduleRequired || timeOpen}
-            onOpenChange={(open) => {
-              if (!scheduleRequired) setTimeOpen(open);
-            }}
+            open={timeOpen}
+            onOpenChange={setTimeOpen}
             className="rounded-xl border border-dls-border/75 bg-dls-surface/45"
           >
             <CollapsibleTrigger className="group flex min-h-11 w-full items-center gap-2 px-3.5 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
@@ -530,7 +629,6 @@ export function WorkItemSheet(props: WorkItemSheetProps) {
                     </span>
                     <span className="min-w-0 flex-1">
                       <span className="block text-[12px] font-medium text-dls-text">{t("work.automation.title")}</span>
-                      <span className="mt-0.5 block text-[9px] leading-4 text-dls-tertiary">{t("work.automation.description")}</span>
                     </span>
                     <Switch
                       checked={value.automation?.enabled === true}
@@ -549,29 +647,34 @@ export function WorkItemSheet(props: WorkItemSheetProps) {
                   {value.automation?.enabled ? (
                     <div className="mt-3 space-y-2">
                       <Label htmlFor="work-item-automation-recurrence">{t("work.automation.recurrence")}</Label>
-                      <select
-                        id="work-item-automation-recurrence"
+                      <Select
                         value={value.automation.recurrence}
-                        className={nativeSelectClassName}
-                        onChange={(event) => {
-                          const recurrence = automationRecurrenceFromValue(event.currentTarget.value);
+                        onValueChange={(nextRecurrence) => {
+                          if (!nextRecurrence) return;
+                          const recurrence = automationRecurrenceFromValue(nextRecurrence);
                           setValue((current) => ({
                             ...current,
                             automation: { enabled: true, recurrence, model: current.automation?.model ?? null },
                           }));
                         }}
                       >
-                        <option value="once">{t("work.automation.once")}</option>
-                        <option value="daily">{t("work.automation.daily")}</option>
-                        <option value="weekly">{t("work.automation.weekly")}</option>
-                      </select>
+                        <SelectTrigger id="work-item-automation-recurrence" className={compactSelectTriggerClassName}>
+                          <SelectValue>{t(`work.automation.${value.automation.recurrence}`)}</SelectValue>
+                        </SelectTrigger>
+                        <SelectContent align="start">
+                          <SelectItem value="once">{t("work.automation.once")}</SelectItem>
+                          <SelectItem value="daily">{t("work.automation.daily")}</SelectItem>
+                          <SelectItem value="weekly">{t("work.automation.weekly")}</SelectItem>
+                        </SelectContent>
+                      </Select>
                       <Label htmlFor="work-item-automation-model">{t("work.automation.model")}</Label>
-                      <select
-                        id="work-item-automation-model"
-                        value={automationModelValue(value.automation.model)}
-                        className={nativeSelectClassName}
-                        onChange={(event) => {
-                          const model = automationModelFromValue(event.currentTarget.value);
+                      <Select
+                        value={selectedAutomationModel
+                          ? automationModelValue(selectedAutomationModel)
+                          : FOLLOW_PROJECT_MODEL_VALUE}
+                        onValueChange={(nextModel) => {
+                          if (!nextModel) return;
+                          const model = automationModelFromValue(nextModel);
                           setValue((current) => ({
                             ...current,
                             automation: current.automation
@@ -580,22 +683,28 @@ export function WorkItemSheet(props: WorkItemSheetProps) {
                           }));
                         }}
                       >
-                        <option value="">{t("work.automation.follow_project_model")}</option>
-                        {!selectedAutomationModelAvailable && selectedAutomationModel ? (
-                          <option value={automationModelValue(selectedAutomationModel)}>
-                            {selectedAutomationModel.providerId} · {selectedAutomationModel.modelId}
-                          </option>
-                        ) : null}
-                        {modelProviders.map((provider) => (
-                          <optgroup key={provider.id} label={provider.name || provider.id}>
-                            {Object.values(provider.models).map((model) => (
-                              <option key={model.id} value={automationModelValue({ providerId: provider.id, modelId: model.id })}>
-                                {model.name || model.id}
-                              </option>
-                            ))}
-                          </optgroup>
-                        ))}
-                      </select>
+                        <SelectTrigger id="work-item-automation-model" className={compactSelectTriggerClassName}>
+                          <SelectValue>{selectedAutomationModelName}</SelectValue>
+                        </SelectTrigger>
+                        <SelectContent align="start">
+                          <SelectItem value={FOLLOW_PROJECT_MODEL_VALUE}>{t("work.automation.follow_project_model")}</SelectItem>
+                          {!selectedAutomationModelAvailable && selectedAutomationModel ? (
+                            <SelectItem value={automationModelValue(selectedAutomationModel)}>
+                              {selectedAutomationModel.providerId} · {selectedAutomationModel.modelId}
+                            </SelectItem>
+                          ) : null}
+                          {modelProviders.map((provider) => (
+                            <SelectGroup key={provider.id}>
+                              <SelectLabel>{provider.name || provider.id}</SelectLabel>
+                              {Object.values(provider.models).map((model) => (
+                                <SelectItem key={model.id} value={automationModelValue({ providerId: provider.id, modelId: model.id })}>
+                                  {model.name || model.id}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          ))}
+                        </SelectContent>
+                      </Select>
                       {modelProviders.length === 0 ? (
                         <p className="text-[9px] leading-4 text-dls-tertiary">{t("work.automation.no_models")}</p>
                       ) : null}

--- a/apps/app/tests/design-expanded-interactions.test.ts
+++ b/apps/app/tests/design-expanded-interactions.test.ts
@@ -9,6 +9,7 @@ const contextMenu = readFileSync(new URL("../src/components/ui/context-menu.tsx"
 const select = readFileSync(new URL("../src/components/ui/select.tsx", import.meta.url), "utf8");
 const popover = readFileSync(new URL("../src/components/ui/popover.tsx", import.meta.url), "utf8");
 const menuStyles = readFileSync(new URL("../src/components/ui/menu-styles.ts", import.meta.url), "utf8");
+const switchControl = readFileSync(new URL("../src/components/ui/switch.tsx", import.meta.url), "utf8");
 
 test("expanded Design menus render above the z-60 panel", () => {
   expect(sidePanel).toContain('positionerClassName={expanded ? "z-[70]" : undefined}');
@@ -19,7 +20,8 @@ test("expanded Design menus render above the z-60 panel", () => {
 
 test("floating menus share an 8px translucent surface with two densities", () => {
   expect(menuStyles).toContain('rounded-[8px]! bg-popover/70');
-  expect(menuStyles).toContain("before:backdrop-blur-2xl");
+  expect(menuStyles).toContain("ring-foreground/5 backdrop-blur-2xl backdrop-saturate-150");
+  expect(menuStyles).not.toContain("before:backdrop-blur");
   expect(menuStyles).toContain("shadow-lg ring-1");
   expect(menuStyles).toContain("default: {");
   expect(menuStyles).toContain("compact: {");
@@ -27,6 +29,11 @@ test("floating menus share an 8px translucent surface with two densities", () =>
     expect(source).toContain("menuSurfaceClassName");
   }
   expect(`${dropdownMenu}\n${contextMenu}\n${select}\n${popover}`).not.toMatch(/rounded-(?:2xl|3xl)/);
+});
+
+test("switches share the teal enabled state", () => {
+  expect(switchControl).toContain("data-checked:border-[#1FBAC0] data-checked:bg-[#1FBAC0]");
+  expect(designPanel).not.toContain("#0A84FF");
 });
 
 test("the parent presentation viewport handles Ctrl or Meta wheel zoom", () => {

--- a/apps/app/tests/project-overview.test.ts
+++ b/apps/app/tests/project-overview.test.ts
@@ -435,11 +435,14 @@ describe("project overview", () => {
     expect(workItemSheetSource).toContain("maxLength={WORK_ITEM_TITLE_MAX_LENGTH}");
     expect(workItemSheetSource).toContain("scheduleRequired = props.scheduleMode");
     expect(workItemSheetSource).not.toContain("props.scheduleMode && props.item === null");
-    expect(workItemSheetSource).toContain("setTimeOpen(props.scheduleMode");
+    expect(workItemSheetSource).toContain("shouldInitiallyOpenTimePanel(props.item, props.scheduleMode)");
+    expect(workItemSheetSource).toContain("return item === null");
     expect(workItemSheetSource).toContain("showCloseButton");
     expect(workItemSheetSource).toContain('w-[min(396px,100vw)]');
     expect(workItemSheetSource).toContain('<SelectTrigger id="work-item-status"');
-    expect(workItemSheetSource).toContain("open={scheduleRequired || timeOpen}");
+    expect(workItemSheetSource).toContain("open={timeOpen}");
+    expect(workItemSheetSource).toContain("onOpenChange={setTimeOpen}");
+    expect(workItemSheetSource).not.toContain("open={scheduleRequired || timeOpen}");
     expect(workItemSheetSource).toContain("required={scheduleRequired}");
     expect(workItemSheetSource).toContain('placeholder={t("work.field.title_placeholder")}');
     expect(workItemSheetSource).toContain('placeholder={t("work.field.description_placeholder")}');
@@ -552,15 +555,29 @@ describe("project overview", () => {
     expect(deleteMutationSource).toContain('onError: (error) => toast.error(t("work.delete_failed")');
   });
 
-  test("uses separate native date and time pickers for task scheduling", () => {
+  test("uses a native date picker and a 15-minute 24-hour time menu for task scheduling", () => {
     expect(workItemSheetSource).toContain("function DateTimePickerField");
+    expect(workItemSheetSource).toContain("function TimePicker24Hour");
     expect(workItemSheetSource).toContain('data-testid="work-item-time-pickers"');
     expect(workItemSheetSource).toContain('type="date"');
-    expect(workItemSheetSource).toContain('type="time"');
+    expect(workItemSheetSource).not.toContain('type="time"');
+    expect(workItemSheetSource).toContain("const TIME_PICKER_INTERVAL_MINUTES = 15;");
+    expect(workItemSheetSource).toContain("TIME_OPTIONS_15_MINUTES");
+    expect(workItemSheetSource).toContain("timePickerOptions(time).map");
+    expect(workItemSheetSource).toContain('id={`${props.id}-time`}');
+    expect(workItemSheetSource).toContain("option < props.minimumTime");
+    expect(workItemSheetSource).toContain('side="bottom"');
+    expect(workItemSheetSource).toContain('collisionAvoidance={{ side: "none", align: "shift", fallbackAxisSide: "none" }}');
+    expect(workItemSheetSource).toContain('className="max-h-64 w-(--anchor-width) min-w-(--anchor-width) p-1"');
+    expect(workItemSheetSource).toContain('className="grid grid-cols-2 gap-2"');
+    expect(workItemSheetSource).toContain("<CalendarDays");
+    expect(workItemSheetSource).toContain("strokeWidth={1}");
+    expect(workItemSheetSource).toContain('rounded-[8px] border-[#EBEBEB] pe-4 leading-[18px]');
+    expect(workItemSheetSource).toContain('[&_svg]:text-[#858A94] [&_svg]:[stroke-width:1.333]');
     expect(workItemSheetSource).toContain("updateDatePart(props.timestamp");
     expect(workItemSheetSource).toContain("updateTimePart(props.timestamp");
     expect(workItemSheetSource).toContain("event.currentTarget.showPicker();");
-    expect(workItemSheetSource.match(/onClick=\{openNativePicker\}/g)).toHaveLength(2);
+    expect(workItemSheetSource.match(/onClick=\{openNativePicker\}/g)).toHaveLength(1);
     expect(workItemSheetSource).not.toContain('type="datetime-local"');
   });
 
@@ -569,20 +586,30 @@ describe("project overview", () => {
     expect(workItemSheetSource).toContain('checked={value.automation?.enabled === true}');
     expect(workItemSheetSource).toContain('t("work.automation.recurrence")');
     expect(workItemSheetSource).toContain('current.automation?.recurrence ?? "once"');
-    expect(workItemSheetSource).toContain('id="work-item-automation-model"');
+    expect(workItemSheetSource).toContain('SelectTrigger id="work-item-automation-recurrence"');
+    expect(workItemSheetSource).toContain('SelectTrigger id="work-item-automation-model"');
+    expect(workItemSheetSource).toContain('<SelectItem value={FOLLOW_PROJECT_MODEL_VALUE}>');
+    expect(workItemSheetSource).toContain('<SelectGroup key={provider.id}>');
+    expect(workItemSheetSource).toContain('<SelectLabel>{provider.name || provider.id}</SelectLabel>');
     expect(workItemSheetSource).toContain('t("work.automation.follow_project_model")');
     expect(workItemSheetSource).toContain("automationModelFromValue");
     expect(workCenterSource).toContain("connectedProviderIds={props.connectedProviderIds}");
     expect(workItemSheetSource).toContain("invalidAutomation");
+    expect(workItemSheetSource).not.toContain("work.automation.description");
+    expect(workItemSheetSource).toContain("work.automation.runtime_notice");
   });
 
   test("selects task owners from the current project's Agent configuration", () => {
     expect(workCenterSource).toContain('["work-item-project-agents", editorEndpoint?.key, editorEndpoint?.workspaceId]');
     expect(workCenterSource).toContain("readProjectWorkspaceConfig(response.ipollowork, editorEndpoint.workspace.engineId).agents");
     expect(workCenterSource).toContain("agents={editorAgentsQuery.data ?? []}");
-    expect(workItemSheetSource).toContain('<select\n              id="work-item-assignee"');
+    expect(workItemSheetSource).toContain('SelectTrigger id="work-item-assignee"');
+    expect(workItemSheetSource).toContain('<SelectItem value={UNASSIGNED_ASSIGNEE_VALUE}>');
     expect(workItemSheetSource).toContain("props.agents.map((agent)");
-    expect(workItemSheetSource).toContain('<option key={agent.id} value={agent.id}>{agent.name}</option>');
+    expect(workItemSheetSource).toContain('<SelectItem key={agent.id} value={agent.id}>{agent.name}</SelectItem>');
+    expect(workItemSheetSource).not.toContain("nativeSelectClassName");
+    expect(workItemSheetSource).not.toContain("<select");
+    expect(workItemSheetSource).not.toContain("<SelectValue />");
     expect(workItemSheetSource).not.toContain('placeholder={t("work.field.assignee_placeholder")}');
   });
 });


### PR DESCRIPTION
## Summary

- Standardize task owner and automatic-execution dropdowns using the shared floating menu components.
- Apply the unified 8px translucent, blurred menu surface and teal `#1FBAC0` switch state.
- Remove the automatic-execution description beside the switch.
- Make task scheduling expanded by default while remaining collapsible.
- Replace the native time input with a 24-hour dropdown using 15-minute intervals.
- Match the Figma date/time control styling, sizing, borders, typography, and icons.
- Preserve minimum-time validation and existing non-15-minute stored values.

## Testing

- `pnpm --filter @ipollowork/app exec bun test --isolate tests/project-overview.test.ts tests/design-expanded-interactions.test.ts`
- `pnpm --filter @ipollowork/app typecheck`
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`
- Verified the create/edit task flows in the Electron development client.