### PR TITLE
fix(release): write engine archives from their output directory

### DIFF
--- a/apps/desktop/scripts/package-engine-runtime.mjs
+++ b/apps/desktop/scripts/package-engine-runtime.mjs
@@ -75,7 +75,7 @@ async function packageEngine(engineId, outputDirectory) {
   for (const entry of entries) {
     if (!existsSync(resolve(runtimeRoot, entry))) throw new Error(`Missing engine runtime entry: ${entry}`);
   }
-  run("tar", ["-czf", archivePath, "-C", runtimeRoot, ...entries]);
+  run("tar", ["-czf", name, "-C", runtimeRoot, ...entries], outputDirectory);
   const checksum = await sha256File(archivePath);
   writeFileSync(`${archivePath}.sha256`, `${checksum}  ${name}\n`);
   process.stdout.write(`[engine-package] ${archivePath}\n`);


### PR DESCRIPTION
## Fix\n\nRun tar inside the engine package output directory and pass only the archive filename. GNU tar on Windows interprets an absolute drive-letter archive path as a remote target, even without a command shell.\n\n## Verification\n\n- confirmed the first fix removed shell execution\n- reproduced the remaining GNU tar drive-letter failure in Release run 32982652608\n- generated a DeepSeek Harness archive using an external output directory\n- verified the generated SHA-256 checksum