### PR TITLE
chore: release v0.50.0

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/app",
   "private": true,
-  "version": "0.21.5",
+  "version": "0.50.0",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/desktop",
   "private": true,
-  "version": "0.21.5",
+  "version": "0.50.0",
   "description": "iPolloWork desktop shell",
   "author": {
     "name": "iPolloWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-orchestrator",
-  "version": "0.21.1",
+  "version": "0.50.0",
   "description": "iPolloWork host orchestrator for opencode + iPolloWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.18.16",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "ipollowork-server": "0.21.1",
+    "ipollowork-server": "0.50.0",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-server",
-  "version": "0.21.1",
+  "version": "0.50.0",
   "description": "Filesystem-backed API for iPolloWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       ipollowork-server:
-        specifier: 0.21.1
+        specifier: 0.50.0
         version: link:../server
       solid-js:
         specifier: 1.9.9

--- a/scripts/release/package-client.mjs
+++ b/scripts/release/package-client.mjs
@@ -3,7 +3,7 @@
  * Builds a distributable desktop client from a single release sequence.
  *
  * Source checkouts use 0.0.0 as the unshipped baseline. Each `package` call
- * advances to the next patch release.
+ * advances to the next client release: 0.1.0 ... 0.99.0, then 1.0.0.
  * The flow deliberately does not commit, tag, push, or publish remotely.
  */
 import { spawnSync } from "node:child_process";
@@ -22,20 +22,23 @@ const versionFiles = [
   "pnpm-lock.yaml",
 ];
 const packageFiles = versionFiles.slice(0, -1);
-const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const versionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.0$/;
 
 export function nextClientVersion(version) {
   const match = versionPattern.exec(version);
   if (!match) {
     throw new Error(
-      `Client version must use semantic versioning (X.Y.Z), got "${version}".`,
+      `Client version must use the X.Y.0 release sequence, got "${version}".`,
     );
   }
 
   const major = Number(match[1]);
   const minor = Number(match[2]);
-  const patch = Number(match[3]);
-  return `${major}.${minor}.${patch + 1}`;
+  if (minor > 99) {
+    throw new Error(`Client version minor must be between 0 and 99, got "${version}".`);
+  }
+
+  return minor === 99 ? `${major + 1}.0.0` : `${major}.${minor + 1}.0`;
 }
 
 function parseArgs(argv) {


### PR DESCRIPTION
## Release\n\n- align app, desktop, orchestrator, and server versions to 0.50.0\n- align the orchestrator server dependency and lockfile\n- restore the documented X.Y.0 desktop release sequence\n\n## Verification\n\n- release tag verification for v0.50.0\n- strict release review\n- release-script tests\n- app, server, orchestrator, and Electron bridge type checks