### PR TITLE
fix(release): gate optional AUR publishing

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -861,6 +861,7 @@ jobs:
     needs: [resolve-release, publish-electron, publish-release]
     if: |
       always() &&
+      vars.AUR_PUBLISH_ENABLED == 'true' &&
       needs.resolve-release.result == 'success' &&
       needs.publish-electron.result == 'success' &&
       (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')


### PR DESCRIPTION
## Summary
- run AUR publishing only when AUR_PUBLISH_ENABLED is explicitly true
- keep missing AUR automation on the dev branch from turning a successful desktop release red

## Verification
- node scripts/release/verify-tag.mjs --tag v0.50.0
- node scripts/release/review.mjs --strict
- Ruby YAML parse
- git diff --check
- node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs