### PR TITLE
fix: restore macOS release notarization

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -254,7 +254,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          # Dispatch-based recovery builds from the selected workflow ref so a
+          # packaging fix can repair an existing tag without moving that tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || env.RELEASE_TAG }}
           fetch-depth: 0
 
       - name: Setup Node
@@ -322,7 +324,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ env.RELEASE_TAG }}
+          # Dispatch-based recovery builds from the selected workflow ref so a
+          # packaging fix can repair an existing tag without moving that tag.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || env.RELEASE_TAG }}
           fetch-depth: 0
 
       - name: Enable git long paths (Windows)

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -15,11 +15,6 @@ files:
   - "!server/dist/opencode-plugins/**"
   - package.json
 extraResources:
-  - from: dist-engine-packs
-    to: engine-packs
-    filter:
-      - "ipollowork-engine-*.tar.gz"
-      - "ipollowork-engine-*.tar.gz.sha256"
   - from: ../../examples/plugin-packages/figma
     to: plugin-packages/figma
   - from: ../../examples/plugin-packages/notion
@@ -104,6 +99,8 @@ mac:
   extendInfo:
     NSMicrophoneUsageDescription: iPolloWork uses the microphone when you start Voice Mode so you can speak commands to your agent.
   extraResources:
+    # Optional engine archives contain third-party native executables. Keep
+    # them as verified Release downloads so Apple notarizes only the app.
     - from: resources/icons/mac
       to: icons/mac
       filter:
@@ -130,6 +127,11 @@ mac:
 linux:
   icon: resources/icons/icon.png
   extraResources:
+    - from: dist-engine-packs
+      to: engine-packs
+      filter:
+        - "ipollowork-engine-*.tar.gz"
+        - "ipollowork-engine-*.tar.gz.sha256"
     - from: resources/sidecars
       to: sidecars
       filter:
@@ -148,6 +150,11 @@ linux:
 win:
   icon: resources/icons/windows/icon.ico
   extraResources:
+    - from: dist-engine-packs
+      to: engine-packs
+      filter:
+        - "ipollowork-engine-*.tar.gz"
+        - "ipollowork-engine-*.tar.gz.sha256"
     - from: resources/icons
       to: icons
       filter:

--- a/apps/desktop/electron/sidecar-packaging.test.mjs
+++ b/apps/desktop/electron/sidecar-packaging.test.mjs
@@ -14,7 +14,7 @@ import {
 
 const afterPack = afterPackModule.default ?? afterPackModule;
 
-it("ships Harness CLIs as verified bundled engine packages with network fallback", async () => {
+it("ships Harness CLIs as verified engine packages with platform-safe bundling", async () => {
   const [builderConfig, mainSource, managerSource, packageSource, windowsPackageSource, macPackageSource, releaseWorkflow, desktopBuildWorkflow, stdioRuntimeSource, buildSource, devSource, codexPrepareSource, codexRuntimeManifest, workspaceConfig, osxSignPatch] = await Promise.all([
     readFile(new URL("../electron-builder.yml", import.meta.url), "utf8"),
     readFile(new URL("./main.mjs", import.meta.url), "utf8"),
@@ -35,7 +35,12 @@ it("ships Harness CLIs as verified bundled engine packages with network fallback
   assert.doesNotMatch(builderConfig, /from: dsh-runtime\s+to: dsh-runtime/);
   assert.match(builderConfig, /from: \.\.\/\.\.\/examples\/plugin-packages\/deepseek-harness/);
   assert.doesNotMatch(builderConfig, /from: codex-runtime\s+to: codex-runtime/);
-  assert.match(builderConfig, /from: dist-engine-packs\s+to: engine-packs/);
+  const macConfig = builderConfig.match(/\nmac:\n[\s\S]*?\nlinux:\n/)?.[0] ?? "";
+  const linuxConfig = builderConfig.match(/\nlinux:\n[\s\S]*?\nwin:\n/)?.[0] ?? "";
+  const windowsConfig = builderConfig.match(/\nwin:\n[\s\S]*$/)?.[0] ?? "";
+  assert.doesNotMatch(macConfig, /from: dist-engine-packs\s+to: engine-packs/);
+  assert.match(linuxConfig, /from: dist-engine-packs\s+to: engine-packs/);
+  assert.match(windowsConfig, /from: dist-engine-packs\s+to: engine-packs/);
   assert.match(mainSource, /createEnginePackageManager/);
   assert.match(mainSource, /app\.getAppPath\(\).*server.*dist.*constants\.json/);
   assert.match(mainSource, /resourcesPath: process\.resourcesPath/);
@@ -59,6 +64,10 @@ it("ships Harness CLIs as verified bundled engine packages with network fallback
   assert.match(windowsPackageSource, /package-engine-runtime\.mjs/);
   assert.match(macPackageSource, /package-engine-runtime\.mjs/);
   assert.match(releaseWorkflow, /package-engine-runtime\.mjs --all --clean --outdir.*apps\/desktop\/dist-engine-packs/);
+  assert.match(releaseWorkflow, /github\.event_name == 'workflow_dispatch' && github\.ref_name \|\| env\.RELEASE_TAG/);
+  const afterSignSource = await readFile(new URL("../scripts/electron-after-sign.cjs", import.meta.url), "utf8");
+  assert.match(afterSignSource, /notarytool[\s\S]*--output-format[\s\S]*json/);
+  assert.match(afterSignSource, /notarytool", "log"/);
   assert.match(desktopBuildWorkflow, /package:engine-runtimes/);
   assert.match(stdioRuntimeSource, /windowsHide: true/);
   assert.match(codexPrepareSource, /Codex native Windows runtime was not installed/);

--- a/apps/desktop/scripts/electron-after-sign.cjs
+++ b/apps/desktop/scripts/electron-after-sign.cjs
@@ -12,6 +12,17 @@ function run(command, args) {
   }
 }
 
+function capture(command, args) {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} failed with status ${result.status}`);
+  }
+  return result.stdout;
+}
+
 function requireEnv(name) {
   const value = process.env[name];
   if (!value) {
@@ -60,21 +71,25 @@ async function afterSign(context) {
   const keyPath = requireEnv("APPLE_API_KEY_PATH");
   const keyId = requireEnv("APPLE_API_KEY");
   const issuer = requireEnv("APPLE_API_ISSUER");
+  const credentials = ["--key", keyPath, "--key-id", keyId, "--issuer", issuer];
 
   try {
     run("ditto", ["-c", "-k", "--keepParent", appPath, notaryZipPath]);
-    run("xcrun", [
+    const submission = JSON.parse(capture("xcrun", [
       "notarytool",
       "submit",
       notaryZipPath,
-      "--key",
-      keyPath,
-      "--key-id",
-      keyId,
-      "--issuer",
-      issuer,
+      ...credentials,
       "--wait",
-    ]);
+      "--output-format",
+      "json",
+    ]));
+    if (submission.status !== "Accepted") {
+      if (submission.id) {
+        run("xcrun", ["notarytool", "log", submission.id, ...credentials]);
+      }
+      throw new Error(`Apple notarization returned ${submission.status ?? "an unknown status"}.`);
+    }
     run("xcrun", ["stapler", "staple", appPath]);
     run("xcrun", ["stapler", "validate", appPath]);
   } finally {


### PR DESCRIPTION
## Summary
- keep optional engine archives outside the notarized macOS app while preserving verified release downloads
- let workflow-dispatch recovery builds use the selected repository ref without moving an existing release tag
- print Apple notarization logs when a submission is rejected

## Verification
- `node --test apps/desktop/electron/sidecar-packaging.test.mjs` (13 passed)
- `pnpm --filter @ipollowork/desktop typecheck:electron`
- `node scripts/release/verify-tag.mjs --tag v0.50.7`
- `node scripts/release/review.mjs --strict`
- `node .codex/skills/ipollowork-maintainable-code/scripts/audit-changes.mjs`
- `git diff --check`
- `pnpm --filter @ipollowork/desktop check:electron`

Full desktop suite: 135 passed, 8 environment-dependent engine-discovery tests failed because installed official Codex/DeepSeek resources override their fixtures; the focused packaging suite passed.