### PR TITLE
chore: prepare v0.50.7 release

### DIFF
--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-orchestrator",
-  "version": "0.50.0",
+  "version": "0.50.7",
   "description": "iPolloWork host orchestrator for opencode + iPolloWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.18.16",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "ipollowork-server": "0.50.0",
+    "ipollowork-server": "0.50.7",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-server",
-  "version": "0.50.0",
+  "version": "0.50.7",
   "description": "Filesystem-backed API for iPolloWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,7 +298,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       ipollowork-server:
-        specifier: 0.50.0
+        specifier: 0.50.7
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
## Release

Prepare the repository for the existing client version `0.50.7` by aligning the orchestrator, server, and lockfile versions.

## Scope

- `apps/orchestrator/package.json`: `0.50.0` → `0.50.7`
- `apps/server/package.json`: `0.50.0` → `0.50.7`
- `pnpm-lock.yaml`: align the exact `ipollowork-server` dependency

No customer-specific workspace or data-annotation plugin code is included.

## Verification

- `node scripts/release/review.mjs --strict`
- `node scripts/release/verify-tag.mjs --tag v0.50.7`
- `pnpm typecheck`
- `pnpm --filter @ipollowork/desktop check:electron`
- `node --test apps/desktop/electron/browser-runtime.test.mjs` (10/10)
- `node --test scripts/release/package-client.test.mjs` (3/3)
- `pnpm --filter @ipollowork/types build`
- `pnpm --filter @ipollowork/app build`
