### PR TITLE
fix(release): exclude checksum manifest from itself

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -949,7 +949,7 @@ jobs:
 
           (
             cd "$release_dir"
-            find . -type f -printf '%P\n' | sort | while IFS= read -r asset; do
+            find . -type f ! -name 'SHA256SUMS.txt' -printf '%P\n' | sort | while IFS= read -r asset; do
               sha256sum "$asset"
             done > SHA256SUMS.txt
           )


### PR DESCRIPTION
## Summary
- exclude SHA256SUMS.txt from its own generated input list
- prevent the published checksum manifest from containing an empty-file self entry

## Verification
- node scripts/release/verify-tag.mjs --tag v0.50.0
- node scripts/release/review.mjs --strict
- Ruby YAML parse
- git diff --check
- node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs
- post-merge recovery workflow will regenerate and verify the public manifest