### PR TITLE
fix(release): package engine runtimes without a shell

### DIFF
--- a/apps/desktop/scripts/package-engine-runtime.mjs
+++ b/apps/desktop/scripts/package-engine-runtime.mjs
@@ -35,7 +35,7 @@ function run(command, args, cwd = desktopRoot) {
     cwd,
     env: process.env,
     stdio: "inherit",
-    shell: process.platform === "win32",
+    shell: false,
   });
   if (result.status !== 0) process.exit(result.status ?? 1);
 }


### PR DESCRIPTION
## Fix\n\nRun Node and tar directly when packaging optional Agent engine runtimes. On Windows, shell execution passed a drive-letter path to tar as a remote archive target.\n\n## Verification\n\n- reproduced the Windows x64 failure from Release run 32980825416\n- generated a DeepSeek Harness runtime archive after the fix\n- verified the generated SHA-256 checksum