### PR TITLE
feat(sidebar): persistent project and session layout

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -627,6 +627,7 @@ export type SessionPageHistoryControls = {
 
 export type SessionPageSidebarProps = {
   projectSessionLists: ProjectSessionList[];
+  workContextId?: string;
   selectedWorkspaceId: string;
   selectedSessionId: string | null;
   developerMode: boolean;
@@ -4432,6 +4433,7 @@ export function SessionPage(props: SessionPageProps) {
       >
         <AppSidebar
           projectSessionLists={props.sidebar.projectSessionLists}
+          workContextId={props.sidebar.workContextId}
           selectedWorkspaceId={props.sidebar.selectedWorkspaceId}
           developerMode={props.sidebar.developerMode}
           selectedSessionId={props.sidebar.selectedSessionId}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx
@@ -8,6 +8,15 @@ import type { iPolloWorkSessionType } from "./session-type";
 export type { iPolloWorkSessionType } from "./session-type";
 export type iPolloWorkTemplateId = string;
 
+export type SidebarDragPayload =
+  | { kind: "project"; id: string }
+  | { kind: "session"; key: string; sourceWorkspaceId: string; sessionId: string };
+
+export type SidebarDropTarget =
+  | { kind: "project"; id: string }
+  | { kind: "session"; key: string }
+  | null;
+
 export type SidebarContextValue = {
   selectedWorkspaceId: string;
   selectedSessionId: string | null;
@@ -34,6 +43,12 @@ export type SidebarContextValue = {
   onEditWorkspaceConnection: (workspaceId: string) => void;
   toggleSessionExpanded: (sessionId: string) => void;
   expandedSessionIds: Set<string>;
+  draggingItem: SidebarDragPayload | null;
+  dropTarget: SidebarDropTarget;
+  onDragStart: (payload: SidebarDragPayload) => void;
+  onDragEnd: () => void;
+  onDragOver: (target: Exclude<SidebarDropTarget, null>, event: React.DragEvent<HTMLElement>) => void;
+  onDrop: (target: Exclude<SidebarDropTarget, null>, event: React.DragEvent<HTMLElement>) => void;
 };
 
 export const SidebarContext = React.createContext<SidebarContextValue | null>(null);

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -91,18 +91,27 @@ import { Button } from "@/components/ui/button";
 import { TemplateIcon } from "@/components/template-icon";
 
 import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
-import type { SidebarContextValue, iPolloWorkSessionType, iPolloWorkTemplateId } from "./app-sidebar-provider";
+import type {
+  SidebarContextValue,
+  SidebarDragPayload,
+  SidebarDropTarget,
+  iPolloWorkSessionType,
+  iPolloWorkTemplateId,
+} from "./app-sidebar-provider";
 import {
   MAX_SESSIONS_PREVIEW,
+  buildSidebarArchivedSessions,
   buildSessionTreeState,
+  buildSidebarLayoutView,
   flattenSessionRows,
   getRootSessions,
   isSessionArchived,
   isStreamingSessionStatus,
-  partitionArchivedSessions,
+  visibleProjectSessionLists,
   workspaceLabel,
 } from "./utils";
-import type { FlattenedSessionRow, SessionListItem, SessionTreeState } from "./utils";
+import { sessionLayoutKey, useSidebarLayoutStore } from "./sidebar-layout-store";
+import type { FlattenedSessionRow, SidebarDisplaySession, SessionListItem, SessionTreeState } from "./utils";
 import {
   usePinnedSessionIds,
   useSessionPinStore,
@@ -264,11 +273,13 @@ function SessionActions({ className, sessionId, workspaceId, isPinned, isArchive
     <DropdownMenu>
       <DropdownMenuTrigger className="size-6 text-muted-foreground"
         render={
-          <Button
+            <Button
             variant="ghost"
             size="icon-sm"
             className={cn("size-6", className)}
-            onClick={(event) => event.stopPropagation()}
+              onClick={(event) => event.stopPropagation()}
+              draggable={false}
+              onDragStart={(event) => event.stopPropagation()}
           >
             <span className="flex size-4 items-center justify-center" aria-hidden="true">
               <img src={publicAssetUrl("sidebar-icon/figma-section-ellipsis.svg")} alt="" className="h-[2.33333px] w-[11.6667px]" />
@@ -407,6 +418,7 @@ function RemoteConnectionIssueCard(props: {
 
 export type AppSidebarProps = {
   projectSessionLists: ProjectSessionList[];
+  workContextId?: string;
   selectedWorkspaceId: string;
   developerMode: boolean;
   selectedSessionId: string | null;
@@ -527,12 +539,38 @@ function isSessionActivityStatus(status: string | undefined): status is SessionA
 
 export function AppSidebar(props: AppSidebarProps) {
   const activeEnterprise = useActiveEnterpriseConnection();
+  const layout = useSidebarLayoutStore();
+  const contextId = props.workContextId?.trim() || "personal";
   const [expandedSessionIds, setExpandedSessionIds] = React.useState<Set<string>>(
     () => new Set(),
   );
   const [language, setLanguage] = React.useState<Language>(() => currentLocale());
   const [projectsExpanded, setProjectsExpanded] = React.useState(true);
-  const namedProjects = props.projectSessionLists.filter((project) => !project.workspace.isDefault);
+  const [archivedExpanded, setArchivedExpanded] = React.useState(false);
+  const sourceProjects = React.useMemo(
+    () => visibleProjectSessionLists(props.projectSessionLists),
+    [props.projectSessionLists],
+  );
+  const namedProjects = React.useMemo(
+    () => buildSidebarLayoutView(props.projectSessionLists, layout, contextId),
+    [contextId, layout, props.projectSessionLists],
+  );
+  const archivedSessions = React.useMemo(
+    () => buildSidebarArchivedSessions(props.projectSessionLists),
+    [props.projectSessionLists],
+  );
+  const sourceProjectBySessionKey = React.useMemo(() => {
+    const result: Record<string, string> = {};
+    for (const project of sourceProjects) {
+      for (const session of project.sessions) {
+        result[sessionLayoutKey(project.workspace.id, session.id)] = project.workspace.id;
+      }
+    }
+    return result;
+  }, [sourceProjects]);
+  const sessionKeys = React.useMemo(() => Object.keys(sourceProjectBySessionKey), [sourceProjectBySessionKey]);
+  const [draggingItem, setDraggingItem] = React.useState<SidebarDragPayload | null>(null);
+  const [dropTarget, setDropTarget] = React.useState<SidebarDropTarget>(null);
   const selectedProject = namedProjects.find((project) => project.workspace.id === props.selectedWorkspaceId)
     ?? namedProjects[0];
   const primarySidebarActionClass = cn(
@@ -543,6 +581,56 @@ export function AppSidebar(props: AppSidebarProps) {
     setLanguage(nextLanguage);
     setLocale(nextLanguage);
   }, []);
+
+  React.useEffect(() => {
+    layout.prune({
+      contextId,
+      projectIds: sourceProjects.map((project) => project.workspace.id),
+      sessionKeys,
+      sourceProjectBySessionKey,
+    });
+  }, [contextId, layout, sessionKeys, sourceProjectBySessionKey, sourceProjects]);
+
+  const handleDragStart = React.useCallback((payload: SidebarDragPayload) => {
+    setDraggingItem(payload);
+  }, []);
+
+  const handleDragEnd = React.useCallback(() => {
+    setDraggingItem(null);
+    setDropTarget(null);
+  }, []);
+
+  const handleDragOver = React.useCallback((target: Exclude<SidebarDropTarget, null>, event: React.DragEvent<HTMLElement>) => {
+    const current = draggingItem;
+    if (!current) return;
+    const allowed = current.kind === "project"
+      ? target.kind === "project" && current.id !== target.id
+      : target.kind === "project" || (target.kind === "session" && current.key !== target.key);
+    if (!allowed) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    setDropTarget(target);
+  }, [draggingItem]);
+
+  const handleDrop = React.useCallback((target: Exclude<SidebarDropTarget, null>, event: React.DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    const current = draggingItem;
+    if (!current) return;
+    if (current.kind === "project" && target.kind === "project") {
+      layout.reorderProjects(contextId, current.id, target.id);
+    } else if (current.kind === "session" && target.kind === "project") {
+      layout.moveSession(current.key, target.id);
+    } else if (current.kind === "session" && target.kind === "session") {
+      const targetProject = namedProjects.find((project) => project.sessions.some((session) => (
+        sessionLayoutKey(session.sourceWorkspaceId, session.id) === target.key
+      )));
+      if (targetProject) {
+        layout.moveSession(current.key, targetProject.workspace.id);
+        layout.reorderSessions(targetProject.workspace.id, current.key, target.key);
+      }
+    }
+    handleDragEnd();
+  }, [contextId, draggingItem, handleDragEnd, layout, namedProjects]);
 
   React.useEffect(() => {
     const syncLanguage = () => setLanguage(currentLocale());
@@ -631,6 +719,12 @@ export function AppSidebar(props: AppSidebarProps) {
     onEditWorkspaceConnection: props.onEditWorkspaceConnection,
     toggleSessionExpanded,
     expandedSessionIds,
+    draggingItem,
+    dropTarget,
+    onDragStart: handleDragStart,
+    onDragEnd: handleDragEnd,
+    onDragOver: handleDragOver,
+    onDrop: handleDrop,
   };
 
   const brandLogoUrl = useBrandLogoUrl();
@@ -781,6 +875,14 @@ export function AppSidebar(props: AppSidebarProps) {
                 ))}
               </CollapsibleContent>
             </Collapsible>
+            {archivedSessions.length > 0 ? (
+              <ArchivedSessionsSection
+                sessions={archivedSessions}
+                sessionStatusById={props.sessionStatusById}
+                expanded={archivedExpanded}
+                onToggle={() => setArchivedExpanded((value) => !value)}
+              />
+            ) : null}
           </m.div>
         </LazyMotion>
 
@@ -928,12 +1030,8 @@ function ProjectSidebarContent({
     (connectionState.status === "error" || project.status === "error");
   const pinnedIds = usePinnedSessionIds();
 
-  const { active: activeSessions, archived: archivedSessions } = React.useMemo(
-    () => partitionArchivedSessions(project.sessions),
-    [project.sessions],
-  );
-  const projectRootSessions = getRootSessions(activeSessions);
-  const projectStatuses = activeSessions.map((session) => ctx.sessionStatusById?.[session.id]);
+  const projectRootSessions = getRootSessions(project.sessions);
+  const projectStatuses = project.sessions.map((session) => ctx.sessionStatusById?.[session.id]);
   const projectStreamingStatus = projectStatuses.find(isStreamingSessionStatus);
   const projectActivityStatus = projectStreamingStatus ?? projectStatuses.find((status) => status && status !== "idle");
   const projectIsStreaming = projectRootSessions.some((session) => tree.streamingIds.has(session.id));
@@ -947,8 +1045,7 @@ function ProjectSidebarContent({
     forcedExpandedSessionIds,
     pinnedIds,
   );
-  const remainingSessionCount = Math.max(0, getRootSessions(activeSessions).length - sessionPreviewCount);
-  const [archivedExpanded, setArchivedExpanded] = React.useState(false);
+  const remainingSessionCount = Math.max(0, projectRootSessions.length - sessionPreviewCount);
   const [creatingConversation, setCreatingConversation] = React.useState(false);
   const createConversationInProject = async () => {
     if (creatingConversation) return;
@@ -968,7 +1065,22 @@ function ProjectSidebarContent({
       <SidebarGroupContent>
         <Collapsible open={projectExpanded} onOpenChange={setProjectExpanded} className="group/project">
           {showProjectRow ? <SidebarMenu>
-            <SidebarMenuItem className="group/project-row relative h-8">
+            <SidebarMenuItem
+              className={cn(
+                "group/project-row relative h-8 cursor-grab active:cursor-grabbing",
+                ctx.dropTarget?.kind === "project" && ctx.dropTarget.id === workspace.id && "rounded-lg bg-sidebar-accent/70",
+              )}
+              draggable
+              onDragStart={(event) => {
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", JSON.stringify({ kind: "project", id: workspace.id }));
+                ctx.onDragStart({ kind: "project", id: workspace.id });
+              }}
+              onDragOver={(event) => ctx.onDragOver({ kind: "project", id: workspace.id }, event)}
+              onDrop={(event) => ctx.onDrop({ kind: "project", id: workspace.id }, event)}
+              onDragEnd={ctx.onDragEnd}
+              data-drop-target={ctx.dropTarget?.kind === "project" && ctx.dropTarget.id === workspace.id ? "true" : undefined}
+            >
               <button
                 type="button"
                 onClick={() => setProjectExpanded((expanded) => !expanded)}
@@ -1036,6 +1148,8 @@ function ProjectSidebarContent({
                         title={t("projects.actions")}
                         data-testid="project-actions-menu"
                         data-project-id={workspace.id}
+                        draggable={false}
+                        onDragStart={(event) => event.stopPropagation()}
                       >
                         <span className="flex size-4 items-center justify-center" aria-hidden="true">
                           <img src={publicAssetUrl("sidebar-icon/figma-section-ellipsis.svg")} alt="" className="h-[2.33333px] w-[11.6667px]" />
@@ -1122,16 +1236,6 @@ function ProjectSidebarContent({
                     remainingCount={remainingSessionCount}
                     onShowMore={() => setSessionPreviewCount((count) => count + MAX_SESSIONS_PREVIEW)}
                   />
-                  {archivedSessions.length > 0 ? (
-                    <ArchivedSessionsSection
-                      sessions={archivedSessions}
-                      tree={tree}
-                      workspaceId={workspace.id}
-                      forcedExpandedSessionIds={forcedExpandedSessionIds}
-                      expanded={archivedExpanded}
-                      onToggle={() => setArchivedExpanded((value) => !value)}
-                    />
-                  ) : null}
                 </>
               ) : (
                 <SidebarMenuSubItem>
@@ -1200,7 +1304,7 @@ function PinnedIndicator({ isPinned }: { isPinned: boolean }) {
 }
 
 type SessionMenuItemProps = {
-  session: SessionListItem;
+  session: SessionListItem & Partial<Pick<SidebarDisplaySession, "sourceWorkspaceId" | "sidebarWorkspaceId">>;
   depth: number;
   tree: SessionTreeState;
   workspaceId: string;
@@ -1218,6 +1322,8 @@ function SessionMenuItem({
 }: SessionMenuItemProps) {
   const ctx = useSidebarContext();
   const isSelected = ctx.selectedSessionId === session.id;
+  const sourceWorkspaceId = session.sourceWorkspaceId?.trim() || workspaceId;
+  const sessionKey = sessionLayoutKey(sourceWorkspaceId, session.id);
   const displayTitle = getDisplaySessionTitle(session.title);
   const hasChildren = (tree.descendantCountBySessionId.get(session.id) ?? 0) > 0;
   const isExpanded = ctx.expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
@@ -1231,15 +1337,35 @@ function SessionMenuItem({
   const sessionFontWeight = ctx.language === "zh" ? "font-medium" : "font-normal";
 
   const openSession = () => {
-    ctx.onOpenSession(workspaceId, session.id);
+    ctx.onOpenSession(sourceWorkspaceId, session.id);
   };
 
   const prefetchSession = () => {
-    if (workspaceId !== ctx.selectedWorkspaceId) {
+    if (sourceWorkspaceId !== ctx.selectedWorkspaceId) {
       return;
     }
 
-    ctx.onPrefetchSession?.(workspaceId, session.id);
+    ctx.onPrefetchSession?.(sourceWorkspaceId, session.id);
+  };
+
+  const dragStart = (event: React.DragEvent<HTMLElement>) => {
+    event.stopPropagation();
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", JSON.stringify({
+      kind: "session",
+      key: sessionKey,
+      sourceWorkspaceId,
+      sessionId: session.id,
+    }));
+    ctx.onDragStart({ kind: "session", key: sessionKey, sourceWorkspaceId, sessionId: session.id });
+  };
+  const dragOver = (event: React.DragEvent<HTMLElement>) => {
+    event.stopPropagation();
+    ctx.onDragOver({ kind: "session", key: sessionKey }, event);
+  };
+  const drop = (event: React.DragEvent<HTMLElement>) => {
+    event.stopPropagation();
+    ctx.onDrop({ kind: "session", key: sessionKey }, event);
   };
 
   const item = hasChildren ? (
@@ -1248,8 +1374,17 @@ function SessionMenuItem({
       onOpenChange={() => ctx.toggleSessionExpanded(session.id)}
       className="group/session-collapsible"
     >
-      <SidebarMenuSubItem>
-        <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
+      <SidebarMenuSubItem
+        draggable
+        onDragStart={dragStart}
+        onDragOver={dragOver}
+        onDrop={drop}
+        onDragEnd={ctx.onDragEnd}
+        data-drop-target={ctx.dropTarget?.kind === "session" && ctx.dropTarget.key === sessionKey ? "true" : undefined}
+        className={cn(ctx.dropTarget?.kind === "session" && ctx.dropTarget.key === sessionKey && "rounded-lg bg-sidebar-accent/70")}
+        style={{ cursor: "grab" }}
+      >
+        <SessionContextMenu sessionId={session.id} workspaceId={sourceWorkspaceId} isPinned={isPinned} isArchived={isArchived}>
           <CollapsibleTrigger
             render={
               <SidebarMenuSubButton
@@ -1275,7 +1410,7 @@ function SessionMenuItem({
         </SessionContextMenu>
         <SessionActions
           sessionId={session.id}
-          workspaceId={workspaceId}
+          workspaceId={sourceWorkspaceId}
           isPinned={isPinned}
           isArchived={isArchived}
           className={cn("absolute top-1/2 -translate-y-1/2 opacity-0 group-hover/menu-sub-item:opacity-100 data-popup-open:opacity-100", nestedActionPosition)}
@@ -1284,8 +1419,17 @@ function SessionMenuItem({
       </SidebarMenuSubItem>
     </Collapsible>
   ) : (
-    <SidebarMenuSubItem>
-      <SessionContextMenu sessionId={session.id} workspaceId={workspaceId} isPinned={isPinned} isArchived={isArchived}>
+    <SidebarMenuSubItem
+      draggable
+      onDragStart={dragStart}
+      onDragOver={dragOver}
+      onDrop={drop}
+      onDragEnd={ctx.onDragEnd}
+      data-drop-target={ctx.dropTarget?.kind === "session" && ctx.dropTarget.key === sessionKey ? "true" : undefined}
+      className={cn(ctx.dropTarget?.kind === "session" && ctx.dropTarget.key === sessionKey && "rounded-lg bg-sidebar-accent/70")}
+      style={{ cursor: "grab" }}
+    >
+      <SessionContextMenu sessionId={session.id} workspaceId={sourceWorkspaceId} isPinned={isPinned} isArchived={isArchived}>
         <SidebarMenuSubButton
           isActive={isSelected}
           onClick={openSession}
@@ -1304,7 +1448,7 @@ function SessionMenuItem({
       </SessionContextMenu>
       <SessionActions
         sessionId={session.id}
-        workspaceId={workspaceId}
+        workspaceId={sourceWorkspaceId}
         isPinned={isPinned}
         isArchived={isArchived}
         className={cn("absolute top-1/2 -translate-y-1/2 opacity-0 group-hover/menu-sub-item:opacity-100 data-popup-open:opacity-100", trailingActionPosition)}
@@ -1322,53 +1466,60 @@ function SessionMenuItem({
 }
 
 type ArchivedSessionsSectionProps = {
-  sessions: SessionListItem[];
-  tree: SessionTreeState;
-  workspaceId: string;
-  forcedExpandedSessionIds: Set<string>;
+  sessions: SidebarDisplaySession[];
+  sessionStatusById?: Record<string, string>;
   expanded: boolean;
   onToggle: () => void;
 };
 
 function ArchivedSessionsSection({
   sessions,
-  tree,
-  workspaceId,
-  forcedExpandedSessionIds,
+  sessionStatusById,
   expanded,
   onToggle,
 }: ArchivedSessionsSectionProps) {
   const pinned = usePinnedSessionIds();
+  const forcedExpandedSessionIds = React.useMemo(() => new Set<string>(), []);
+  const tree = React.useMemo(
+    () => buildSessionTreeState(sessions, sessionStatusById),
+    [sessionStatusById, sessions],
+  );
   return (
-    <Collapsible open={expanded} onOpenChange={onToggle} className="group/archived">
-      <CollapsibleTrigger
-        render={
-          <button
-            type="button"
-            className="group/separator flex w-full cursor-pointer items-center gap-1.5 px-2 pb-1 pt-2.5 rounded transition-colors hover:bg-sidebar-accent/50"
-          >
-            <Archive className="size-3 shrink-0 text-muted-foreground" />
-            <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              {t("session_management.archived_label")}
-            </span>
-            <span className="text-[10px] tabular-nums text-muted-foreground/70">{sessions.length}</span>
-            <ChevronRight className="ml-auto size-3.5 text-muted-foreground transition-transform duration-200 group-data-open/archived:rotate-90" />
-          </button>
-        }
-      />
-      <CollapsibleContent>
-        {sessions.map((session) => (
-          <SessionMenuItem
-            key={session.id}
-            session={session}
-            depth={0}
-            tree={tree}
-            workspaceId={workspaceId}
-            forcedExpandedSessionIds={forcedExpandedSessionIds}
-            isPinned={pinned.has(session.id)}
+    <SidebarGroup className="group/archived px-2">
+      <SidebarGroupContent>
+        <Collapsible open={expanded} onOpenChange={onToggle} className="group/archived-content">
+          <CollapsibleTrigger
+            render={
+              <button
+                type="button"
+                className="group/separator flex h-8 w-full cursor-pointer items-center gap-1.5 rounded px-2 text-left transition-colors hover:bg-sidebar-accent/50"
+              >
+                <Archive className="size-3 shrink-0 text-muted-foreground" />
+                <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {t("session_management.archived_label")}
+                </span>
+                <span className="text-[10px] tabular-nums text-muted-foreground/70">{sessions.length}</span>
+                <ChevronRight className="ml-auto size-3.5 text-muted-foreground transition-transform duration-200 group-data-open/archived-content:rotate-90" />
+              </button>
+            }
           />
-        ))}
-      </CollapsibleContent>
-    </Collapsible>
+          <CollapsibleContent>
+            <SidebarMenuSub className="mt-[2px] translate-x-0 gap-1 pb-2">
+              {sessions.map((session) => (
+                <SessionMenuItem
+                  key={session.id}
+                  session={session}
+                  depth={0}
+                  tree={tree}
+                  workspaceId={session.sourceWorkspaceId}
+                  forcedExpandedSessionIds={forcedExpandedSessionIds}
+                  isPinned={pinned.has(session.id)}
+                />
+              ))}
+            </SidebarMenuSub>
+          </CollapsibleContent>
+        </Collapsible>
+      </SidebarGroupContent>
+    </SidebarGroup>
   );
 }

--- a/apps/app/src/react-app/domains/session/sidebar/sidebar-layout-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/sidebar-layout-store.ts
@@ -1,0 +1,190 @@
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+export const SIDEBAR_LAYOUT_STORAGE_KEY = "ipollowork.react.sidebarLayout.v1";
+export const PERSONAL_SIDEBAR_CONTEXT_ID = "personal";
+
+export type SidebarLayoutSnapshot = {
+  projectOrderByContext: Record<string, string[]>;
+  sessionOrderByProject: Record<string, string[]>;
+  sessionProjectByKey: Record<string, string>;
+};
+
+export type SidebarLayoutState = SidebarLayoutSnapshot & {
+  reorderProjects: (contextId: string, sourceId: string, targetId: string) => void;
+  moveSession: (sessionKey: string, targetProjectId: string) => void;
+  reorderSessions: (projectId: string, sourceKey: string, targetKey: string) => void;
+  prune: (input: {
+    contextId: string;
+    projectIds: string[];
+    sessionKeys: string[];
+    sourceProjectBySessionKey?: Record<string, string>;
+  }) => void;
+};
+
+const EMPTY_LAYOUT: SidebarLayoutSnapshot = {
+  projectOrderByContext: {},
+  sessionOrderByProject: {},
+  sessionProjectByKey: {},
+};
+
+function cleanIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const id = item.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
+function cleanMap(value: unknown): Record<string, string[]> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, ids]) => {
+      const normalizedKey = key.trim();
+      const normalizedIds = cleanIds(ids);
+      return normalizedKey && normalizedIds.length > 0 ? [[normalizedKey, normalizedIds]] : [];
+    }),
+  );
+}
+
+function cleanAssignmentMap(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, target]) => {
+      const normalizedKey = key.trim();
+      const normalizedTarget = typeof target === "string" ? target.trim() : "";
+      return normalizedKey && normalizedTarget ? [[normalizedKey, normalizedTarget]] : [];
+    }),
+  );
+}
+
+export function createSidebarLayoutSnapshot(): SidebarLayoutSnapshot {
+  return {
+    projectOrderByContext: {},
+    sessionOrderByProject: {},
+    sessionProjectByKey: {},
+  };
+}
+
+export function normalizeSidebarLayout(value: unknown): SidebarLayoutSnapshot {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return createSidebarLayoutSnapshot();
+  const record = value as Record<string, unknown>;
+  return {
+    projectOrderByContext: cleanMap(record.projectOrderByContext),
+    sessionOrderByProject: cleanMap(record.sessionOrderByProject),
+    sessionProjectByKey: cleanAssignmentMap(record.sessionProjectByKey),
+  };
+}
+
+export function sessionLayoutKey(sourceWorkspaceId: string, sessionId: string): string {
+  return `${sourceWorkspaceId.trim()}\u0000${sessionId.trim()}`;
+}
+
+function reorderIds(ids: string[], sourceId: string, targetId: string): string[] {
+  const source = sourceId.trim();
+  const target = targetId.trim();
+  if (!source || !target || source === target) return ids;
+  const next = ids.filter((id) => id !== source);
+  const targetIndex = next.indexOf(target);
+  if (targetIndex < 0) return [...next, source];
+  next.splice(targetIndex, 0, source);
+  return next;
+}
+
+function upsertOrder(
+  map: Record<string, string[]>,
+  key: string,
+  sourceId: string,
+  targetId: string,
+): Record<string, string[]> {
+  const normalizedKey = key.trim();
+  if (!normalizedKey) return map;
+  const existing = cleanIds(map[normalizedKey]);
+  const source = sourceId.trim();
+  const target = targetId.trim();
+  const seeded = existing.length === 0
+    ? [source, target]
+    : [...existing, ...[source, target].filter((id) => id && !existing.includes(id))];
+  const next = reorderIds(seeded, sourceId, targetId);
+  if (existing.length === next.length && existing.every((id, index) => id === next[index])) return map;
+  return { ...map, [normalizedKey]: next };
+}
+
+export const useSidebarLayoutStore = create<SidebarLayoutState>()(
+  persist(
+    (set) => ({
+      ...createSidebarLayoutSnapshot(),
+      reorderProjects: (contextId, sourceId, targetId) => set((state) => ({
+        projectOrderByContext: upsertOrder(state.projectOrderByContext, contextId, sourceId, targetId),
+      })),
+      moveSession: (sessionKey, targetProjectId) => set((state) => {
+        const key = sessionKey.trim();
+        const target = targetProjectId.trim();
+        if (!key || !target || state.sessionProjectByKey[key] === target) return state;
+        return {
+          sessionProjectByKey: { ...state.sessionProjectByKey, [key]: target },
+        };
+      }),
+      reorderSessions: (projectId, sourceKey, targetKey) => set((state) => ({
+        sessionOrderByProject: upsertOrder(state.sessionOrderByProject, projectId, sourceKey, targetKey),
+      })),
+      prune: ({ contextId, projectIds, sessionKeys, sourceProjectBySessionKey }) => set((state) => {
+        const knownProjects = new Set(cleanIds(projectIds));
+        const knownSessions = new Set(cleanIds(sessionKeys));
+        const context = contextId.trim();
+        const projectOrder = cleanIds(state.projectOrderByContext[context]).filter((id) => knownProjects.has(id));
+        const projectOrderByContext = { ...state.projectOrderByContext };
+        if (context) {
+          if (projectOrder.length > 0) projectOrderByContext[context] = projectOrder;
+          else delete projectOrderByContext[context];
+        }
+
+        const sessionOrderByProject = Object.fromEntries(
+          Object.entries(state.sessionOrderByProject).flatMap(([projectId, ids]) => {
+            if (!knownProjects.has(projectId)) return [];
+            const next = cleanIds(ids).filter((id) => knownSessions.has(id));
+            return next.length > 0 ? [[projectId, next]] : [];
+          }),
+        );
+        const sessionProjectByKey = Object.fromEntries(
+          Object.entries(state.sessionProjectByKey).flatMap(([key, projectId]) => {
+            if (!knownSessions.has(key) || !knownProjects.has(projectId)) return [];
+            return [[key, projectId]];
+          }),
+        );
+        for (const key of knownSessions) {
+          const sourceProject = sourceProjectBySessionKey?.[key]?.trim();
+          if (!sourceProject) continue;
+          if (!sessionProjectByKey[key]) sessionProjectByKey[key] = sourceProject;
+        }
+
+        const unchanged = JSON.stringify({ projectOrderByContext, sessionOrderByProject, sessionProjectByKey })
+          === JSON.stringify({
+            projectOrderByContext: state.projectOrderByContext,
+            sessionOrderByProject: state.sessionOrderByProject,
+            sessionProjectByKey: state.sessionProjectByKey,
+          });
+        return unchanged ? state : { projectOrderByContext, sessionOrderByProject, sessionProjectByKey };
+      }),
+    }),
+    {
+      name: SIDEBAR_LAYOUT_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        projectOrderByContext: state.projectOrderByContext,
+        sessionOrderByProject: state.sessionOrderByProject,
+        sessionProjectByKey: state.sessionProjectByKey,
+      }),
+      merge: (persisted, current) => ({
+        ...current,
+        ...normalizeSidebarLayout(persisted),
+      }),
+    },
+  ),
+);

--- a/apps/app/src/react-app/domains/session/sidebar/utils.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/utils.ts
@@ -2,11 +2,20 @@ import type { WorkspaceInfo } from "../../../../app/lib/desktop";
 import type { ProjectSessionList } from "../../../../app/types";
 import { isSandboxWorkspace } from "../../../../app/utils";
 import { t } from "../../../../i18n";
+import type { SidebarLayoutSnapshot } from "./sidebar-layout-store";
+import { sessionLayoutKey } from "./sidebar-layout-store";
 
 export const MAX_SESSIONS_PREVIEW = 6;
 
 export type SessionListItem = ProjectSessionList["sessions"][number];
-export type FlattenedSessionRow = { session: SessionListItem; depth: number };
+export type SidebarDisplaySession = SessionListItem & {
+  sourceWorkspaceId: string;
+  sidebarWorkspaceId: string;
+};
+export type SidebarDisplayProject = Omit<ProjectSessionList, "sessions"> & {
+  sessions: SidebarDisplaySession[];
+};
+export type FlattenedSessionRow = { session: SidebarDisplaySession | SessionListItem; depth: number };
 export type SessionTreeState = {
   childrenByParent: Map<string, SessionListItem[]>;
   ancestorIdsBySessionId: Map<string, string[]>;
@@ -15,8 +24,95 @@ export type SessionTreeState = {
   streamingIds: Set<string>;
 };
 
+export const visibleProjectSessionLists = (projects: ProjectSessionList[]) =>
+  projects.filter((project) => !project.workspace.isDefault || project.sessions.length > 0);
+
+function orderByPersistedIds<T>(items: T[], persistedIds: string[], getId: (item: T) => string): T[] {
+  const byId = new Map(items.map((item) => [getId(item), item]));
+  const ordered: T[] = [];
+  const used = new Set<string>();
+  for (const id of persistedIds) {
+    const item = byId.get(id);
+    if (!item || used.has(id)) continue;
+    ordered.push(item);
+    used.add(id);
+  }
+  for (const item of items) {
+    const id = getId(item);
+    if (used.has(id)) continue;
+    ordered.push(item);
+    used.add(id);
+  }
+  return ordered;
+}
+
+/**
+ * Build the sidebar-only view. Session placement changes are presentation
+ * metadata: sourceWorkspaceId remains the owner used for all engine actions.
+ */
+export function buildSidebarLayoutView(
+  projects: ProjectSessionList[],
+  layout: SidebarLayoutSnapshot,
+  contextId = "personal",
+): SidebarDisplayProject[] {
+  const visible = visibleProjectSessionLists(projects);
+  const projectIds = new Set(visible.map((project) => project.workspace.id));
+  const sessionsByProject = new Map<string, SidebarDisplaySession[]>();
+
+  for (const project of visible) {
+    for (const session of project.sessions) {
+      if (isSessionArchived(session)) continue;
+      const key = sessionLayoutKey(project.workspace.id, session.id);
+      const targetProjectId = layout.sessionProjectByKey[key];
+      const target = targetProjectId && projectIds.has(targetProjectId)
+        ? targetProjectId
+        : project.workspace.id;
+      const entries = sessionsByProject.get(target) ?? [];
+      entries.push({
+        ...session,
+        sourceWorkspaceId: project.workspace.id,
+        sidebarWorkspaceId: target,
+      });
+      sessionsByProject.set(target, entries);
+    }
+  }
+
+  const orderedProjects = orderByPersistedIds(
+    visible,
+    layout.projectOrderByContext[contextId] ?? [],
+    (project) => project.workspace.id,
+  );
+  return orderedProjects.map((project) => {
+    const sessions = orderByPersistedIds(
+      sessionsByProject.get(project.workspace.id) ?? [],
+      layout.sessionOrderByProject[project.workspace.id] ?? [],
+      (session) => sessionLayoutKey(session.sourceWorkspaceId, session.id),
+    );
+    return { ...project, sessions };
+  });
+}
+
 export const isSessionArchived = (session: SessionListItem): boolean =>
   typeof session.time?.archived === "number" && session.time.archived > 0;
+
+/**
+ * Collect archived sessions into one sidebar-only list. Archived sessions keep
+ * their source workspace so engine actions still target the owning project.
+ */
+export function buildSidebarArchivedSessions(projects: ProjectSessionList[]): SidebarDisplaySession[] {
+  const archived: SidebarDisplaySession[] = [];
+  for (const project of visibleProjectSessionLists(projects)) {
+    for (const session of project.sessions) {
+      if (!isSessionArchived(session)) continue;
+      archived.push({
+        ...session,
+        sourceWorkspaceId: project.workspace.id,
+        sidebarWorkspaceId: project.workspace.id,
+      });
+    }
+  }
+  return archived;
+}
 
 export const isStreamingSessionStatus = (status: string | undefined) =>
   status === "running" ||

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -2796,6 +2796,7 @@ export function SessionRoute() {
       )}
       sidebar={{
         projectSessionLists,
+        workContextId: activeWorkContextId,
         selectedWorkspaceId,
         selectedSessionId,
         developerMode: false,

--- a/apps/app/tests/sidebar-projects.test.ts
+++ b/apps/app/tests/sidebar-projects.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "node:fs";
 
-import { buildSessionTreeState } from "../src/react-app/domains/session/sidebar/utils";
+import {
+  buildSessionTreeState,
+  buildSidebarArchivedSessions,
+  buildSidebarLayoutView,
+  visibleProjectSessionLists,
+} from "../src/react-app/domains/session/sidebar/utils";
+import {
+  createSidebarLayoutSnapshot,
+  normalizeSidebarLayout,
+  sessionLayoutKey,
+} from "../src/react-app/domains/session/sidebar/sidebar-layout-store";
+import type { ProjectSessionList } from "../src/app/types";
 
 const sidebarSource = readFileSync(
   new URL("../src/react-app/domains/session/sidebar/app-sidebar.tsx", import.meta.url),
@@ -53,11 +64,106 @@ const chineseLocaleSource = readFileSync(
 );
 
 describe("sidebar projects", () => {
+  test("normalizes persisted sidebar layout and reorders projects and sessions", () => {
+    const layout = normalizeSidebarLayout({
+      projectOrderByContext: { personal: ["ws_b", "stale", "ws_a"] },
+      sessionOrderByProject: { ws_b: ["stale-session", sessionLayoutKey("ws_a", "ses_a")] },
+      sessionProjectByKey: { [sessionLayoutKey("ws_a", "ses_a")]: "ws_b", stale: "stale" },
+    });
+    const projects: ProjectSessionList[] = [
+      { workspace: { id: "ws_a", name: "A", path: "/a", preset: "starter", workspaceType: "local" }, sessions: [{ id: "ses_a", title: "A task" }], status: "ready" },
+      { workspace: { id: "ws_b", name: "B", path: "/b", preset: "starter", workspaceType: "local" }, sessions: [{ id: "ses_b", title: "B task" }], status: "ready" },
+    ];
+    const view = buildSidebarLayoutView(projects, layout);
+    expect(view.map((project) => project.workspace.id)).toEqual(["ws_b", "ws_a"]);
+    expect(view[0]?.sessions.map((session) => session.id)).toEqual(["ses_a", "ses_b"]);
+    expect(view[0]?.sessions[0]?.sourceWorkspaceId).toBe("ws_a");
+    expect(view[0]?.sessions[0]?.sidebarWorkspaceId).toBe("ws_b");
+  });
+
+  test("keeps archived sessions out of projects and collects them globally", () => {
+    const projects: ProjectSessionList[] = [
+      {
+        workspace: { id: "ws_a", name: "A", path: "/a", preset: "starter", workspaceType: "local" },
+        sessions: [
+          { id: "active", title: "Active" },
+          { id: "archived", title: "Archived", time: { archived: 1 } },
+        ],
+        status: "ready",
+      },
+    ];
+
+    expect(buildSidebarLayoutView(projects, createSidebarLayoutSnapshot())[0]?.sessions.map((session) => session.id))
+      .toEqual(["active"]);
+    expect(buildSidebarArchivedSessions(projects).map((session) => session.id)).toEqual(["archived"]);
+    expect(buildSidebarArchivedSessions(projects)[0]?.sourceWorkspaceId).toBe("ws_a");
+    expect(sidebarSource).toContain("buildSidebarArchivedSessions(props.projectSessionLists)");
+    expect(sidebarSource).not.toContain("<ArchivedSessionsSection\n                      sessions={archivedSessions}");
+    expect(sidebarSource).toContain('className="group/archived px-2"');
+  });
+
+  test("creates a clean empty layout snapshot", () => {
+    expect(createSidebarLayoutSnapshot()).toEqual({
+      projectOrderByContext: {},
+      sessionOrderByProject: {},
+      sessionProjectByKey: {},
+    });
+  });
+
+  test("keeps a default workspace visible when it owns historical sessions", () => {
+    const projects: ProjectSessionList[] = [
+      {
+        workspace: {
+          id: "ws_default",
+          name: "Personal",
+          path: "/Users/test/iPolloWork",
+          preset: "starter",
+          isDefault: true,
+          workspaceType: "local",
+        },
+        sessions: [{ id: "ses_history", title: "Historical task" }],
+        status: "ready",
+      },
+      {
+        workspace: {
+          id: "ws_project",
+          name: "Project",
+          path: "/Users/test/project",
+          preset: "starter",
+          isDefault: false,
+          workspaceType: "local",
+        },
+        sessions: [],
+        status: "ready",
+      },
+    ];
+
+    expect(visibleProjectSessionLists(projects).map((project) => project.workspace.id))
+      .toEqual(["ws_default", "ws_project"]);
+  });
+
+  test("keeps an empty default workspace hidden from the projects section", () => {
+    const projects: ProjectSessionList[] = [{
+      workspace: {
+        id: "ws_default",
+        name: "iPolloWork",
+        path: "/Users/test/iPolloWork",
+        preset: "starter",
+        isDefault: true,
+        workspaceType: "local",
+      },
+      sessions: [],
+      status: "ready",
+    }];
+
+    expect(visibleProjectSessionLists(projects)).toEqual([]);
+  });
+
   test("renders named projects inside an independently collapsible all-projects section", () => {
     expect(sidebarSource).not.toContain("function ProjectSwitcher");
     expect(sidebarSource).not.toContain("selectedProjectSessionLists");
     expect(sidebarSource).toContain("const [projectsExpanded, setProjectsExpanded] = React.useState(true)");
-    expect(sidebarSource).toContain("const namedProjects = props.projectSessionLists.filter((project) => !project.workspace.isDefault)");
+    expect(sidebarSource).toContain("visibleProjectSessionLists(props.projectSessionLists)");
     expect(sidebarSource).toContain("namedProjects.map((project)");
     expect(sidebarSource).toContain('toggleTestId="projects-section-toggle"');
     expect(sidebarSource).toContain('data-testid="project-row"');
@@ -92,8 +198,8 @@ describe("sidebar projects", () => {
     expect(sidebarSource).toContain('<SidebarMenu className="gap-1">');
   });
 
-  test("hides the default workspace and renders only named projects", () => {
-    expect(sidebarSource).toContain("const namedProjects = props.projectSessionLists.filter((project) => !project.workspace.isDefault)");
+  test("hides only an empty default workspace and renders projects with task history", () => {
+    expect(sidebarSource).toContain("visibleProjectSessionLists(props.projectSessionLists)");
     expect(sidebarSource).not.toContain("ungroupedExpanded");
     expect(sidebarSource).not.toContain("ungroupedProject");
     expect(sidebarSource).not.toContain('data-testid="ungrouped-section"');
@@ -413,6 +519,19 @@ describe("sidebar projects", () => {
     expect(sidebarSource).toContain('<SidebarMenuSub className="mt-[2px] translate-x-0 gap-1 pb-2">');
     expect(sidebarSource).toContain('const rowPadding = depth > 0 ? "ps-[68px]" : "ps-8";');
     expect(sidebarSource).not.toContain("GroupedSessionList");
+  });
+
+  test("supports persistent drag/drop layout management without changing engine ownership", () => {
+    expect(sidebarSource).toContain("useSidebarLayoutStore");
+    expect(sidebarSource).toContain('draggable\n              onDragStart');
+    expect(sidebarSource).toContain('kind: "project"');
+    expect(sidebarSource).toContain('kind: "session"');
+    expect(sidebarSource).toContain("onDragOver");
+    expect(sidebarSource).toContain("onDrop");
+    expect(sidebarSource).toContain("session.sourceWorkspaceId");
+    expect(sidebarSource).toContain("ctx.onOpenSession(sourceWorkspaceId, session.id)");
+    expect(sessionPageSource).toContain("workContextId?: string");
+    expect(sessionRouteSource).toContain("workContextId: activeWorkContextId");
   });
 
   test("keeps only the independent pin preference store", () => {

--- a/docs/superpowers/plans/2026-08-30-sidebar-layout-management.md
+++ b/docs/superpowers/plans/2026-08-30-sidebar-layout-management.md
@@ -1,0 +1,139 @@
+# Sidebar Layout Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent project ordering, Session ordering, and UI-only Session reassignment between sidebar projects without changing engine-owned Session data.
+
+**Architecture:** A small Zustand persisted store owns layout metadata keyed by work context. The sidebar derives visible project/session rows from that store, carries each Session's source Workspace ID through rendering, and handles native HTML drag/drop locally. Server routes and engine runtimes remain unchanged.
+
+**Tech Stack:** React, TypeScript, Zustand 5, native HTML5 drag/drop, Bun tests.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-sidebar-layout-management-design.md`
+
+## Global Constraints
+
+- Do not mutate Session engine data, cwd, history, or project files.
+- Do not add a dependency; use the existing Zustand dependency and native drag/drop.
+- Preserve all existing click, context-menu, rename, archive, delete, and expand behavior.
+- Keep source Workspace ID separate from the sidebar display container Workspace ID.
+- Do not touch unrelated existing worktree changes.
+
+---
+
+### Task 1: Add the persisted sidebar layout model
+
+**Files:**
+- Create: `apps/app/src/react-app/domains/session/sidebar/sidebar-layout-store.ts`
+- Modify: `apps/app/tests/sidebar-projects.test.ts`
+
+**Interfaces:**
+- Produces `SidebarLayoutState`, `sessionLayoutKey`, `normalizeSidebarLayout`, and the `useSidebarLayoutStore` actions used by the sidebar.
+
+- [x] **Step 1: Write failing pure-state tests**
+
+Add tests for project reorder, moving a Session to another project, root Session reorder, and pruning stale IDs. The tests must assert that only layout metadata changes.
+
+- [x] **Step 2: Run the focused test and verify failure**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: FAIL because the new store module and actions do not exist.
+
+- [x] **Step 3: Implement the store**
+
+Implement a persisted Zustand store with:
+
+```ts
+type SidebarLayoutState = {
+  projectOrderByContext: Record<string, string[]>;
+  sessionOrderByProject: Record<string, string[]>;
+  sessionProjectByKey: Record<string, string>;
+  reorderProjects: (contextId: string, sourceId: string, targetId: string) => void;
+  moveSession: (sessionKey: string, targetProjectId: string) => void;
+  reorderSessions: (projectId: string, sourceKey: string, targetKey: string) => void;
+  prune: (input: { contextId: string; projectIds: string[]; sessionKeys: string[] }) => void;
+};
+```
+
+Use `createJSONStorage(() => localStorage)` with name `ipollowork.react.sidebarLayout.v1`. Reorder functions must be no-ops for unknown or identical IDs and must preserve unlisted IDs. `prune` must remove stale IDs and reset a Session assignment to its source project when the target no longer exists.
+
+- [x] **Step 4: Run the focused test and verify pass**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: PASS for all new store tests and all existing sidebar tests.
+
+### Task 2: Wire source Workspace identity and derive ordered rows
+
+**Files:**
+- Modify: `apps/app/src/react-app/domains/session/sidebar/utils.ts`
+- Modify: `apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx`
+- Modify: `apps/app/src/react-app/domains/session/sidebar/app-sidebar-provider.tsx`
+- Modify: `apps/app/src/react-app/domains/session/chat/session-page.tsx`
+- Modify: `apps/app/src/react-app/shell/session-route.tsx`
+
+**Interfaces:**
+- Consumes the store from Task 1.
+- Produces ordered project data and `FlattenedSessionRow.sourceWorkspaceId` for drag rendering and action routing.
+
+- [x] **Step 1: Add a failing derivation test**
+
+Test that a moved Session appears under the target project but retains its original Workspace ID, and that unknown layout IDs are pruned from derived output.
+
+- [x] **Step 2: Run the focused test and verify failure**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: FAIL because the sidebar derivation does not yet consume layout state.
+
+- [x] **Step 3: Implement derivation and routing**
+
+Add an optional `workContextId` to sidebar props, pass `activeWorkContextId` from `session-route`, order projects from the store, and build display project lists by assigning each Session to its stored target project while attaching `sourceWorkspaceId`. Pass `sourceWorkspaceId` to Session actions and navigation. Call `prune` after project/session lists are available.
+
+- [x] **Step 4: Run focused tests**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: PASS with existing project/sidebar behavior unchanged.
+
+### Task 3: Add native drag/drop interactions
+
+**Files:**
+- Modify: `apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx`
+- Modify: `apps/app/tests/sidebar-projects.test.ts`
+
+**Interfaces:**
+- Consumes ordered rows and source Workspace identity from Task 2.
+- Produces project reorder, Session move, and Session reorder callbacks backed by the persisted store.
+
+- [x] **Step 1: Add source-level interaction tests**
+
+Assert that project and Session rows expose `draggable`, `onDragStart`, `onDragOver`, `onDrop`, and a drop-target highlight class; assert that Session actions still call the source Workspace ID.
+
+- [x] **Step 2: Run the focused test and verify failure**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: FAIL because the sidebar rows have no drag/drop handlers.
+
+- [x] **Step 3: Implement drag/drop**
+
+Use a local drag payload discriminated by `project` or `session`. Project rows reorder within the active work context. Session rows dropped on a project move their layout assignment; Session rows dropped on another Session first assign to that Session's project and then reorder. Prevent drops onto the same item, stop propagation from action buttons, and clear drag state on `dragend`.
+
+- [x] **Step 4: Run focused tests**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: PASS.
+
+### Task 4: Verify build-level safety and document behavior
+
+**Files:**
+- Modify: `apps/app/tests/sidebar-projects.test.ts` if additional regression coverage is needed.
+
+- [x] **Step 1: Run targeted tests**
+
+Run `bun test apps/app/tests/sidebar-projects.test.ts`.
+Expected: PASS.
+
+- [x] **Step 2: Run TypeScript/app validation available in the repository**
+
+Run the app's documented typecheck/build command from `apps/app/package.json`; do not install dependencies. Expected: no new type errors.
+
+- [x] **Step 3: Inspect the diff**
+
+Run `git diff --check` and `git diff --stat`. Confirm only the new sidebar layout files and directly related tests/components changed; leave unrelated pre-existing modifications untouched.

--- a/docs/superpowers/specs/2026-08-30-sidebar-layout-management-design.md
+++ b/docs/superpowers/specs/2026-08-30-sidebar-layout-management-design.md
@@ -1,0 +1,39 @@
+# iPolloWork Sidebar Layout Management
+
+## Goal
+
+让用户可以在 iPolloWork 侧栏中手动排列项目，并把 Session 归类到另一个侧栏项目，同时保持 Session 的真实引擎工作目录和历史记录不变。
+
+## Scope
+
+- 项目排序、Session 排序和 Session 侧栏归类仅属于本地 UI 布局状态。
+- Session 的 OpenCode/Codex Harness/DeepSeek Harness 归属、cwd、消息历史和项目文件不被改写。
+- 拖动项目到项目之间改变项目显示顺序。
+- 拖动 Session 到另一个项目行改变其侧栏显示归类。
+- 拖动 Session 到同一项目中的另一个 Session 行改变根 Session 的显示顺序。
+- 已归档 Session 从项目树中剥离，汇总到独立的“已归档”分类，并保持原项目操作归属。
+- 不新增虚拟文件夹创建功能；现有 Workspace 项目行作为可投放的侧栏容器。
+
+## Persistence and safety
+
+- 使用单独的 Zustand persisted store，localStorage key 为 `ipollowork.react.sidebarLayout.v1`。
+- 布局按 `workContextId` 隔离；Personal 使用 `personal` 作为 key。
+- Session identity 使用 `sourceWorkspaceId/sessionId`，避免不同引擎或远程 Workspace 出现同 ID 碰撞。
+- 刷新时只保留当前存在的项目和 Session；失效的排序/归类记录自动丢弃。
+- 归档 Session 不参与项目侧栏归类；归档分类按原始 Workspace 汇总展示，并复用项目 Session 的行布局。
+- 删除项目或 Session 不删除布局记录以外的任何数据；下次清理时再丢弃失效记录。
+
+## Interaction contract
+
+- 项目行和 Session 行设置 `draggable`，拖动时使用明确的 `dataTransfer` payload。
+- 项目行接受项目拖放并显示目标高亮；Session 行接受 Session 拖放并显示目标高亮。
+- 点击、重命名、归档、删除和展开行为不因拖动支持而改变。
+- 归档分类独立折叠，不随项目分类折叠；归档/恢复操作仍使用原始 Workspace ID。
+- Session 打开、重命名、归档、删除始终使用其原始 Workspace ID，而不是侧栏显示容器的 Workspace ID。
+- 侧栏只在用户完成 drop 后写入布局 store；dragover 只阻止默认行为并更新临时高亮。
+
+## Non-goals
+
+- 不移动 `.opencode`、Codex Harness 或 DeepSeek Harness 的底层数据文件。
+- 不修改服务端 Session API 或引擎协议。
+- 不声称完成真实的跨项目 Session 迁移；该能力需要另一个引擎级迁移方案。


### PR DESCRIPTION
## Summary

- Add persistent sidebar layout metadata for project ordering, Session ordering, and UI-only Session placement across existing projects.
- Keep each Session's source Workspace ID for open, rename, archive, restore, and delete actions.
- Move archived Sessions out of project trees into a standalone, independently collapsible archived category.
- Add native drag-and-drop feedback and regression coverage.

## Design boundary

This change only affects sidebar presentation state (`ipollowork.react.sidebarLayout.v1`). It does not move `.opencode`, Codex Harness, or DeepSeek Harness files, change Session cwd/history, or add server APIs. Archived Sessions remain owned by their original Workspace even when displayed in the global archived category.

## Verification

- `bun test --isolate tests/sidebar-projects.test.ts` (25 passed)
- `bun run typecheck`
- `bun run build`
- `pnpm --filter @ipollowork/desktop package:electron:dir`

The full app suite currently has two pre-existing source-string assertion failures outside this change; the focused sidebar suite and build checks pass.
