### PR TITLE
chore: prepare v0.50.8 release

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/app",
   "private": true,
-  "version": "0.50.7",
+  "version": "0.50.8",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ipollowork/desktop",
   "private": true,
-  "version": "0.50.7",
+  "version": "0.50.8",
   "description": "iPolloWork desktop shell",
   "author": {
     "name": "iPolloWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-orchestrator",
-  "version": "0.50.7",
+  "version": "0.50.8",
   "description": "iPolloWork host orchestrator for opencode + iPolloWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.18.16",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "ipollowork-server": "0.50.7",
+    "ipollowork-server": "0.50.8",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipollowork-server",
-  "version": "0.50.7",
+  "version": "0.50.8",
   "description": "Filesystem-backed API for iPolloWork remote clients",
   "type": "module",
   "bin": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,7 @@ importers:
       electron-devtools-installer:
         specifier: ^4.0.0
         version: 4.0.0
+
   apps/installer:
     dependencies:
       '@ipollowork/install-config':
@@ -298,7 +299,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       ipollowork-server:
-        specifier: 0.50.7
+        specifier: 0.50.8
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
## Summary
- release the cross-platform engine package installation fix
- ship trusted macOS engine checksums without embedding native engine archives
- align app, desktop, server, orchestrator, and lockfile versions at 0.50.8

## Verification
- live v0.50.7 DSH download, SHA-256 verification, and isolated install succeeded
- macOS checksum-pinned DSH test passed
- Windows bundled DSH test passed
- desktop packaging tests: 14 passed
- desktop Electron typecheck passed
- Electron bridge check passed (56 methods)
- strict release review and maintainability audit passed

Local full engine-manager discovery tests are affected by the official Codex client installed on this Mac; the new installation-path tests pass in isolation.